### PR TITLE
sdcard: allow exit from 'Insert SD Card' screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Bitcoin: allow multisig accounts at arbitrary keypaths
 - Bitcoin: allow spendung UTXOs at very high BIP-44 address indices
 - Ethereum: allow signing EIP-712 messages containing multi-line strings
+- Allow exiting the screen asking to insert the microSD card
 
 ### 9.18.0
 - Add support for deriving BIP-39 mnemonics according to BIP-85

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -312,7 +312,10 @@ class SendMessage:
         print(f"SD Card inserted: {self._device.check_sdcard()}")
 
     def _insert_sdcard(self) -> None:
-        self._device.insert_sdcard()
+        try:
+            self._device.insert_sdcard()
+        except UserAbortException:
+            print("Aborted by user")
 
     def _remove_sdcard(self) -> None:
         self._device.remove_sdcard()

--- a/src/rust/bitbox02-rust/src/hww/api/error.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/error.rs
@@ -75,6 +75,12 @@ impl core::convert::From<crate::workflow::transaction::UserAbort> for Error {
     }
 }
 
+impl core::convert::From<crate::workflow::sdcard::UserAbort> for Error {
+    fn from(_error: crate::workflow::sdcard::UserAbort) -> Self {
+        Error::UserAbort
+    }
+}
+
 impl core::convert::From<crate::workflow::verify_message::Error> for Error {
     fn from(error: crate::workflow::verify_message::Error) -> Self {
         match error {

--- a/src/rust/bitbox02-rust/src/hww/api/sdcard.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/sdcard.rs
@@ -34,7 +34,7 @@ pub async fn process(
     {
         return Ok(Response::Success(pb::Success {}));
     }
-    sdcard::sdcard(action == SdCardAction::InsertCard).await;
+    sdcard::sdcard(action == SdCardAction::InsertCard).await?;
     Ok(Response::Success(pb::Success {}))
 }
 

--- a/src/rust/bitbox02-rust/src/workflow/sdcard.rs
+++ b/src/rust/bitbox02-rust/src/workflow/sdcard.rs
@@ -15,10 +15,16 @@
 use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
-pub async fn sdcard(insert: bool) {
-    let result = RefCell::new(None);
-    let mut component = bitbox02::ui::sdcard_create(insert, || {
-        *result.borrow_mut() = Some(());
+pub struct UserAbort;
+
+pub async fn sdcard(insert: bool) -> Result<(), UserAbort> {
+    let result = RefCell::new(None as Option<Result<(), UserAbort>>);
+    let mut component = bitbox02::ui::sdcard_create(insert, |sd_done| {
+        *result.borrow_mut() = if sd_done {
+            Some(Ok(()))
+        } else {
+            Some(Err(UserAbort))
+        };
     });
     component.screen_stack_push();
     option_no_screensaver(&result).await

--- a/src/rust/bitbox02/src/ui/ui_stub.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub.rs
@@ -93,13 +93,13 @@ where
     }
 }
 
-pub fn sdcard_create<'a, F>(insert: bool, mut continue_callback: F) -> Component<'a>
+pub fn sdcard_create<'a, F>(insert: bool, mut callback: F) -> Component<'a>
 where
-    F: FnMut() + 'a,
+    F: FnMut(bool) + 'a,
 {
     let data = crate::testing::DATA.0.borrow();
     assert_eq!(data.ui_sdcard_create_arg.unwrap(), insert);
-    continue_callback();
+    callback(true);
     Component {
         is_pushed: false,
         _p: PhantomData,

--- a/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
@@ -100,11 +100,11 @@ where
     }
 }
 
-pub fn sdcard_create<'a, F>(_insert: bool, mut continue_callback: F) -> Component<'a>
+pub fn sdcard_create<'a, F>(_insert: bool, mut callback: F) -> Component<'a>
 where
-    F: FnMut() + 'a,
+    F: FnMut(bool) + 'a,
 {
-    continue_callback();
+    callback(true);
     Component {
         is_pushed: false,
         _p: PhantomData,

--- a/src/ui/components/sdcard.c
+++ b/src/ui/components/sdcard.c
@@ -27,8 +27,8 @@ typedef struct {
     // if true, the callback won't be called until the sd card is inserted.
     // the insert/remove label changes depending on this flag.
     bool insert;
-    void (*continue_callback)(void*);
-    void* continue_callback_param;
+    void (*callback)(bool, void*);
+    void* callback_param;
 } data_t;
 
 static void _render(component_t* component)
@@ -51,17 +51,23 @@ static void _continue_callback(component_t* component)
 {
     data_t* data = (data_t*)component->parent->data;
     if (!data->insert || sd_card_inserted()) {
-        if (data->continue_callback) {
-            data->continue_callback(data->continue_callback_param);
-            data->continue_callback = NULL;
+        if (data->callback) {
+            data->callback(true, data->callback_param);
+            data->callback = NULL;
         }
     }
 }
 
-component_t* sdcard_create(
-    bool insert,
-    void (*continue_callback)(void*),
-    void* continue_callback_param)
+static void _cancel_callback(component_t* component)
+{
+    data_t* data = (data_t*)component->parent->data;
+    if (data->callback) {
+        data->callback(false, data->callback_param);
+        data->callback = NULL;
+    }
+}
+
+component_t* sdcard_create(bool insert, void (*callback)(bool, void*), void* callback_param)
 {
     component_t* component = malloc(sizeof(component_t));
     if (!component) {
@@ -75,8 +81,8 @@ component_t* sdcard_create(
     memset(component, 0, sizeof(component_t));
 
     data->insert = insert;
-    data->continue_callback = continue_callback;
-    data->continue_callback_param = continue_callback_param;
+    data->callback = callback;
+    data->callback_param = callback_param;
     component->data = data;
     component->f = &_component_functions;
     component->dimension.width = SCREEN_WIDTH;
@@ -91,6 +97,9 @@ component_t* sdcard_create(
             component));
     ui_util_add_sub_component(
         component, icon_button_create(top_slider, ICON_BUTTON_CHECK, _continue_callback));
-
+    if (insert) {
+        ui_util_add_sub_component(
+            component, icon_button_create(top_slider, ICON_BUTTON_CROSS, _cancel_callback));
+    }
     return component;
 }

--- a/src/ui/components/sdcard.h
+++ b/src/ui/components/sdcard.h
@@ -22,9 +22,6 @@
  * @param[in] insert if true, the user is asked to insert the sdcard. Otherwise the user is asked to
  *            remove it.
  */
-component_t* sdcard_create(
-    bool insert,
-    void (*continue_callback)(void*),
-    void* continue_callback_param);
+component_t* sdcard_create(bool insert, void (*callback)(bool, void*), void* callback_param);
 
 #endif


### PR DESCRIPTION
Currently the user has no option to go back from the 'Insert SD Card' screen prompt except by unplugging the device. Maybe the user clicks the button to manage backups in the settings by mistake and they don't have the SD card available and need to cancel the request.

This commit introduces a cancel option on the 'Insert SD Card to continue' screen, allowing going back to the original menu. Thus, unplugging is not needed anymore and the device can continue without an interruption.