### PR TITLE
hww: _api_info write byte for initialized status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Bitcoin: allow spendung UTXOs at very high BIP-44 address indices
 - Ethereum: allow signing EIP-712 messages containing multi-line strings
 - Allow exiting the screen asking to insert the microSD card
+- HWW: add initialized status byte to _api_info response
 
 ### 9.18.0
 - Add support for deriving BIP-39 mnemonics according to BIP-85

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,8 @@ endif()
 #
 # Versions MUST contain three parts and start with lowercase 'v'.
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
-set(FIRMWARE_VERSION "v9.19.0")
-set(FIRMWARE_BTC_ONLY_VERSION "v9.19.0")
+set(FIRMWARE_VERSION "v9.20.0")
+set(FIRMWARE_BTC_ONLY_VERSION "v9.20.0")
 set(BOOTLOADER_VERSION "v1.0.6")
 
 find_package(PythonInterp 3.6 REQUIRED)

--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+# 7.0.0
+- get_info: add optional device initialized boolean to returned tuple
+
 # 6.3.0
 - Allow infering product and version via API call instead of via USB descriptor
 - Accept EIP1559 transactions in `eth_sign()` - requires BitBox02 firmware v9.16.0

--- a/py/bitbox02/bitbox02/bitbox02/__init__.py
+++ b/py/bitbox02/bitbox02/bitbox02/__init__.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 import sys
 
-__version__ = "6.3.0"
+__version__ = "7.0.0"
 
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
     print(

--- a/src/hww.c
+++ b/src/hww.c
@@ -16,6 +16,7 @@
 
 #include <hardfault.h>
 #include <keystore.h>
+#include <memory/memory.h>
 
 #include <platform_config.h>
 #include <rust/rust.h>
@@ -65,6 +66,7 @@ typedef struct {
  * - For the BitBoxBase platform (deprecated):
  " - 0x00 - Standard
  * 1 byte: 0x00 if the device is locked, 0x01 if the device is unlocked.
+ * 1 byte: 0x00 if the device is uninitialized, 0x01 if the device is initialized.
  * @param[out] buf serialize info to this buffer.
  * @return number of bytes written
  */
@@ -95,6 +97,10 @@ static size_t _api_info(uint8_t* buf)
 
     // 1 byte locked status
     *current = keystore_is_locked() ? 0x00 : 0x01;
+    current++;
+
+    // 1 byte initialized status
+    *current = memory_is_initialized() ? 0x01 : 0x00;
     current++;
 
     return current - buf;


### PR DESCRIPTION
Write another byte for the initialized status in the _api_info function. This field can be used to check whether a device can be unlocked or not. The unlocked byte is not sufficient because unlocked = false could mean the device is locked or the device is uninitialized.