### PR TITLE
lockscreen: show device name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Display device name on screen before unlock
 - Bitcoin: add support for payment requests
 - Ethereum: allow signing EIP-712 messages containing multi-line strings
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,7 @@ set(DBB-FIRMWARE-UI-SOURCES
     ${CMAKE_SOURCE_DIR}/src/ui/components/keyboard_switch.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/orientation_arrows.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/info_centered.c
+    ${CMAKE_SOURCE_DIR}/src/ui/components/lockscreen.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/menu.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/status.c
     ${CMAKE_SOURCE_DIR}/src/ui/components/image.c

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -36,6 +36,8 @@
 
 /********* Definitions and read/write helper functions ****************/
 
+const char* MEMORY_DEFAULT_DEVICE_NAME = "My BitBox";
+
 // Documentation of all appData chunks and their contents.  A chunk is defined as
 // 16 pages, which is the erase granularity: changing any byte in the page
 // involves erases and writing all 16 pages. One page is 512 bytes.  The MCU has

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -60,7 +60,8 @@ USE_RESULT bool memory_reset_hww(void);
  */
 USE_RESULT bool memory_cleanup_smarteeprom(void);
 
-#define MEMORY_DEFAULT_DEVICE_NAME "My BitBox"
+// Default device name if no name was set by the user.
+extern const char* MEMORY_DEFAULT_DEVICE_NAME;
 // Don't change this without proper memory layout migration! (see chunk_1_t in
 // memory.c)
 #define MEMORY_DEVICE_NAME_MAX_LEN (64)
@@ -69,7 +70,8 @@ USE_RESULT bool memory_cleanup_smarteeprom(void);
 // size (including the null terminator) is MEMORY_DEVICE_NAME_MAX_LEN bytes.
 USE_RESULT bool memory_set_device_name(const char* name);
 
-// name_out must have MEMORY_DEVICE_NAME_MAX_LEN bytes in size.
+// name_out must have MEMORY_DEVICE_NAME_MAX_LEN bytes in size. Returns `MEMORY_DEFAULT_DEVICE_NAME`
+// if no device name is set.
 void memory_get_device_name(char* name_out);
 
 /**

--- a/src/ui/components/info_centered.c
+++ b/src/ui/components/info_centered.c
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 #include "info_centered.h"
-#include "../event.h"
+#include "../ui_util.h"
 #include "button.h"
 #include "label.h"
 
 #include <hardfault.h>
 #include <screen.h>
-#include <touch/gestures.h>
 
 #include <string.h>
 

--- a/src/ui/components/lockscreen.c
+++ b/src/ui/components/lockscreen.c
@@ -1,0 +1,110 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lockscreen.h"
+#include "../ui_util.h"
+#include "label.h"
+
+#include <hardfault.h>
+#include <memory/memory.h>
+#include <screen.h>
+#include <string.h>
+#include <touch/gestures.h>
+#include <ui/fonts/arial_fonts.h>
+
+/********************************** Component Functions **********************************/
+
+/**
+ * Collects all component functions.
+ */
+static const component_functions_t _component_functions = {
+    .cleanup = ui_util_component_cleanup,
+    .render = ui_util_component_render_subcomponents,
+    .on_event = ui_util_on_event_noop,
+};
+
+/********************************** Create Instance **********************************/
+
+// Outputs `in` as is if it can be rendered to fit in `max_width`.
+// If it can't, it is truncated (with appended "...") to a size where it fits.
+static void _truncate_to_fit(
+    const char* in,
+    char* out,
+    size_t out_len,
+    const UG_FONT* font,
+    UG_S16 max_width)
+{
+    if (out == NULL || out_len == 0) {
+        return;
+    }
+    if (in[0] == 0) {
+        out[0] = 0;
+        return;
+    }
+    UG_S16 width = 0;
+    UG_S16 height = 0;
+    UG_FontSelect(font);
+    UG_MeasureStringCentered(&width, &height, in);
+
+    // Name fits without truncation.
+    if (width <= max_width) {
+        snprintf(out, MEMORY_DEVICE_NAME_MAX_LEN, "%s", in);
+        return;
+    }
+
+    // Truncate if too long to a size where "<name>..." fits.
+    size_t truncate_len = strlen(in) - 1;
+    do {
+        // truncate at `truncate_len`.
+        snprintf(out, out_len, "%.*s...", (int)truncate_len, in);
+        truncate_len--;
+        UG_MeasureStringCentered(&width, &height, out);
+    } while (truncate_len > 0 && width >= max_width);
+}
+
+component_t* lockscreen_create(void)
+{
+    component_t* component = malloc(sizeof(component_t));
+    if (!component) {
+        Abort("Error: malloc lockscreen component");
+    }
+    memset(component, 0, sizeof(component_t));
+    component->f = &_component_functions;
+
+    component->dimension.width = SCREEN_WIDTH;
+    component->dimension.height = SCREEN_HEIGHT;
+
+    const UG_FONT* device_name_font = &font_font_a_9X9;
+
+    char device_name[MEMORY_DEVICE_NAME_MAX_LEN] = {0};
+    memory_get_device_name(device_name);
+    // Show nothing if the name is the default name.
+    if (STREQ(device_name, MEMORY_DEFAULT_DEVICE_NAME)) {
+        device_name[0] = 0;
+    }
+
+    char display_name[MEMORY_DEVICE_NAME_MAX_LEN + 3] = {0};
+    _truncate_to_fit(
+        device_name,
+        display_name,
+        sizeof(display_name),
+        device_name_font,
+        component->dimension.width);
+    ui_util_add_sub_component(
+        component, label_create("See the BitBoxApp", NULL, CENTER, component));
+    ui_util_add_sub_component(
+        component, label_create(display_name, device_name_font, CENTER_BOTTOM, component));
+
+    return component;
+}

--- a/src/ui/components/lockscreen.h
+++ b/src/ui/components/lockscreen.h
@@ -1,0 +1,25 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _LOCKSCREEN_H_
+#define _LOCKSCREEN_H_
+
+#include <ui/component.h>
+
+/**
+ * Creates the screen shown when the device is locked.
+ */
+component_t* lockscreen_create(void);
+
+#endif

--- a/src/workflow/idle_workflow.c
+++ b/src/workflow/idle_workflow.c
@@ -19,7 +19,7 @@
 
 #include <hww.h>
 #include <platform_config.h>
-#include <ui/components/info_centered.h>
+#include <ui/components/lockscreen.h>
 #include <ui/components/waiting.h>
 #include <ui/screen_stack.h>
 #include <ui/ugui/ugui.h>
@@ -34,7 +34,7 @@
 static void _init_communication(void)
 {
     usb_start(hww_setup);
-    ui_screen_stack_push(info_centered_create("See the BitBoxApp", NULL));
+    ui_screen_stack_push(lockscreen_create());
 }
 
 void idle_workflow_blocking(void)


### PR DESCRIPTION
It is useful to see the name of the device before you unlock it. For
example, if you have multiple BitBoxes, it is useful to know which one
is inserted before entering long passwords or passphrases.

The device name is not a secret, and can already be queried in the API
at any time, also before unlock.

Users that dislike this can change the device name in the settings to
something generic.