### PR TITLE
rust: remove lazy_static dep

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -68,7 +68,6 @@ name = "bitbox02"
 version = "0.1.0"
 dependencies = [
  "bitbox02-sys",
- "lazy_static",
  "util",
  "zeroize",
 ]
@@ -100,7 +99,6 @@ dependencies = [
  "erc20_params",
  "hex",
  "hmac",
- "lazy_static",
  "minicbor",
  "miniscript",
  "num-bigint",
@@ -430,12 +428,6 @@ checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -29,7 +29,6 @@ resolver = "2"
 [workspace.dependencies]
 bitcoin = { version = "0.32.2", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-lazy_static = { version = "1.4.0" }
 num-bigint = { version = "0.4.3", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -46,7 +46,6 @@ blake2 = { version = "0.10.6", default-features = false, features = ["size_opt"]
 minicbor = { version = "0.24.0", default-features = false, features = ["alloc"], optional = true }
 crc = { version = "3.0.1", optional = true }
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["hazmat", "digest"], optional = true }
-lazy_static = { workspace = true, optional = true }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 
 miniscript = { version = "12.0.0", default-features = false, features = ["no-std"], optional = true }
@@ -110,9 +109,6 @@ app-cardano = [
 ]
 
 testing = [
-  # enable these deps
-  "lazy_static",
-
   # enable these features
   "bitbox02/testing"
 ]

--- a/src/rust/bitbox02-rust/src/hww.rs
+++ b/src/rust/bitbox02-rust/src/hww.rs
@@ -51,20 +51,17 @@ pub struct SafeData<T>(T);
 unsafe impl<T> Sync for SafeData<T> {}
 
 #[cfg(feature = "testing")]
-lazy_static! {
-    pub static ref MOCK_NEXT_REQUEST: SafeData<
-        core::cell::RefCell<
-            Option<
-                alloc::boxed::Box<
-                    dyn Fn(
-                        crate::pb::response::Response,
-                    )
-                        -> Result<crate::pb::request::Request, api::error::Error>,
-                >,
+pub static MOCK_NEXT_REQUEST: SafeData<
+    core::cell::RefCell<
+        Option<
+            alloc::boxed::Box<
+                dyn Fn(
+                    crate::pb::response::Response,
+                ) -> Result<crate::pb::request::Request, api::error::Error>,
             >,
         >,
-    > = SafeData(core::cell::RefCell::new(None));
-}
+    >,
+> = SafeData(core::cell::RefCell::new(None));
 
 /// Set `MOCK_NEXT_REQUEST` to mock requests from the host.
 #[cfg(feature = "testing")]

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -43,10 +43,6 @@ mod xpubcache;
 #[macro_use]
 extern crate alloc;
 
-#[cfg(feature = "testing")]
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -25,11 +25,10 @@ license = "Apache-2.0"
 bitbox02-sys = {path="../bitbox02-sys"}
 util = {path = "../util"}
 zeroize = { workspace = true }
-lazy_static = { workspace = true, optional = true }
 
 [features]
 # Only to be enabled in unit tests.
-testing = ["lazy_static"]
+testing = []
 # Active when the Rust code is compiled to be linked into the C unit tests and simulator.
 c-unit-testing = []
 

--- a/src/rust/bitbox02/src/lib.rs
+++ b/src/rust/bitbox02/src/lib.rs
@@ -31,10 +31,6 @@ extern crate alloc;
 use alloc::string::String;
 
 #[cfg(feature = "testing")]
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(feature = "testing")]
 pub mod testing;
 
 pub mod bip32;

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Shift Crypto AG
+// Copyright 2020-2024 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,9 +37,14 @@ pub struct SafeData(pub RefCell<Data>);
 // Safety: must not be accessed concurrently.
 unsafe impl Sync for SafeData {}
 
-lazy_static! {
-    pub static ref DATA: SafeData = SafeData(RefCell::new(Default::default()));
-}
+pub static DATA: SafeData = SafeData(RefCell::new(Data {
+    ui_confirm_create: None,
+    sdcard_inserted: None,
+    ui_sdcard_create_arg: None,
+    ui_transaction_address_create: None,
+    ui_transaction_fee_create: None,
+    ui_trinary_input_string_create: None,
+}));
 
 /// Provide mock implementations and data. This also locks the keystore - use `mock_unlocked()` to mock a seeded and unlocked keystore.
 pub fn mock(data: Data) {


### PR DESCRIPTION
We can initialize the vars without it directly.