### PR TITLE
bitcoin/signtx: add support for payment requests

### DIFF
--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -124,6 +124,7 @@ message BTCSignNextResponse {
     PREVTX_INPUT = 4;
     PREVTX_OUTPUT = 5;
     HOST_NONCE = 6;
+    PAYMENT_REQUEST = 7;
   }
   Type type = 1;
   // index of the current input or output
@@ -165,6 +166,7 @@ message BTCSignOutputRequest {
   repeated uint32 keypath = 5; // if ours is true
   // If ours is true. References a script config from BTCSignInitRequest
   uint32 script_config_index = 6;
+  optional uint32 payment_request_index = 7;
 }
 
 message BTCScriptConfigRegistration {
@@ -217,6 +219,23 @@ message BTCPrevTxOutputRequest {
   bytes pubkey_script = 2;
 }
 
+message BTCPaymentRequestRequest {
+  message Memo {
+    message TextMemo {
+      string note = 1;
+    }
+    oneof memo {
+      TextMemo text_memo = 1;
+    }
+  }
+
+  string recipient_name = 1;
+  repeated Memo memos = 2;
+  bytes nonce = 3;
+  uint64 total_amount = 4;
+  bytes signature = 5;
+}
+
 message BTCSignMessageRequest {
   BTCCoin coin = 1;
   BTCScriptConfigWithKeypath script_config = 2;
@@ -238,6 +257,7 @@ message BTCRequest {
     BTCPrevTxOutputRequest prevtx_output = 5;
     BTCSignMessageRequest sign_message = 6;
     AntiKleptoSignatureRequest antiklepto_signature = 7;
+    BTCPaymentRequestRequest payment_request = 8;
   }
 }
 

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.py
@@ -15,17 +15,17 @@ from . import common_pb2 as common__pb2
 from . import antiklepto_pb2 as antiklepto__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\x1a\x10\x61ntiklepto.proto\"\xc6\x04\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x12>\n\x06policy\x18\x03 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCScriptConfig.PolicyH\x00\x1a\xd9\x01\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\x12N\n\x0bscript_type\x18\x04 \x01(\x0e\x32\x39.shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType\"\'\n\nScriptType\x12\t\n\x05P2WSH\x10\x00\x12\x0e\n\nP2WSH_P2SH\x10\x01\x1aK\n\x06Policy\x12\x0e\n\x06policy\x18\x01 \x01(\t\x12\x31\n\x04keys\x18\x02 \x03(\x0b\x32#.shiftcrypto.bitbox02.KeyOriginInfo\"3\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x12\x08\n\x04P2TR\x10\x02\x42\x08\n\x06\x63onfig\"\xfc\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"\x8e\x01\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x12\x10\n\x0c\x43\x41PITAL_UPUB\x10\x08\x12\x10\n\x0c\x43\x41PITAL_YPUB\x10\tB\x08\n\x06output\"k\n\x1a\x42TCScriptConfigWithKeypath\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\xc5\x02\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12H\n\x0escript_configs\x18\x02 \x03(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\x12H\n\x0b\x66ormat_unit\x18\x08 \x01(\x0e\x32\x33.shiftcrypto.bitbox02.BTCSignInitRequest.FormatUnit\"\"\n\nFormatUnit\x12\x0b\n\x07\x44\x45\x46\x41ULT\x10\x00\x12\x07\n\x03SAT\x10\x01\"\xe8\x02\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12\x12\n\nprev_index\x18\x05 \x01(\r\x12W\n\x1d\x61nti_klepto_signer_commitment\x18\x06 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitment\"m\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\x0f\n\x0bPREVTX_INIT\x10\x03\x12\x10\n\x0cPREVTX_INPUT\x10\x04\x12\x11\n\rPREVTX_OUTPUT\x10\x05\x12\x0e\n\nHOST_NONCE\x10\x06\"\xea\x01\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\x12\x1b\n\x13script_config_index\x18\x07 \x01(\r\x12R\n\x15host_nonce_commitment\x18\x08 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"\xa5\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0f\n\x07payload\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\x12\x1b\n\x13script_config_index\x18\x06 \x01(\r\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"\xfc\x01\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\x12P\n\txpub_type\x18\x03 \x01(\x0e\x32=.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.XPubType\"1\n\x08XPubType\x12\x11\n\rAUTO_ELECTRUM\x10\x00\x12\x12\n\x0e\x41UTO_XPUB_TPUB\x10\x01\"b\n\x14\x42TCPrevTxInitRequest\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\x12\n\nnum_inputs\x18\x02 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x03 \x01(\r\x12\x10\n\x08locktime\x18\x04 \x01(\r\"r\n\x15\x42TCPrevTxInputRequest\x12\x15\n\rprev_out_hash\x18\x01 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x02 \x01(\r\x12\x18\n\x10signature_script\x18\x03 \x01(\x0c\x12\x10\n\x08sequence\x18\x04 \x01(\r\">\n\x16\x42TCPrevTxOutputRequest\x12\r\n\x05value\x18\x01 \x01(\x04\x12\x15\n\rpubkey_script\x18\x02 \x01(\x0c\"\xee\x01\n\x15\x42TCSignMessageRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12G\n\rscript_config\x18\x02 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0b\n\x03msg\x18\x03 \x01(\x0c\x12R\n\x15host_nonce_commitment\x18\x04 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"+\n\x16\x42TCSignMessageResponse\x12\x11\n\tsignature\x18\x01 \x01(\x0c\"\xb6\x04\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x12\x41\n\x0bprevtx_init\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCPrevTxInitRequestH\x00\x12\x43\n\x0cprevtx_input\x18\x04 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCPrevTxInputRequestH\x00\x12\x45\n\rprevtx_output\x18\x05 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCPrevTxOutputRequestH\x00\x12\x43\n\x0csign_message\x18\x06 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCSignMessageRequestH\x00\x12P\n\x14\x61ntiklepto_signature\x18\x07 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignatureRequestH\x00\x42\t\n\x07request\"\x90\x03\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x12>\n\tsign_next\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x12\x44\n\x0csign_message\x18\x04 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCSignMessageResponseH\x00\x12X\n\x1c\x61ntiklepto_signer_commitment\x18\x05 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitmentH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*R\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x12\x08\n\x04P2TR\x10\x05\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tbtc.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\x1a\x10\x61ntiklepto.proto\"\xc6\x04\n\x0f\x42TCScriptConfig\x12G\n\x0bsimple_type\x18\x01 \x01(\x0e\x32\x30.shiftcrypto.bitbox02.BTCScriptConfig.SimpleTypeH\x00\x12\x42\n\x08multisig\x18\x02 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCScriptConfig.MultisigH\x00\x12>\n\x06policy\x18\x03 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCScriptConfig.PolicyH\x00\x1a\xd9\x01\n\x08Multisig\x12\x11\n\tthreshold\x18\x01 \x01(\r\x12)\n\x05xpubs\x18\x02 \x03(\x0b\x32\x1a.shiftcrypto.bitbox02.XPub\x12\x16\n\x0eour_xpub_index\x18\x03 \x01(\r\x12N\n\x0bscript_type\x18\x04 \x01(\x0e\x32\x39.shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType\"\'\n\nScriptType\x12\t\n\x05P2WSH\x10\x00\x12\x0e\n\nP2WSH_P2SH\x10\x01\x1aK\n\x06Policy\x12\x0e\n\x06policy\x18\x01 \x01(\t\x12\x31\n\x04keys\x18\x02 \x03(\x0b\x32#.shiftcrypto.bitbox02.KeyOriginInfo\"3\n\nSimpleType\x12\x0f\n\x0bP2WPKH_P2SH\x10\x00\x12\n\n\x06P2WPKH\x10\x01\x12\x08\n\x04P2TR\x10\x02\x42\x08\n\x06\x63onfig\"\xfc\x02\n\rBTCPubRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12\x0f\n\x07keypath\x18\x02 \x03(\r\x12\x41\n\txpub_type\x18\x03 \x01(\x0e\x32,.shiftcrypto.bitbox02.BTCPubRequest.XPubTypeH\x00\x12>\n\rscript_config\x18\x04 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfigH\x00\x12\x0f\n\x07\x64isplay\x18\x05 \x01(\x08\"\x8e\x01\n\x08XPubType\x12\x08\n\x04TPUB\x10\x00\x12\x08\n\x04XPUB\x10\x01\x12\x08\n\x04YPUB\x10\x02\x12\x08\n\x04ZPUB\x10\x03\x12\x08\n\x04VPUB\x10\x04\x12\x08\n\x04UPUB\x10\x05\x12\x10\n\x0c\x43\x41PITAL_VPUB\x10\x06\x12\x10\n\x0c\x43\x41PITAL_ZPUB\x10\x07\x12\x10\n\x0c\x43\x41PITAL_UPUB\x10\x08\x12\x10\n\x0c\x43\x41PITAL_YPUB\x10\tB\x08\n\x06output\"k\n\x1a\x42TCScriptConfigWithKeypath\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\xc5\x02\n\x12\x42TCSignInitRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12H\n\x0escript_configs\x18\x02 \x03(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0f\n\x07version\x18\x04 \x01(\r\x12\x12\n\nnum_inputs\x18\x05 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x06 \x01(\r\x12\x10\n\x08locktime\x18\x07 \x01(\r\x12H\n\x0b\x66ormat_unit\x18\x08 \x01(\x0e\x32\x33.shiftcrypto.bitbox02.BTCSignInitRequest.FormatUnit\"\"\n\nFormatUnit\x12\x0b\n\x07\x44\x45\x46\x41ULT\x10\x00\x12\x07\n\x03SAT\x10\x01\"\xfe\x02\n\x13\x42TCSignNextResponse\x12<\n\x04type\x18\x01 \x01(\x0e\x32..shiftcrypto.bitbox02.BTCSignNextResponse.Type\x12\r\n\x05index\x18\x02 \x01(\r\x12\x15\n\rhas_signature\x18\x03 \x01(\x08\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12\x12\n\nprev_index\x18\x05 \x01(\r\x12W\n\x1d\x61nti_klepto_signer_commitment\x18\x06 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitment\"\x82\x01\n\x04Type\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\x0f\n\x0bPREVTX_INIT\x10\x03\x12\x10\n\x0cPREVTX_INPUT\x10\x04\x12\x11\n\rPREVTX_OUTPUT\x10\x05\x12\x0e\n\nHOST_NONCE\x10\x06\x12\x13\n\x0fPAYMENT_REQUEST\x10\x07\"\xea\x01\n\x13\x42TCSignInputRequest\x12\x13\n\x0bprevOutHash\x18\x01 \x01(\x0c\x12\x14\n\x0cprevOutIndex\x18\x02 \x01(\r\x12\x14\n\x0cprevOutValue\x18\x03 \x01(\x04\x12\x10\n\x08sequence\x18\x04 \x01(\r\x12\x0f\n\x07keypath\x18\x06 \x03(\r\x12\x1b\n\x13script_config_index\x18\x07 \x01(\r\x12R\n\x15host_nonce_commitment\x18\x08 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"\xe3\x01\n\x14\x42TCSignOutputRequest\x12\x0c\n\x04ours\x18\x01 \x01(\x08\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.shiftcrypto.bitbox02.BTCOutputType\x12\r\n\x05value\x18\x03 \x01(\x04\x12\x0f\n\x07payload\x18\x04 \x01(\x0c\x12\x0f\n\x07keypath\x18\x05 \x03(\r\x12\x1b\n\x13script_config_index\x18\x06 \x01(\r\x12\"\n\x15payment_request_index\x18\x07 \x01(\rH\x00\x88\x01\x01\x42\x18\n\x16_payment_request_index\"\x99\x01\n\x1b\x42TCScriptConfigRegistration\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12<\n\rscript_config\x18\x02 \x01(\x0b\x32%.shiftcrypto.bitbox02.BTCScriptConfig\x12\x0f\n\x07keypath\x18\x03 \x03(\r\"\x0c\n\nBTCSuccess\"m\n\"BTCIsScriptConfigRegisteredRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\"<\n#BTCIsScriptConfigRegisteredResponse\x12\x15\n\ris_registered\x18\x01 \x01(\x08\"\xfc\x01\n\x1e\x42TCRegisterScriptConfigRequest\x12G\n\x0cregistration\x18\x01 \x01(\x0b\x32\x31.shiftcrypto.bitbox02.BTCScriptConfigRegistration\x12\x0c\n\x04name\x18\x02 \x01(\t\x12P\n\txpub_type\x18\x03 \x01(\x0e\x32=.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.XPubType\"1\n\x08XPubType\x12\x11\n\rAUTO_ELECTRUM\x10\x00\x12\x12\n\x0e\x41UTO_XPUB_TPUB\x10\x01\"b\n\x14\x42TCPrevTxInitRequest\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\x12\n\nnum_inputs\x18\x02 \x01(\r\x12\x13\n\x0bnum_outputs\x18\x03 \x01(\r\x12\x10\n\x08locktime\x18\x04 \x01(\r\"r\n\x15\x42TCPrevTxInputRequest\x12\x15\n\rprev_out_hash\x18\x01 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x02 \x01(\r\x12\x18\n\x10signature_script\x18\x03 \x01(\x0c\x12\x10\n\x08sequence\x18\x04 \x01(\r\">\n\x16\x42TCPrevTxOutputRequest\x12\r\n\x05value\x18\x01 \x01(\x04\x12\x15\n\rpubkey_script\x18\x02 \x01(\x0c\"\xab\x02\n\x18\x42TCPaymentRequestRequest\x12\x16\n\x0erecipient_name\x18\x01 \x01(\t\x12\x42\n\x05memos\x18\x02 \x03(\x0b\x32\x33.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo\x12\r\n\x05nonce\x18\x03 \x01(\x0c\x12\x14\n\x0ctotal_amount\x18\x04 \x01(\x04\x12\x11\n\tsignature\x18\x05 \x01(\x0c\x1a{\n\x04Memo\x12Q\n\ttext_memo\x18\x01 \x01(\x0b\x32<.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.TextMemoH\x00\x1a\x18\n\x08TextMemo\x12\x0c\n\x04note\x18\x01 \x01(\tB\x06\n\x04memo\"\xee\x01\n\x15\x42TCSignMessageRequest\x12+\n\x04\x63oin\x18\x01 \x01(\x0e\x32\x1d.shiftcrypto.bitbox02.BTCCoin\x12G\n\rscript_config\x18\x02 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.BTCScriptConfigWithKeypath\x12\x0b\n\x03msg\x18\x03 \x01(\x0c\x12R\n\x15host_nonce_commitment\x18\x04 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment\"+\n\x16\x42TCSignMessageResponse\x12\x11\n\tsignature\x18\x01 \x01(\x0c\"\x81\x05\n\nBTCRequest\x12_\n\x1bis_script_config_registered\x18\x01 \x01(\x0b\x32\x38.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequestH\x00\x12V\n\x16register_script_config\x18\x02 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.BTCRegisterScriptConfigRequestH\x00\x12\x41\n\x0bprevtx_init\x18\x03 \x01(\x0b\x32*.shiftcrypto.bitbox02.BTCPrevTxInitRequestH\x00\x12\x43\n\x0cprevtx_input\x18\x04 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCPrevTxInputRequestH\x00\x12\x45\n\rprevtx_output\x18\x05 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCPrevTxOutputRequestH\x00\x12\x43\n\x0csign_message\x18\x06 \x01(\x0b\x32+.shiftcrypto.bitbox02.BTCSignMessageRequestH\x00\x12P\n\x14\x61ntiklepto_signature\x18\x07 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignatureRequestH\x00\x12I\n\x0fpayment_request\x18\x08 \x01(\x0b\x32..shiftcrypto.bitbox02.BTCPaymentRequestRequestH\x00\x42\t\n\x07request\"\x90\x03\n\x0b\x42TCResponse\x12\x33\n\x07success\x18\x01 \x01(\x0b\x32 .shiftcrypto.bitbox02.BTCSuccessH\x00\x12`\n\x1bis_script_config_registered\x18\x02 \x01(\x0b\x32\x39.shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponseH\x00\x12>\n\tsign_next\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.BTCSignNextResponseH\x00\x12\x44\n\x0csign_message\x18\x04 \x01(\x0b\x32,.shiftcrypto.bitbox02.BTCSignMessageResponseH\x00\x12X\n\x1c\x61ntiklepto_signer_commitment\x18\x05 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.AntiKleptoSignerCommitmentH\x00\x42\n\n\x08response*/\n\x07\x42TCCoin\x12\x07\n\x03\x42TC\x10\x00\x12\x08\n\x04TBTC\x10\x01\x12\x07\n\x03LTC\x10\x02\x12\x08\n\x04TLTC\x10\x03*R\n\rBTCOutputType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05P2PKH\x10\x01\x12\x08\n\x04P2SH\x10\x02\x12\n\n\x06P2WPKH\x10\x03\x12\t\n\x05P2WSH\x10\x04\x12\x08\n\x04P2TR\x10\x05\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'btc_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _BTCCOIN._serialized_start=4376
-  _BTCCOIN._serialized_end=4423
-  _BTCOUTPUTTYPE._serialized_start=4425
-  _BTCOUTPUTTYPE._serialized_end=4507
+  _BTCCOIN._serialized_start=4837
+  _BTCCOIN._serialized_end=4884
+  _BTCOUTPUTTYPE._serialized_start=4886
+  _BTCOUTPUTTYPE._serialized_end=4968
   _BTCSCRIPTCONFIG._serialized_start=68
   _BTCSCRIPTCONFIG._serialized_end=650
   _BTCSCRIPTCONFIG_MULTISIG._serialized_start=293
@@ -47,37 +47,43 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _BTCSIGNINITREQUEST_FORMATUNIT._serialized_start=1436
   _BTCSIGNINITREQUEST_FORMATUNIT._serialized_end=1470
   _BTCSIGNNEXTRESPONSE._serialized_start=1473
-  _BTCSIGNNEXTRESPONSE._serialized_end=1833
-  _BTCSIGNNEXTRESPONSE_TYPE._serialized_start=1724
-  _BTCSIGNNEXTRESPONSE_TYPE._serialized_end=1833
-  _BTCSIGNINPUTREQUEST._serialized_start=1836
-  _BTCSIGNINPUTREQUEST._serialized_end=2070
-  _BTCSIGNOUTPUTREQUEST._serialized_start=2073
-  _BTCSIGNOUTPUTREQUEST._serialized_end=2238
-  _BTCSCRIPTCONFIGREGISTRATION._serialized_start=2241
-  _BTCSCRIPTCONFIGREGISTRATION._serialized_end=2394
-  _BTCSUCCESS._serialized_start=2396
-  _BTCSUCCESS._serialized_end=2408
-  _BTCISSCRIPTCONFIGREGISTEREDREQUEST._serialized_start=2410
-  _BTCISSCRIPTCONFIGREGISTEREDREQUEST._serialized_end=2519
-  _BTCISSCRIPTCONFIGREGISTEREDRESPONSE._serialized_start=2521
-  _BTCISSCRIPTCONFIGREGISTEREDRESPONSE._serialized_end=2581
-  _BTCREGISTERSCRIPTCONFIGREQUEST._serialized_start=2584
-  _BTCREGISTERSCRIPTCONFIGREQUEST._serialized_end=2836
-  _BTCREGISTERSCRIPTCONFIGREQUEST_XPUBTYPE._serialized_start=2787
-  _BTCREGISTERSCRIPTCONFIGREQUEST_XPUBTYPE._serialized_end=2836
-  _BTCPREVTXINITREQUEST._serialized_start=2838
-  _BTCPREVTXINITREQUEST._serialized_end=2936
-  _BTCPREVTXINPUTREQUEST._serialized_start=2938
-  _BTCPREVTXINPUTREQUEST._serialized_end=3052
-  _BTCPREVTXOUTPUTREQUEST._serialized_start=3054
-  _BTCPREVTXOUTPUTREQUEST._serialized_end=3116
-  _BTCSIGNMESSAGEREQUEST._serialized_start=3119
-  _BTCSIGNMESSAGEREQUEST._serialized_end=3357
-  _BTCSIGNMESSAGERESPONSE._serialized_start=3359
-  _BTCSIGNMESSAGERESPONSE._serialized_end=3402
-  _BTCREQUEST._serialized_start=3405
-  _BTCREQUEST._serialized_end=3971
-  _BTCRESPONSE._serialized_start=3974
-  _BTCRESPONSE._serialized_end=4374
+  _BTCSIGNNEXTRESPONSE._serialized_end=1855
+  _BTCSIGNNEXTRESPONSE_TYPE._serialized_start=1725
+  _BTCSIGNNEXTRESPONSE_TYPE._serialized_end=1855
+  _BTCSIGNINPUTREQUEST._serialized_start=1858
+  _BTCSIGNINPUTREQUEST._serialized_end=2092
+  _BTCSIGNOUTPUTREQUEST._serialized_start=2095
+  _BTCSIGNOUTPUTREQUEST._serialized_end=2322
+  _BTCSCRIPTCONFIGREGISTRATION._serialized_start=2325
+  _BTCSCRIPTCONFIGREGISTRATION._serialized_end=2478
+  _BTCSUCCESS._serialized_start=2480
+  _BTCSUCCESS._serialized_end=2492
+  _BTCISSCRIPTCONFIGREGISTEREDREQUEST._serialized_start=2494
+  _BTCISSCRIPTCONFIGREGISTEREDREQUEST._serialized_end=2603
+  _BTCISSCRIPTCONFIGREGISTEREDRESPONSE._serialized_start=2605
+  _BTCISSCRIPTCONFIGREGISTEREDRESPONSE._serialized_end=2665
+  _BTCREGISTERSCRIPTCONFIGREQUEST._serialized_start=2668
+  _BTCREGISTERSCRIPTCONFIGREQUEST._serialized_end=2920
+  _BTCREGISTERSCRIPTCONFIGREQUEST_XPUBTYPE._serialized_start=2871
+  _BTCREGISTERSCRIPTCONFIGREQUEST_XPUBTYPE._serialized_end=2920
+  _BTCPREVTXINITREQUEST._serialized_start=2922
+  _BTCPREVTXINITREQUEST._serialized_end=3020
+  _BTCPREVTXINPUTREQUEST._serialized_start=3022
+  _BTCPREVTXINPUTREQUEST._serialized_end=3136
+  _BTCPREVTXOUTPUTREQUEST._serialized_start=3138
+  _BTCPREVTXOUTPUTREQUEST._serialized_end=3200
+  _BTCPAYMENTREQUESTREQUEST._serialized_start=3203
+  _BTCPAYMENTREQUESTREQUEST._serialized_end=3502
+  _BTCPAYMENTREQUESTREQUEST_MEMO._serialized_start=3379
+  _BTCPAYMENTREQUESTREQUEST_MEMO._serialized_end=3502
+  _BTCPAYMENTREQUESTREQUEST_MEMO_TEXTMEMO._serialized_start=3470
+  _BTCPAYMENTREQUESTREQUEST_MEMO_TEXTMEMO._serialized_end=3494
+  _BTCSIGNMESSAGEREQUEST._serialized_start=3505
+  _BTCSIGNMESSAGEREQUEST._serialized_end=3743
+  _BTCSIGNMESSAGERESPONSE._serialized_start=3745
+  _BTCSIGNMESSAGERESPONSE._serialized_end=3788
+  _BTCREQUEST._serialized_start=3791
+  _BTCREQUEST._serialized_end=4432
+  _BTCRESPONSE._serialized_start=4435
+  _BTCRESPONSE._serialized_end=4835
 # @@protoc_insertion_point(module_scope)

--- a/py/bitbox02/bitbox02/communication/generated/btc_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/btc_pb2.pyi
@@ -329,6 +329,7 @@ class BTCSignNextResponse(google.protobuf.message.Message):
         PREVTX_INPUT: BTCSignNextResponse._Type.ValueType  # 4
         PREVTX_OUTPUT: BTCSignNextResponse._Type.ValueType  # 5
         HOST_NONCE: BTCSignNextResponse._Type.ValueType  # 6
+        PAYMENT_REQUEST: BTCSignNextResponse._Type.ValueType  # 7
     class Type(_Type, metaclass=_TypeEnumTypeWrapper):
         pass
 
@@ -341,6 +342,7 @@ class BTCSignNextResponse(google.protobuf.message.Message):
     PREVTX_INPUT: BTCSignNextResponse.Type.ValueType  # 4
     PREVTX_OUTPUT: BTCSignNextResponse.Type.ValueType  # 5
     HOST_NONCE: BTCSignNextResponse.Type.ValueType  # 6
+    PAYMENT_REQUEST: BTCSignNextResponse.Type.ValueType  # 7
 
     TYPE_FIELD_NUMBER: builtins.int
     INDEX_FIELD_NUMBER: builtins.int
@@ -422,6 +424,7 @@ class BTCSignOutputRequest(google.protobuf.message.Message):
     PAYLOAD_FIELD_NUMBER: builtins.int
     KEYPATH_FIELD_NUMBER: builtins.int
     SCRIPT_CONFIG_INDEX_FIELD_NUMBER: builtins.int
+    PAYMENT_REQUEST_INDEX_FIELD_NUMBER: builtins.int
     ours: builtins.bool
     type: global___BTCOutputType.ValueType
     """if ours is false"""
@@ -439,6 +442,7 @@ class BTCSignOutputRequest(google.protobuf.message.Message):
     script_config_index: builtins.int
     """If ours is true. References a script config from BTCSignInitRequest"""
 
+    payment_request_index: builtins.int
     def __init__(self,
         *,
         ours: builtins.bool = ...,
@@ -447,8 +451,11 @@ class BTCSignOutputRequest(google.protobuf.message.Message):
         payload: builtins.bytes = ...,
         keypath: typing.Optional[typing.Iterable[builtins.int]] = ...,
         script_config_index: builtins.int = ...,
+        payment_request_index: typing.Optional[builtins.int] = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["keypath",b"keypath","ours",b"ours","payload",b"payload","script_config_index",b"script_config_index","type",b"type","value",b"value"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["_payment_request_index",b"_payment_request_index","payment_request_index",b"payment_request_index"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_payment_request_index",b"_payment_request_index","keypath",b"keypath","ours",b"ours","payload",b"payload","payment_request_index",b"payment_request_index","script_config_index",b"script_config_index","type",b"type","value",b"value"]) -> None: ...
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_payment_request_index",b"_payment_request_index"]) -> typing.Optional[typing_extensions.Literal["payment_request_index"]]: ...
 global___BTCSignOutputRequest = BTCSignOutputRequest
 
 class BTCScriptConfigRegistration(google.protobuf.message.Message):
@@ -599,6 +606,53 @@ class BTCPrevTxOutputRequest(google.protobuf.message.Message):
     def ClearField(self, field_name: typing_extensions.Literal["pubkey_script",b"pubkey_script","value",b"value"]) -> None: ...
 global___BTCPrevTxOutputRequest = BTCPrevTxOutputRequest
 
+class BTCPaymentRequestRequest(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    class Memo(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+        class TextMemo(google.protobuf.message.Message):
+            DESCRIPTOR: google.protobuf.descriptor.Descriptor
+            NOTE_FIELD_NUMBER: builtins.int
+            note: typing.Text
+            def __init__(self,
+                *,
+                note: typing.Text = ...,
+                ) -> None: ...
+            def ClearField(self, field_name: typing_extensions.Literal["note",b"note"]) -> None: ...
+
+        TEXT_MEMO_FIELD_NUMBER: builtins.int
+        @property
+        def text_memo(self) -> global___BTCPaymentRequestRequest.Memo.TextMemo: ...
+        def __init__(self,
+            *,
+            text_memo: typing.Optional[global___BTCPaymentRequestRequest.Memo.TextMemo] = ...,
+            ) -> None: ...
+        def HasField(self, field_name: typing_extensions.Literal["memo",b"memo","text_memo",b"text_memo"]) -> builtins.bool: ...
+        def ClearField(self, field_name: typing_extensions.Literal["memo",b"memo","text_memo",b"text_memo"]) -> None: ...
+        def WhichOneof(self, oneof_group: typing_extensions.Literal["memo",b"memo"]) -> typing.Optional[typing_extensions.Literal["text_memo"]]: ...
+
+    RECIPIENT_NAME_FIELD_NUMBER: builtins.int
+    MEMOS_FIELD_NUMBER: builtins.int
+    NONCE_FIELD_NUMBER: builtins.int
+    TOTAL_AMOUNT_FIELD_NUMBER: builtins.int
+    SIGNATURE_FIELD_NUMBER: builtins.int
+    recipient_name: typing.Text
+    @property
+    def memos(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___BTCPaymentRequestRequest.Memo]: ...
+    nonce: builtins.bytes
+    total_amount: builtins.int
+    signature: builtins.bytes
+    def __init__(self,
+        *,
+        recipient_name: typing.Text = ...,
+        memos: typing.Optional[typing.Iterable[global___BTCPaymentRequestRequest.Memo]] = ...,
+        nonce: builtins.bytes = ...,
+        total_amount: builtins.int = ...,
+        signature: builtins.bytes = ...,
+        ) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["memos",b"memos","nonce",b"nonce","recipient_name",b"recipient_name","signature",b"signature","total_amount",b"total_amount"]) -> None: ...
+global___BTCPaymentRequestRequest = BTCPaymentRequestRequest
+
 class BTCSignMessageRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
     COIN_FIELD_NUMBER: builtins.int
@@ -644,6 +698,7 @@ class BTCRequest(google.protobuf.message.Message):
     PREVTX_OUTPUT_FIELD_NUMBER: builtins.int
     SIGN_MESSAGE_FIELD_NUMBER: builtins.int
     ANTIKLEPTO_SIGNATURE_FIELD_NUMBER: builtins.int
+    PAYMENT_REQUEST_FIELD_NUMBER: builtins.int
     @property
     def is_script_config_registered(self) -> global___BTCIsScriptConfigRegisteredRequest: ...
     @property
@@ -658,6 +713,8 @@ class BTCRequest(google.protobuf.message.Message):
     def sign_message(self) -> global___BTCSignMessageRequest: ...
     @property
     def antiklepto_signature(self) -> antiklepto_pb2.AntiKleptoSignatureRequest: ...
+    @property
+    def payment_request(self) -> global___BTCPaymentRequestRequest: ...
     def __init__(self,
         *,
         is_script_config_registered: typing.Optional[global___BTCIsScriptConfigRegisteredRequest] = ...,
@@ -667,10 +724,11 @@ class BTCRequest(google.protobuf.message.Message):
         prevtx_output: typing.Optional[global___BTCPrevTxOutputRequest] = ...,
         sign_message: typing.Optional[global___BTCSignMessageRequest] = ...,
         antiklepto_signature: typing.Optional[antiklepto_pb2.AntiKleptoSignatureRequest] = ...,
+        payment_request: typing.Optional[global___BTCPaymentRequestRequest] = ...,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal["antiklepto_signature",b"antiklepto_signature","is_script_config_registered",b"is_script_config_registered","prevtx_init",b"prevtx_init","prevtx_input",b"prevtx_input","prevtx_output",b"prevtx_output","register_script_config",b"register_script_config","request",b"request","sign_message",b"sign_message"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["antiklepto_signature",b"antiklepto_signature","is_script_config_registered",b"is_script_config_registered","prevtx_init",b"prevtx_init","prevtx_input",b"prevtx_input","prevtx_output",b"prevtx_output","register_script_config",b"register_script_config","request",b"request","sign_message",b"sign_message"]) -> None: ...
-    def WhichOneof(self, oneof_group: typing_extensions.Literal["request",b"request"]) -> typing.Optional[typing_extensions.Literal["is_script_config_registered","register_script_config","prevtx_init","prevtx_input","prevtx_output","sign_message","antiklepto_signature"]]: ...
+    def HasField(self, field_name: typing_extensions.Literal["antiklepto_signature",b"antiklepto_signature","is_script_config_registered",b"is_script_config_registered","payment_request",b"payment_request","prevtx_init",b"prevtx_init","prevtx_input",b"prevtx_input","prevtx_output",b"prevtx_output","register_script_config",b"register_script_config","request",b"request","sign_message",b"sign_message"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["antiklepto_signature",b"antiklepto_signature","is_script_config_registered",b"is_script_config_registered","payment_request",b"payment_request","prevtx_init",b"prevtx_init","prevtx_input",b"prevtx_input","prevtx_output",b"prevtx_output","register_script_config",b"register_script_config","request",b"request","sign_message",b"sign_message"]) -> None: ...
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["request",b"request"]) -> typing.Optional[typing_extensions.Literal["is_script_config_registered","register_script_config","prevtx_init","prevtx_input","prevtx_output","sign_message","antiklepto_signature","payment_request"]]: ...
 global___BTCRequest = BTCRequest
 
 class BTCResponse(google.protobuf.message.Message):

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -21,6 +21,7 @@ pub mod common;
 pub mod keypath;
 mod multisig;
 pub mod params;
+mod payment_request;
 mod policies;
 mod registration;
 mod script;
@@ -305,7 +306,8 @@ pub async fn process_api(request: &Request) -> Result<pb::btc_response::Response
         Request::PrevtxInit(_)
         | Request::PrevtxInput(_)
         | Request::PrevtxOutput(_)
-        | Request::AntikleptoSignature(_) => Err(Error::InvalidState),
+        | Request::AntikleptoSignature(_)
+        | Request::PaymentRequest(_) => Err(Error::InvalidState),
     }
 }
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/params.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/params.rs
@@ -31,6 +31,14 @@ pub struct Params {
     pub taproot_support: bool,
 }
 
+impl Params {
+    /// Returns the SLIP44 coin type:
+    /// https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    pub fn slip44(&self) -> u32 {
+        self.bip44_coin - HARDENED
+    }
+}
+
 const PARAMS_BTC: Params = Params {
     coin: BtcCoin::Btc,
     bip44_coin: 0 + HARDENED,

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/payment_request.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/payment_request.rs
@@ -1,0 +1,327 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::pb;
+use super::Error;
+
+use alloc::vec::Vec;
+
+use super::common::format_amount;
+use super::params;
+use super::script::serialize_varint;
+
+use pb::btc_payment_request_request::{memo, Memo};
+use pb::btc_sign_init_request::FormatUnit;
+
+use crate::workflow::{confirm, transaction};
+
+use sha2::{Digest, Sha256};
+
+use bitcoin::secp256k1;
+
+// Arbitrary limit on number of memos that a payment request can show to the user.
+const MAX_MEMOS_NUM: usize = 3;
+
+struct Identity {
+    name: &'static str,
+    public_key: &'static [u8],
+}
+
+const IDENTITIES: &[Identity] = &[
+    // Identity {
+    //     name: "PocketBitcoin",
+    //     public_key: b"...",
+    // },
+    #[cfg(feature = "testing")]
+    Identity {
+        name: "Test Merchant",
+        // private_key: b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        public_key: b"\x02\xe5\xa0\x18\xb3\xa2\xe1\x55\x31\x61\x09\xd9\xcd\xc5\xea\xb7\x39\x75\x9c\x0e\x07\xe0\xc0\x0b\xf9\xfc\xcb\x82\x37\xfe\x4d\x7f\x02",
+    },
+];
+
+fn find_identity(name: &str) -> Option<&Identity> {
+    IDENTITIES.iter().find(|identity| identity.name == name)
+}
+
+/// Prompt user to verify the payment request.
+pub async fn user_verify(
+    coin_params: &params::Params,
+    payment_request: &pb::BtcPaymentRequestRequest,
+    format_unit: FormatUnit,
+) -> Result<(), Error> {
+    if find_identity(&payment_request.recipient_name).is_none() {
+        return Err(Error::InvalidInput);
+    }
+    transaction::verify_recipient(
+        &payment_request.recipient_name,
+        &format_amount(coin_params, format_unit, payment_request.total_amount)?,
+    )
+    .await?;
+    for memo in payment_request.memos.iter() {
+        match memo {
+            Memo {
+                memo: Some(memo::Memo::TextMemo(text_memo)),
+            } => {
+                if !util::ascii::is_printable_ascii(&text_memo.note, util::ascii::Charset::All) {
+                    return Err(Error::InvalidInput);
+                }
+                confirm::confirm(&confirm::Params {
+                    title: "",
+                    body: &format!(
+                        "Memo from {}: {}",
+                        payment_request.recipient_name, text_memo.note,
+                    ),
+                    scrollable: true,
+                    accept_is_nextarrow: true,
+                    ..Default::default()
+                })
+                .await?;
+            }
+            _ => return Err(Error::InvalidInput),
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum ValidationError {
+    UnknownRecipient,
+    InvalidSignature,
+    Other,
+}
+
+fn hash_data_lenprefixed<U: digest::Update>(hasher: &mut U, data: &[u8]) {
+    hasher.update(&serialize_varint(data.len() as u64));
+    hasher.update(data);
+}
+
+// Compute payment request sighash.  See
+// https://github.com/satoshilabs/slips/blob/master/slip-0024.md#signature-generation For now, only
+// one output for a payment request is supported - for multiple output support, the data must be
+// streamed into the hasher.
+fn compute_sighash(
+    coin_params: &params::Params,
+    payment_request: &pb::BtcPaymentRequestRequest,
+    output_value: u64,
+    output_address: &str,
+) -> Result<Vec<u8>, ValidationError> {
+    let mut sighash = Sha256::new();
+    // versionMagic
+    sighash.update(b"SL\x00\x24");
+    // nonce
+    hash_data_lenprefixed(&mut sighash, &payment_request.nonce);
+    // recipientName
+    hash_data_lenprefixed(&mut sighash, payment_request.recipient_name.as_bytes());
+    // memos
+    sighash.update(&serialize_varint(payment_request.memos.len() as u64));
+    for memo in payment_request.memos.iter() {
+        match memo {
+            Memo {
+                memo: Some(memo::Memo::TextMemo(text_memo)),
+            } => {
+                sighash.update(1u32.to_le_bytes());
+                hash_data_lenprefixed(&mut sighash, text_memo.note.as_bytes());
+            }
+            _ => return Err(ValidationError::Other),
+        }
+    }
+    // coinType
+    sighash.update(coin_params.slip44().to_le_bytes());
+    // outputsHash (only one output for now).
+    sighash.update({
+        let mut output_hasher = Sha256::new();
+        output_hasher.update(output_value.to_le_bytes());
+        hash_data_lenprefixed(&mut output_hasher, output_address.as_bytes());
+        output_hasher.finalize()
+    });
+    Ok(sighash.finalize().to_vec())
+}
+
+#[cfg(feature = "testing")]
+#[allow(dead_code)]
+pub fn tst_sign_payment_request(
+    coin_params: &params::Params,
+    payment_request: &mut pb::BtcPaymentRequestRequest,
+    output_value: u64,
+    output_address: &str,
+) {
+    let sighash =
+        compute_sighash(coin_params, payment_request, output_value, output_address).unwrap();
+
+    let privkey = secp256k1::SecretKey::from_slice(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+    let msg = secp256k1::Message::from_digest_slice(&sighash).unwrap();
+    let secp = secp256k1::Secp256k1::new();
+    let sig = secp.sign_ecdsa(&msg, &privkey);
+    payment_request.signature = sig.serialize_compact().to_vec();
+}
+
+fn ecdsa_verify(sig64: &[u8], msg32: &[u8], pubkey33: &[u8]) -> Result<(), ValidationError> {
+    let secp = secp256k1::Secp256k1::new();
+    let pubkey = secp256k1::PublicKey::from_slice(pubkey33)
+        .map_err(|_| ValidationError::InvalidSignature)?;
+    let msg = secp256k1::Message::from_digest_slice(msg32).unwrap();
+    let sig = secp256k1::ecdsa::Signature::from_compact(sig64)
+        .map_err(|_| ValidationError::InvalidSignature)?;
+    secp.verify_ecdsa(&msg, &sig, &pubkey)
+        .map_err(|_| ValidationError::InvalidSignature)
+}
+
+/// Validate the payment request: amount, signature, etc.
+pub fn validate(
+    coin_params: &params::Params,
+    payment_request: &pb::BtcPaymentRequestRequest,
+    output_value: u64,
+    output_address: &str,
+) -> Result<(), ValidationError> {
+    let identity =
+        find_identity(&payment_request.recipient_name).ok_or(ValidationError::UnknownRecipient)?;
+    if payment_request.total_amount != output_value {
+        return Err(ValidationError::Other);
+    }
+    if !payment_request.nonce.is_empty() {
+        // No support for nonces yet.
+        return Err(ValidationError::Other);
+    }
+    if payment_request.memos.len() > MAX_MEMOS_NUM {
+        return Err(ValidationError::Other);
+    }
+    let sighash = compute_sighash(coin_params, payment_request, output_value, output_address)?;
+    ecdsa_verify(&payment_request.signature, &sighash, identity.public_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_text_memo(note: &str) -> Memo {
+        Memo {
+            memo: Some(memo::Memo::TextMemo(memo::TextMemo { note: note.into() })),
+        }
+    }
+
+    #[test]
+    fn test_sighash() {
+        let coin_params = params::get(pb::BtcCoin::Tbtc);
+
+        let sighash = compute_sighash(
+            coin_params,
+            &pb::BtcPaymentRequestRequest {
+                recipient_name: "Merchant".into(),
+                memos: vec![],
+                nonce: vec![],
+                total_amount: 123456,
+                signature: vec![],
+            },
+            123456,
+            "tb1q2q0j6gmfxynj40p0kxsr9jkagcvgpuqvqynnup",
+        )
+        .unwrap();
+        assert_eq!(
+            hex::encode(sighash),
+            "d6b996da9ea1129b601e4ec2edf54aa67cf917e1e3bca82be0f8302af9138fac"
+        );
+
+        let sighash = compute_sighash(
+            coin_params,
+            &pb::BtcPaymentRequestRequest {
+                recipient_name: "Merchant".into(),
+                memos: vec![make_text_memo("TextMemo 1"), make_text_memo("TextMemo 2")],
+                nonce: vec![],
+                total_amount: 123456,
+                signature: vec![],
+            },
+            123456,
+            "tb1q2q0j6gmfxynj40p0kxsr9jkagcvgpuqvqynnup",
+        )
+        .unwrap();
+        assert_eq!(
+            hex::encode(sighash),
+            "9303ef0189ab78e92b7518ebf9851bf567ca06ddce242fb33220c3b31a489251"
+        );
+    }
+
+    #[test]
+    fn test_validate() {
+        let coin_params = params::get(pb::BtcCoin::Tbtc);
+
+        let value = 123456u64;
+        let address = "tb1q2q0j6gmfxynj40p0kxsr9jkagcvgpuqvqynnup";
+
+        let mut payment_request = pb::BtcPaymentRequestRequest {
+            recipient_name: "Test Merchant".into(),
+            memos: vec![make_text_memo("TextMemo")],
+            nonce: vec![],
+            total_amount: value,
+            signature: vec![],
+        };
+        tst_sign_payment_request(coin_params, &mut payment_request, value, address);
+
+        assert!(validate(coin_params, &payment_request, value, address).is_ok());
+
+        // Unhappy cases:
+
+        // Unnown recipient
+        let payment_request = pb::BtcPaymentRequestRequest {
+            recipient_name: "Unknown Merchant".into(),
+            memos: vec![make_text_memo("TextMemo")],
+            nonce: vec![],
+            total_amount: value,
+            signature: vec![],
+        };
+        assert!(matches!(
+            validate(coin_params, &payment_request, value, address),
+            Err(ValidationError::UnknownRecipient)
+        ));
+
+        // Wrong output value
+        let payment_request = pb::BtcPaymentRequestRequest {
+            recipient_name: "Test Merchant".into(),
+            memos: vec![make_text_memo("TextMemo")],
+            nonce: vec![],
+            total_amount: value,
+            signature: vec![],
+        };
+        assert!(matches!(
+            validate(coin_params, &payment_request, value + 1, address),
+            Err(ValidationError::Other)
+        ));
+
+        // Nonzero nonce (not supported yet)
+        let payment_request = pb::BtcPaymentRequestRequest {
+            recipient_name: "Test Merchant".into(),
+            memos: vec![make_text_memo("TextMemo")],
+            nonce: vec![0xaa],
+            total_amount: value,
+            signature: vec![],
+        };
+        assert!(matches!(
+            validate(coin_params, &payment_request, value, address),
+            Err(ValidationError::Other)
+        ));
+
+        // Invalid signature
+        let payment_request = pb::BtcPaymentRequestRequest {
+            recipient_name: "Test Merchant".into(),
+            memos: vec![make_text_memo("TextMemo")],
+            nonce: vec![],
+            total_amount: value,
+            signature: vec![],
+        };
+        assert!(matches!(
+            validate(coin_params, &payment_request, value, address),
+            Err(ValidationError::InvalidSignature)
+        ));
+    }
+}

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -16,6 +16,7 @@ use super::pb;
 use super::Error;
 
 use super::common::format_amount;
+use super::payment_request;
 use super::script::serialize_varint;
 use super::{bip143, bip341, common, keypath};
 
@@ -168,6 +169,20 @@ async fn get_tx_output(
     response.wrap = false;
     match request {
         Request::BtcSignOutput(request) => Ok(request),
+        _ => Err(Error::InvalidState),
+    }
+}
+
+async fn get_payment_request(
+    index: u32,
+    response: &mut NextResponse,
+) -> Result<pb::BtcPaymentRequestRequest, Error> {
+    let request = get_request(NextType::PaymentRequest, index, None, response).await?;
+    response.wrap = true;
+    match request {
+        Request::Btc(pb::BtcRequest {
+            request: Some(pb::btc_request::Request::PaymentRequest(request)),
+        }) => Ok(request),
         _ => Err(Error::InvalidState),
     }
 }
@@ -573,6 +588,12 @@ async fn _process(request: &pb::BtcSignInitRequest) -> Result<Response, Error> {
     let mut xpub_cache = Bip32XpubCache::new();
     setup_xpub_cache(&mut xpub_cache, &request.script_configs);
 
+    // For now we only allow one payment request with one output per transaction.  In the future,
+    // this could be extended to allow multiple outputs per payment request (payment request
+    // requests payout to multiple addresses/outputs), as well as multiple payment requests per
+    // transaction.
+    let mut payment_request_seen = false;
+
     let mut progress_component = {
         let mut c = bitbox02::ui::progress_create("Loading transaction...");
         c.screen_stack_push();
@@ -755,19 +776,50 @@ async fn _process(request: &pb::BtcSignInitRequest) -> Result<Response, Error> {
             false
         };
 
+        // Only non-change outputs can belong to a payment request.
+        if is_change && tx_output.payment_request_index.is_some() {
+            return Err(Error::InvalidInput);
+        }
+
         if !is_change {
             // Verify output if it is not a change output.
             // Assemble address to display, get user confirmation.
             let address = payload.address(coin_params)?;
-            transaction::verify_recipient(
-                &(if tx_output.ours {
-                    format!("This BitBox02: {}", address)
-                } else {
-                    address
-                }),
-                &format_amount(coin_params, format_unit, tx_output.value)?,
-            )
-            .await?;
+
+            if let Some(output_payment_request_index) = tx_output.payment_request_index {
+                if output_payment_request_index != 0 {
+                    return Err(Error::InvalidInput);
+                }
+                if payment_request_seen {
+                    return Err(Error::InvalidInput);
+                }
+                let payment_request: pb::BtcPaymentRequestRequest =
+                    get_payment_request(output_index, &mut next_response).await?;
+                payment_request::user_verify(coin_params, &payment_request, format_unit).await?;
+                if payment_request::validate(
+                    coin_params,
+                    &payment_request,
+                    tx_output.value,
+                    &address,
+                )
+                .is_err()
+                {
+                    status::status("Invalid\npayment request", true).await;
+                    return Err(Error::InvalidInput);
+                }
+
+                payment_request_seen = true;
+            } else {
+                transaction::verify_recipient(
+                    &(if tx_output.ours {
+                        format!("This BitBox02: {}", address)
+                    } else {
+                        address
+                    }),
+                    &format_amount(coin_params, format_unit, tx_output.value)?,
+                )
+                .await?;
+            }
         }
 
         if is_change {
@@ -988,6 +1040,7 @@ mod tests {
     use crate::bip32::parse_xpub;
     use alloc::boxed::Box;
     use bitbox02::testing::{mock, mock_memory, mock_unlocked, mock_unlocked_using_mnemonic, Data};
+    use pb::btc_payment_request_request::{memo, Memo};
     use util::bip32::HARDENED;
 
     fn extract_next(response: &Response) -> &pb::BtcSignNextResponse {
@@ -1017,6 +1070,7 @@ mod tests {
         inputs: Vec<TxInput>,
         outputs: Vec<pb::BtcSignOutputRequest>,
         locktime: u32,
+        payment_request: Option<pb::BtcPaymentRequestRequest>,
     }
 
     impl Transaction {
@@ -1124,6 +1178,7 @@ mod tests {
                         ],
                         keypath: vec![],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                     pb::BtcSignOutputRequest {
                         ours: false,
@@ -1135,6 +1190,7 @@ mod tests {
                         ],
                         keypath: vec![],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                     pb::BtcSignOutputRequest {
                         ours: false,
@@ -1146,6 +1202,7 @@ mod tests {
                         ],
                         keypath: vec![],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                     pb::BtcSignOutputRequest {
                         ours: false,
@@ -1158,6 +1215,7 @@ mod tests {
                         ],
                         keypath: vec![],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                     pb::BtcSignOutputRequest {
                         // change
@@ -1167,6 +1225,7 @@ mod tests {
                         payload: vec![],
                         keypath: vec![84 + HARDENED, bip44_coin, 10 + HARDENED, 1, 3],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                     pb::BtcSignOutputRequest {
                         // change #2
@@ -1176,9 +1235,11 @@ mod tests {
                         payload: vec![],
                         keypath: vec![84 + HARDENED, bip44_coin, 10 + HARDENED, 1, 30],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                 ],
                 locktime: 0,
+                payment_request: None,
             }
         }
 
@@ -1230,6 +1291,7 @@ mod tests {
                         payload: vec![],
                         keypath: vec![48 + HARDENED, bip44_coin, 0 + HARDENED, 2 + HARDENED, 1, 0],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                     pb::BtcSignOutputRequest {
                         ours: false,
@@ -1242,9 +1304,11 @@ mod tests {
                         ],
                         keypath: vec![],
                         script_config_index: 0,
+                        payment_request_index: None,
                     },
                 ],
                 locktime: 1663289,
+                payment_request: None,
             }
         }
 
@@ -1314,6 +1378,11 @@ mod tests {
                 NextType::Output => {
                     Request::BtcSignOutput(self.outputs[next.index as usize].clone())
                 }
+                NextType::PaymentRequest => Request::Btc(pb::BtcRequest {
+                    request: Some(pb::btc_request::Request::PaymentRequest(
+                        self.payment_request.clone().unwrap(),
+                    )),
+                }),
                 NextType::PrevtxInit => Request::Btc(pb::BtcRequest {
                     request: Some(pb::btc_request::Request::PrevtxInit(
                         pb::BtcPrevTxInitRequest {
@@ -3074,6 +3143,118 @@ mod tests {
                     .init_request_policy(policy, keypath_account)
             )),
             Err(Error::InvalidInput)
+        );
+    }
+
+    #[test]
+    pub fn test_payment_request() {
+        let transaction =
+            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
+
+        // Attach second output to a payment request.
+        {
+            let mut tx = transaction.borrow_mut();
+            // An additional confirmation for the text memo.
+            tx.total_confirmations += 1;
+            let payment_request_output_index = 1;
+            let output_value = tx.outputs[payment_request_output_index].value;
+            let mut payment_request = pb::BtcPaymentRequestRequest {
+                recipient_name: "Test Merchant".into(),
+                memos: vec![Memo {
+                    memo: Some(memo::Memo::TextMemo(memo::TextMemo {
+                        note: "Test memo".into(),
+                    })),
+                }],
+                nonce: vec![],
+                total_amount: output_value,
+                signature: vec![],
+            };
+            let coin_params = super::super::params::get(tx.coin);
+            payment_request::tst_sign_payment_request(
+                coin_params,
+                &mut payment_request,
+                output_value,
+                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
+            );
+            tx.payment_request = Some(payment_request);
+            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
+        }
+
+        mock_host_responder(transaction.clone());
+        static mut UI_COUNTER: u32 = 0;
+        mock(Data {
+            ui_transaction_address_create: Some(Box::new(move |amount, address| {
+                match unsafe {
+                    UI_COUNTER += 1;
+                    UI_COUNTER
+                } {
+                    1 => {
+                        assert_eq!(address, "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH");
+                        assert_eq!(amount, "1.00000000 BTC");
+                        true
+                    }
+                    2 => {
+                        // Payment request
+                        assert_eq!(address, "Test Merchant");
+                        assert_eq!(amount, "12.34567890 BTC");
+                        true
+                    }
+                    4 => {
+                        assert_eq!(address, "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8");
+                        assert_eq!(amount, "0.00006000 BTC");
+                        true
+                    }
+                    5 => {
+                        assert_eq!(
+                            address,
+                            "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+                        );
+                        assert_eq!(amount, "0.00007000 BTC");
+                        true
+                    }
+                    _ => panic!("unexpected UI dialog"),
+                }
+            })),
+            ui_transaction_fee_create: Some(Box::new(move |total, fee, _longtouch| {
+                match unsafe {
+                    UI_COUNTER += 1;
+                    UI_COUNTER
+                } {
+                    7 => {
+                        assert_eq!(total, "13.39999900 BTC");
+                        assert_eq!(fee, "0.05419010 BTC");
+                        true
+                    }
+                    _ => panic!("unexpected UI dialog"),
+                }
+            })),
+            ui_confirm_create: Some(Box::new(|params| {
+                match unsafe {
+                    UI_COUNTER += 1;
+                    UI_COUNTER
+                } {
+                    3 => {
+                        assert_eq!(params.body, "Memo from Test Merchant: Test memo");
+                        true
+                    }
+                    6 => {
+                        assert_eq!(params.title, "Warning");
+                        assert_eq!(params.body, "There are 2\nchange outputs.\nProceed?");
+                        true
+                    }
+                    _ => panic!("unexpected UI dialog"),
+                }
+            })),
+            ..Default::default()
+        });
+        mock_unlocked();
+        bitbox02::random::mock_reset();
+        let init_request = transaction.borrow().init_request();
+        let result = block_on(process(&init_request));
+        assert!(result.is_ok());
+        assert_eq!(
+            unsafe { UI_COUNTER },
+            transaction.borrow().total_confirmations
         );
     }
 }

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -540,6 +540,7 @@ pub mod btc_sign_next_response {
         PrevtxInput = 4,
         PrevtxOutput = 5,
         HostNonce = 6,
+        PaymentRequest = 7,
     }
     impl Type {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -555,6 +556,7 @@ pub mod btc_sign_next_response {
                 Type::PrevtxInput => "PREVTX_INPUT",
                 Type::PrevtxOutput => "PREVTX_OUTPUT",
                 Type::HostNonce => "HOST_NONCE",
+                Type::PaymentRequest => "PAYMENT_REQUEST",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -567,6 +569,7 @@ pub mod btc_sign_next_response {
                 "PREVTX_INPUT" => Some(Self::PrevtxInput),
                 "PREVTX_OUTPUT" => Some(Self::PrevtxOutput),
                 "HOST_NONCE" => Some(Self::HostNonce),
+                "PAYMENT_REQUEST" => Some(Self::PaymentRequest),
                 _ => None,
             }
         }
@@ -613,6 +616,8 @@ pub struct BtcSignOutputRequest {
     /// If ours is true. References a script config from BTCSignInitRequest
     #[prost(uint32, tag = "6")]
     pub script_config_index: u32,
+    #[prost(uint32, optional, tag = "7")]
+    pub payment_request_index: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -726,6 +731,44 @@ pub struct BtcPrevTxOutputRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BtcPaymentRequestRequest {
+    #[prost(string, tag = "1")]
+    pub recipient_name: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub memos: ::prost::alloc::vec::Vec<btc_payment_request_request::Memo>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub nonce: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "4")]
+    pub total_amount: u64,
+    #[prost(bytes = "vec", tag = "5")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+}
+/// Nested message and enum types in `BTCPaymentRequestRequest`.
+pub mod btc_payment_request_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Memo {
+        #[prost(oneof = "memo::Memo", tags = "1")]
+        pub memo: ::core::option::Option<memo::Memo>,
+    }
+    /// Nested message and enum types in `Memo`.
+    pub mod memo {
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct TextMemo {
+            #[prost(string, tag = "1")]
+            pub note: ::prost::alloc::string::String,
+        }
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Memo {
+            #[prost(message, tag = "1")]
+            TextMemo(TextMemo),
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BtcSignMessageRequest {
     #[prost(enumeration = "BtcCoin", tag = "1")]
     pub coin: i32,
@@ -746,7 +789,7 @@ pub struct BtcSignMessageResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BtcRequest {
-    #[prost(oneof = "btc_request::Request", tags = "1, 2, 3, 4, 5, 6, 7")]
+    #[prost(oneof = "btc_request::Request", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
     pub request: ::core::option::Option<btc_request::Request>,
 }
 /// Nested message and enum types in `BTCRequest`.
@@ -768,6 +811,8 @@ pub mod btc_request {
         SignMessage(super::BtcSignMessageRequest),
         #[prost(message, tag = "7")]
         AntikleptoSignature(super::AntiKleptoSignatureRequest),
+        #[prost(message, tag = "8")]
+        PaymentRequest(super::BtcPaymentRequestRequest),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
We implement a subset of the payment requests protocol described in SLIP-24: https://github.com/satoshilabs/slips/blob/master/slip-0024.md

Subset means, unlike the full SLIP-24 proposal, this commit does not implement:
- support for multiple outputs per payment request
- support for multiple payment requests per transaction
- memo types other than text memo
- non-empty nonces

The subset is sufficient to cover the first application: selling Bitcoin via PocketBitcoin.

The protobuf messages and code has been designed so that support for the above missing features can be added in a backwards compatible way. This is why there is a `payment_request_index` in the output, which has to be `0` if present, and where at most one output can attach to a payment request.

To allow a payment request to request payout to multiple addresses in the future, multiple outputs can have the same index, and the sighash computation (the outputs hash part of it) would need to be streamed and validation done at the end.

To allow multiple payment requests per transaction, the payment_request_index can be incremented.

SLIP-24 does not go much into how the trusted party is identified. For now we identify them by the recipient name with one hardcoded pubkey per recipient. We might want to extend this with a certificate chain (root key signs signing keys, possibly with expiry dates, which sign payment requests) - this is postponed until we finalize the design.