### PR TITLE
rust: use .into not .try_into for hash->array conversion

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -941,11 +941,11 @@ async fn _process(request: &pb::BtcSignInitRequest) -> Result<Response, Error> {
             let sighash = bip341::sighash(&bip341::Args {
                 version: request.version,
                 locktime: request.locktime,
-                hash_prevouts: hash_prevouts.as_slice().try_into().unwrap(),
-                hash_amounts: hash_amounts.as_slice().try_into().unwrap(),
-                hash_scriptpubkeys: hash_scriptpubkeys.as_slice().try_into().unwrap(),
-                hash_sequences: hash_sequence.as_slice().try_into().unwrap(),
-                hash_outputs: hash_outputs.as_slice().try_into().unwrap(),
+                hash_prevouts: hash_prevouts.into(),
+                hash_amounts: hash_amounts.into(),
+                hash_scriptpubkeys: hash_scriptpubkeys.into(),
+                hash_sequences: hash_sequence.into(),
+                hash_outputs: hash_outputs.into(),
                 input_index,
             });
             next_response.next.has_signature = true;

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -58,7 +58,7 @@ pub async fn process(request: &pb::EthSignMessageRequest) -> Result<Response, Er
     msg.extend(format!("{}", request.msg.len()).as_bytes());
     msg.extend(&request.msg);
 
-    let sighash: [u8; 32] = sha3::Keccak256::digest(&msg).as_slice().try_into().unwrap();
+    let sighash: [u8; 32] = sha3::Keccak256::digest(&msg).into();
 
     let host_nonce = match request.host_nonce_commitment {
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.


### PR DESCRIPTION
Since digest-0.13.0, one can convert directly to the `[u8;32]` array.

This does not change the compilation output at all (identical binaries).