### PR TITLE
transaction/fee: don't use fmt with "{.1}" to reduce binary size

### DIFF
--- a/.ci/ci
+++ b/.ci/ci
@@ -53,6 +53,13 @@ make -j8 factory-setup
 make -j8 bootloader-semihosting
 make -j8 firmware-semihosting
 
+# Disallow some symbols in the final binary that we don't want.
+if arm-none-eabi-nm build/bin/firmware.elf | grep -q "float_to_decimal_common_shortest"; then
+    echo "Rust fmt float formatting like {.1} adds significant binary bloat."
+    echo "Use something simpler like (float*10).round() as u64, then format with util::decimal::format"
+    exit 1
+fi
+
 (cd tools/atecc608; go test ./...)
 
 # Don't generate graphics in CI

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -38,7 +38,7 @@ sha3 = { workspace = true, optional = true }
 digest = "0.10.6"
 zeroize = { workspace = true }
 num-bigint = { workspace = true, optional = true }
-num-traits = { version = "0.2", default-features = false, optional = true }
+num-traits = { version = "0.2", default-features = false }
 # If you change this, also change src/rust/.cargo/config.toml.
 bip32-ed25519 = { git = "https://github.com/digitalbitbox/rust-bip32-ed25519", tag = "v0.1.2", optional = true }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"], optional = true }
@@ -74,7 +74,6 @@ app-ethereum = [
   "erc20_params",
   "sha3",
   "num-bigint",
-  "num-traits",
   # enable this feature in the deps
   "bitbox02/app-ethereum",
 ]

--- a/src/rust/bitbox02-rust/src/workflow/transaction.rs
+++ b/src/rust/bitbox02-rust/src/workflow/transaction.rs
@@ -35,7 +35,8 @@ pub async fn verify_recipient(recipient: &str, amount: &str) -> Result<(), UserA
 }
 
 fn format_percentage(p: f64) -> String {
-    format!("{:.1}", p)
+    let int: u64 = num_traits::float::FloatCore::round(p * 10.) as _;
+    util::decimal::format_no_trim(int, 1)
 }
 
 pub async fn verify_total_fee(

--- a/src/rust/bitbox02-rust/src/workflow/transaction.rs
+++ b/src/rust/bitbox02-rust/src/workflow/transaction.rs
@@ -16,6 +16,7 @@ use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
 use alloc::boxed::Box;
+use alloc::string::String;
 
 pub struct UserAbort;
 
@@ -31,6 +32,10 @@ pub async fn verify_recipient(recipient: &str, amount: &str) -> Result<(), UserA
     );
     component.screen_stack_push();
     option_no_screensaver(&result).await
+}
+
+fn format_percentage(p: f64) -> String {
+    format!("{:.1}", p)
 }
 
 pub async fn verify_total_fee(
@@ -57,7 +62,10 @@ pub async fn verify_total_fee(
     if let Some(fee_percentage) = fee_percentage {
         match super::confirm::confirm(&super::confirm::Params {
             title: "High fee",
-            body: &format!("The fee is {:.1}%\nthe send amount.\nProceed?", fee_percentage),
+            body: &format!(
+                "The fee is {}%\nthe send amount.\nProceed?",
+                format_percentage(fee_percentage)
+            ),
             longtouch: true,
             ..Default::default()
         })
@@ -68,4 +76,18 @@ pub async fn verify_total_fee(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_percentage() {
+        assert_eq!(format_percentage(0.), "0.0");
+        assert_eq!(format_percentage(10.0), "10.0");
+        assert_eq!(format_percentage(10.1), "10.1");
+        assert_eq!(format_percentage(10.14), "10.1");
+        assert_eq!(format_percentage(10.15), "10.2");
+    }
 }


### PR DESCRIPTION
Using this pulls in
`core::fmt::float::float_to_decimal_common_shortest` into the binary,
which is a huge function.

By changing the impl to something simpler, we save 20112 bytes in the binary :O