### PR TITLE
securechip_random : multiple tries

### DIFF
--- a/src/reset.c
+++ b/src/reset.c
@@ -48,11 +48,25 @@ void reset_reset(bool status)
 {
     keystore_lock();
 #if !defined(TESTING)
-    if (!securechip_update_keys()) {
+    bool sc_result_update_keys = false;
+    for (int retries = 0; retries < 5; retries++) {
+        sc_result_update_keys = securechip_update_keys();
+        if (sc_result_update_keys) {
+            break;
+        }
+    }
+    if (!sc_result_update_keys) {
         Abort("Could not reset secure chip.");
     }
 #if APP_U2F == 1
-    if (!securechip_u2f_counter_set(0)) {
+    bool sc_result_u2f_counter_set = false;
+    for (int retries = 0; retries < 5; retries++) {
+        sc_result_u2f_counter_set = securechip_u2f_counter_set(0);
+        if (sc_result_u2f_counter_set) {
+            break;
+        }
+    }
+    if (!sc_result_u2f_counter_set) {
         Abort("Could not initialize U2F counter.");
     }
 #endif

--- a/src/securechip/securechip.c
+++ b/src/securechip/securechip.c
@@ -605,7 +605,12 @@ bool securechip_monotonic_increments_remaining(uint32_t* remaining_out)
 
 bool securechip_random(uint8_t* rand_out)
 {
-    return atcab_random(rand_out) == ATCA_SUCCESS;
+    for (int retries = 0; retries < 5; retries++) {
+        if (atcab_random(rand_out) == ATCA_SUCCESS) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // Length of priv_key must be 32 bytes


### PR DESCRIPTION
secure_chip random function uses atca library for randomness, but this call to library may not be successful and error codes might be returned by atca. In this case, firmware was also calling `Abort()`. This stops the usb connection and terminates the program. Should it happen during a factory reset, then it means the device is left in a half-reset state.

That's why it is a good practice to try this atca library call for randomness multiple times, making it possible to avoid rare unexpected errors from atca random implementation. Furthermore, this commit also specifies a `ATCA_STATUS` code in the abort message, hence allowing debugging a potential error coming from atca.