### PR TITLE
rust: enable size_opt feature on blake2 to reduce binary size

### DIFF
--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = { version = "0.2", default-features = false, optional = true }
 # If you change this, also change src/rust/.cargo/config.toml.
 bip32-ed25519 = { git = "https://github.com/digitalbitbox/rust-bip32-ed25519", tag = "v0.1.2", optional = true }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"], optional = true }
-blake2 = { version = "0.10.6", default-features = false, optional = true }
+blake2 = { version = "0.10.6", default-features = false, features = ["size_opt"], optional = true }
 minicbor = { version = "0.24.0", default-features = false, features = ["alloc"], optional = true }
 crc = { version = "3.0.1", optional = true }
 ed25519-dalek = { version = "2.0.0", default-features = false, features = ["hazmat"], optional = true }


### PR DESCRIPTION
This reduces the binary size by 11576 bytes.