### PR TITLE
rust: add `dep:` prefix when enabling deps

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -51,9 +51,7 @@ target-factory-setup = [
 ]
 # add Rust features which are called in the C unit tests (currently there is only one target for C tests).
 target-c-unit-tests = [
-  # enable this dependency
-  "bitcoin", # for rust_base58_encode_check()
-  # enable these features
+  "dep:bitcoin", # for rust_base58_encode_check()
   "app-bitcoin",
   "app-ethereum",
   "app-cardano",

--- a/src/rust/bitbox02-rust-c/src/util.rs
+++ b/src/rust/bitbox02-rust-c/src/util.rs
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn rust_util_bytes_mut(buf: *mut c_uchar, len: usize) -> B
 ///
 /// #Safety
 /// buf and out must not be NULL and point to valid memory areas.
-#[cfg(feature = "bitcoin")]
+#[cfg(feature = "c-unit-testing")]
 #[no_mangle]
 pub unsafe extern "C" fn rust_base58_encode_check(buf: Bytes, mut out: BytesMut) -> bool {
     if buf.len == 0 {

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -63,52 +63,40 @@ features = ["derive"]
 
 [features]
 ed25519 = [
-  # enable these dependencies
-  "bip32-ed25519",
-  "ed25519-dalek"
+  "dep:bip32-ed25519",
+  "dep:ed25519-dalek"
 ]
 
 app-ethereum = [
-  # enable these dependencies
-  "erc20_params",
-  "sha3",
-  "num-bigint",
-  # enable this feature in the deps
+  "dep:erc20_params",
+  "dep:sha3",
+  "dep:num-bigint",
   "bitbox02/app-ethereum",
 ]
 
 app-bitcoin = [
-  # enable these dependencies
-  "bech32",
-  "miniscript",
-  # enable this feature in the deps
+  "dep:bech32",
+  "dep:miniscript",
   "bitbox02/app-bitcoin",
 ]
 app-litecoin = [
-  # enable these dependencies
-  "bech32",
-  # enable this feature in the deps
+  "dep:bech32",
   "bitbox02/app-litecoin",
 ]
 
 app-u2f = [
-  # enable this feature in the deps
   "bitbox02/app-u2f",
 ]
 
 app-cardano = [
-  # enable these deps
-  "bech32",
-  "blake2",
-  "minicbor",
-  "crc",
-
-  # enable these features
+  "dep:bech32",
+  "dep:blake2",
+  "dep:minicbor",
+  "dep:crc",
   "ed25519"
 ]
 
 testing = [
-  # enable these features
   "bitbox02/testing"
 ]
 


### PR DESCRIPTION
For clarity.

The bitcoin dep is now always enabledas it's needed in bip32.rs, which is used not only by the bitcoin app.