### PR TITLE
rust: use .into not .try_into for hash->array conversion

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -88,10 +88,7 @@ pub async fn process(request: &pb::BtcSignMessageRequest) -> Result<Response, Er
     msg.extend(super::script::serialize_varint(request.msg.len() as _));
     msg.extend(&request.msg);
 
-    let sighash: [u8; 32] = Sha256::digest(Sha256::digest(msg))
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let sighash: [u8; 32] = Sha256::digest(Sha256::digest(msg)).into();
 
     let host_nonce = match request.host_nonce_commitment {
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.


### PR DESCRIPTION
Same as 0d409134a407c56ca36dd6d2ca3f92eb321e6b28.