### PR TITLE
policies: refactor script derivation

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
@@ -155,10 +155,10 @@ impl Payload {
         policy: &super::policies::ParsedPolicy,
         keypath: &[u32],
     ) -> Result<Self, Error> {
-        let witness_script = policy.witness_script_at_keypath(keypath)?;
-        match &policy.descriptor {
-            super::policies::Descriptor::Wsh { .. } => Ok(Payload {
-                data: Sha256::digest(witness_script).to_vec(),
+        let derived_descriptor = policy.derive_at_keypath(keypath)?;
+        match derived_descriptor {
+            super::policies::Descriptor::Wsh(wsh) => Ok(Payload {
+                data: Sha256::digest(wsh.witness_script()).to_vec(),
                 output_type: BtcOutputType::P2wsh,
             }),
         }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -293,7 +293,9 @@ fn sighash_script(
         ValidatedScriptConfigWithKeypath {
             config: ValidatedScriptConfig::Policy(policy),
             ..
-        } => policy.witness_script_at_keypath(keypath),
+        } => match policy.derive_at_keypath(keypath)? {
+            super::policies::Descriptor::Wsh(wsh) => Ok(wsh.witness_script()),
+        },
     }
 }
 


### PR DESCRIPTION
Instead of deriving the witness script at a keypath, we instead derive a descriptor instead.

The reason for this is that witness_script only makes sense for `wsh(...)` desciptors. When we add `tr(...)` Taproot descriptors, we will need the Taproot output key instead. So a `witness_script()` method directly on the policy does not make sense as it does not work for both variants.