### PR TITLE
[wip] Enable lto (should only be merged if needed, modifies bootloader)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=600")
 string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
+# LTO doesn't play well with `-Wl,--wrap` that we are using for unit tests
+if(CMAKE_CROSSCOMPILING)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION True)
+endif()
 
 # protoc is used to generate API messages
 find_program(PROTOC protoc)

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -240,15 +240,10 @@ static void _render_bootloader_finished_marker(void)
     delay_ms(30);
 }
 
-void _binExec(void* l_code_addr) __attribute__((noreturn));
-void _binExec(void* l_code_addr)
+void _binExec(const uint32_t* l_code_addr) __attribute__((noreturn));
+void _binExec(const uint32_t* l_code_addr)
 {
-    __asm__(
-        "mov   r1, r0        \n"
-        "ldr   r0, [r1, #4]  \n"
-        "ldr   sp, [r1]      \n"
-        "blx   r0");
-    (void)l_code_addr;
+    __asm__ volatile("bx   %0" : : "r"(l_code_addr[1]));
     __builtin_unreachable();
 }
 

--- a/src/bootloader/startup.c
+++ b/src/bootloader/startup.c
@@ -35,7 +35,8 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
     } // satisfy noreturn
 }
 
-uint32_t __stack_chk_guard = 0;
+// uint32_t __stack_chk_guard = 0;
+extern uint32_t __stack_chk_guard;
 
 int main(void)
 {


### PR DESCRIPTION
This PR enables LTO. We might want to think a minute or two before merging...

* `_binExec` was a bit sloppy written. It didn't actually read the input variable and the asm block wasn't volatile. So the compiler happily optimized most of it away.
* I have no freakin clue why `__stack_chk_guard` cannot be declared in the same way in `firmware.c` as in `bootloader/startup.c`. I get linker errors saying that the variable doesn't exist. I have carefully tried to get the link commands be as equal as possible, but no, the only way I could fix it was to change from local declaration to extern.


The benefits are that we get back about 10% of space.