### PR TITLE
bitcoin: allow multisig at arbitrary keypaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### [Unreleased]
 - Bitcoin: add support for payment requests
+- Bitcoin: allow multisig accounts at arbitrary keypaths
 - Ethereum: allow signing EIP-712 messages containing multi-line strings
 
 ### 9.18.0

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/registration.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/registration.rs
@@ -115,7 +115,7 @@ pub async fn process_register_script_config(
             let coin = BtcCoin::try_from(*coin)?;
             let coin_params = params::get(coin);
             let name = get_name(request).await?;
-            super::multisig::validate(multisig, keypath, coin_params.bip44_coin)?;
+            super::multisig::validate(multisig, keypath)?;
             let xpub_type = XPubType::try_from(request.xpub_type)?;
             super::multisig::confirm_extended(
                 title,

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -218,12 +218,9 @@ fn validate_keypath(
             .or(Err(Error::InvalidInput))?;
         }
         Some(pb::BtcScriptConfig {
-            config: Some(pb::btc_script_config::Config::Multisig(multisig)),
+            config: Some(pb::btc_script_config::Config::Multisig(_)),
         }) => {
-            let script_type =
-                pb::btc_script_config::multisig::ScriptType::try_from(multisig.script_type)?;
-            keypath::validate_address_multisig(keypath, params.bip44_coin, script_type)
-                .or(Err(Error::InvalidInput))?;
+            keypath::validate_address_policy(keypath).or(Err(Error::InvalidInput))?;
         }
         Some(pb::BtcScriptConfig {
             config: Some(pb::btc_script_config::Config::Policy(_)),
@@ -411,7 +408,7 @@ async fn validate_script_configs(
         keypath,
     }] = script_configs
     {
-        super::multisig::validate(multisig, keypath, coin_params.bip44_coin)?;
+        super::multisig::validate(multisig, keypath)?;
         let name = super::multisig::get_name(coin_params.coin, multisig, keypath)?
             .ok_or(Error::InvalidInput)?;
         super::multisig::confirm("Spend from", coin_params, &name, multisig).await?;


### PR DESCRIPTION
Before, we would restrict the account-level keypaths for multisig to be:

- m/48'/coin'/account'/1' for P2WSH_P2SH
- m/48'/coin'/account'/2' for P2WSH

Since the keypath is verified by the user and the coin network is confirmed for every receive/send, ransom and isolation bypass attacks are mitigated sufficiently, and we can lift this restriction. Note that for wallet policies (of which multisig is a subset of), arbitrary keypaths are already allowed.

When exporting an xpub, we furthermore warned about "unusual" keypaths. In addition to the above keypaths, we also allow exporting the xpub at m/45' without warning, as this path is used by Unchained for their vaults.