### PR TITLE
pairing: remove impossible panic

### DIFF
--- a/src/rust/bitbox02-rust/src/workflow/pairing.rs
+++ b/src/rust/bitbox02-rust/src/workflow/pairing.rs
@@ -21,8 +21,8 @@ use alloc::string::String;
 pub fn format_hash(hash: &[u8; 32]) -> String {
     let mut encoded = [0u8; 60];
     let encoded = binascii::b32encode(&hash[..], &mut encoded).unwrap();
-    // Base32 contains only utf-8 valid chars. unwrap is safe
-    let encoded = core::str::from_utf8(encoded).expect("invalid utf-8");
+    // Base32 contains only utf-8 valid chars.
+    let encoded = unsafe { core::str::from_utf8_unchecked(encoded) };
     format!(
         "{} {}\n{} {}",
         &encoded[0..5],


### PR DESCRIPTION
Good to avoid panics, plus it save some bytes in the binary for code that never executes.