### PR TITLE
ci: Run CI for every commit in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 # See reference docs at
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
-name: ci
-on: [push, pull_request]
+name: Default branch ci
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   linux-docker:
@@ -14,4 +18,4 @@ jobs:
       - name: Pull CI container image
         run: ./.ci/run-container-ci pull
       - name: Run CI in container
-        run: ./.ci/run-container-ci ${{github.workspace}} ${{github.base_ref}}
+        run: ./.ci/run-container-ci ${{github.workspace}}

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -1,0 +1,61 @@
+# See reference docs at
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: Per commit CI
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Git commit to check
+        required: true
+      base_ref:
+        description: Base reference we are comparing against (e.g., 'master')
+        required: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set commit status to pending
+        run: |
+          curl -L -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ inputs.sha }} \
+            -d '{"state":"pending","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","description":"The build started!","context":"ci / per-commit-build"}'
+
+      - name: Clone the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ inputs.base_ref }}
+
+      - name: Create merge commit
+        env:
+          GIT_AUTHOR_NAME: Bot
+          GIT_AUTHOR_EMAIL: bot@bitbox.swiss
+          GIT_COMMITTER_NAME: Bot
+          GIT_COMMITTER_EMAIL: bot@bitbox.swiss
+        run: |
+          git fetch origin ${{ inputs.sha }}
+          git merge --no-ff --no-edit ${{ inputs.sha }}
+          echo "merge commit parents:"
+          git log -1 --format=%P
+
+      - name: Pull container image
+        run: ./.ci/run-container-ci pull
+
+      - name: Run CI in container
+        run: ./.ci/run-container-ci ${{github.workspace}} ${{ inputs.base_ref }}
+
+      - name: Set status
+        if: always()
+        run: |
+          curl -L -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ inputs.sha }} \
+            -d '{"state":"${{job.status}}","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","description":"The build ${{ job.status }}!","context":"ci / per-commit-build"}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,34 @@
+# See reference docs at
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: Pull request CI
+on: pull_request
+
+jobs:
+  pr-ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      # HEAD^2~ because PR branch is second parent and we want to skip the last commit
+      - name: Dispatch jobs for commits in PR history
+        run: |
+          for commit in $(git log --format="%H" origin/${{github.base_ref}}..HEAD^2~); do
+            echo ::notice::Dispatching job for $commit
+            curl -L -s \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/commit-ci.yml/dispatches \
+              -d "{\"ref\":\"${{ github.event.pull_request.head.ref }}\",\"inputs\":{\"sha\":\"$commit\",\"base_ref\":\"${{ github.base_ref}}\"}}"
+          done
+
+      - name: Pull container image
+        run: ./.ci/run-container-ci pull
+
+      - name: Run CI in container
+        run: ./.ci/run-container-ci ${{github.workspace}} ${{ github.base_ref }}


### PR DESCRIPTION
* Split out Pull Request CI into separate file
* Dispatch one job per commit in PR


I've tested it quite thoroughly on my fork of the repo in github.