### PR TITLE
rust: update toolchain to 1.79.0

### DIFF
--- a/.ci/run-container-ci
+++ b/.ci/run-container-ci
@@ -25,7 +25,7 @@
 set -e
 set -x
 
-CONTAINER=shiftcrypto/firmware_v2:38
+CONTAINER=shiftcrypto/firmware_v2:39
 
 if [ "$1" == "pull" ] ; then
 	docker pull "$CONTAINER"

--- a/src/rust/rust-toolchain.toml
+++ b/src/rust/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"


### PR DESCRIPTION
This reduces the binary size by 3648 bytes.