### PR TITLE
external/libwally-core: update to v1.3.0

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -25,12 +25,10 @@ endif()
 if(SANITIZE_UNDEFINED)
   set(LIBWALLY_CFLAGS "${LIBWALLY_CFLAGS} -fsanitize=undefined")
 endif()
-# USE_BASIC_CONFIG is for secp256k1
 # _DEFAULT_SOURCE enables the BSD explicit_bzero function referenced by libwally.
 set(LIBWALLY_CFLAGS  "\
   ${LIBWALLY_CFLAGS} \
   ${MODIFIED_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE}} \
-  -DUSE_BASIC_CONFIG=1 \
   -D_DEFAULT_SOURCE \
   -fno-strict-aliasing \
 ")
@@ -48,16 +46,15 @@ set(LIBWALLY_LDFLAGS "${LIBWALLY_LDFLAGS} ${CMAKE_C_LINK_FLAGS}")
 
 ExternalProject_Add(libwally-core
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/libwally-core
-  STEP_TARGETS   build-libwally
+  STEP_TARGETS    build-libwally
   SOURCE_DIR      ${CMAKE_CURRENT_SOURCE_DIR}/libwally-core
-  CONFIGURE_COMMAND autoreconf --install --force ${CMAKE_CURRENT_SOURCE_DIR}/libwally-core
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR}/libwally-core tools/autogen.sh
   COMMAND         ${CMAKE_COMMAND} -E env
                   "CFLAGS=${LIBWALLY_CFLAGS}"
                   "LDFLAGS=${LIBWALLY_LDFLAGS}"
                   ${CMAKE_CURRENT_SOURCE_DIR}/libwally-core/configure
                   ${CONFIGURE_FLAGS}
                   ${LIBWALLY_CONFIGURE_FLAGS}
-  # TODO: Add darwin hack to libwally repo
   BUILD_COMMAND   ${CMAKE_MAKE_PROGRAM}
   INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
   COMMAND         ${CMAKE_COMMAND} -E copy


### PR DESCRIPTION
Calling autogen.sh instead of autoreconf as autogen.sh also does that
but also calls autogen.sh on secp256k1. Without this change secp256k1
would not build anymore b/c of a build system change in libwally.

USE_BASIC_CONFIG dropped, it's not used anymore in secp256k1.

Darin hack TODO dropped, as libwally's autogen.sh contains it.

Submodule now points to:

https://github.com/BitBoxSwiss/libwally-core/tree/bitbox02-firmware-20240722

which has a custom patch to point its secp256k1 submodule to
https://github.com/BitBoxSwiss/secp256k1-zkp/tree/bitbox02-20240722.