### PR TITLE
DX: Move clang-tidy config to config file

### DIFF
--- a/.ci/check-tidy
+++ b/.ci/check-tidy
@@ -31,10 +31,6 @@ for dir in build build-build; do
 		exit 1
 	fi
 
-	# Remove flags unknown to tidy
-	sed -i 's/-mcpu=cortex-m4//g; s/-mfloat-abi=softfp//g; s/-mlong-calls//g; s/-mthumb//g; s/--specs=nano.specs//g; s/--specs=nosys.specs//g;
-	        s/-Wno-cast-function-type//g; s/-mfpu=fpv4-sp-d16//g; s/-Wformat-signedness//g' ${dir}/compile_commands.json
-
 	# Only check our files
 	SOURCES1=$(git --no-pager diff --diff-filter=d --name-only ${TARGET_BRANCH} HEAD |\
 		grep -v -E "(^src/(drivers|ui/fonts)|.*ugui.*|.*base32.*)" |\
@@ -55,6 +51,5 @@ for dir in build build-build; do
 	fi
 
 	echo "Checking $(echo ${SOURCES} | wc -w) files with clang-tidy"
-	# The list of tidy checks must stay in sync with scripts/tidy
-	${CLANGTIDY} -quiet -p ${dir} -checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,bugprone-*,performance-*,portability-*,readability-*,-readability-braces-around-statements,-readability-magic-numbers,-readability-isolate-declaration,-readability-identifier-length,-readability-function-cognitive-complexity,-bugprone-reserved-identifier,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,-performance-no-int-to-ptr,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-readability-avoid-unconditional-preprocessor-if -warnings-as-errors=* -header-filter '.*' ${SOURCES}
+	${CLANGTIDY} --quiet -p ${dir} --warnings-as-errors='*' ${SOURCES}
 done

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,22 @@
+Checks: >-
+  clang-analyzer-*,
+  -clang-analyzer-cplusplus*,
+  bugprone-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-magic-numbers,
+  -readability-isolate-declaration,
+  -readability-identifier-length,
+  -readability-function-cognitive-complexity,
+  -bugprone-reserved-identifier,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -performance-no-int-to-ptr,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -readability-avoid-unconditional-preprocessor-if
+HeaderFilterRegex: '.*'
+ExtraArgs:
+  - -Wno-unknown-warning-option
+  - -Qunused-arguments

--- a/scripts/tidy
+++ b/scripts/tidy
@@ -8,7 +8,7 @@ set -e
 # Exit on pipe fail
 set -o pipefail
 
-CLANGTIDY=${CLANGTIDY:-clang-tidy-8}
+CLANGTIDY=${CLANGTIDY:-clang-tidy-18}
 command -v ${CLANGTIDY} >/dev/null 2>&1 || { echo >&2 "${CLANGTIDY} is missing"; exit 1; }
 
 JQ=${JQ:-jq}
@@ -24,15 +24,11 @@ for dir in build build-build; do
 	if ! test -d ${dir}; then
 		continue
 	fi
-	# Filter out some commands that are not understood by clang-tidy
-	sed -i 's/-mcpu=cortex-m4//g; s/-mfloat-abi=softfp//g; s/-mlong-calls//g; s/-mthumb//g;
-	        s/-Wno-cast-function-type//g; s/-mfpu=fpv4-sp-d16//g; s/-Wformat-signedness//g' ${dir}/compile_commands.json
 
 	# Exclude drivers and external for now. We get the base file set from compile_commands.json, as
 	# clang-tidy unfortunately tries to lint a provided source anyway even if it is not part of the
 	# build.
 	SOURCES=$(cat ${dir}/compile_commands.json | ${JQ} 'map_values(.file) | .[]' | grep -v -e '/drivers/' -e '/external/' -e '/test/unit-test/u2f/' -e '/build/' -e '/build-build/' | sort | uniq | xargs echo)
 
-	# The list of tidy checks must stay in sync with .ci/check-tidy
-	${CLANGTIDY} -quiet -p ${dir} -checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,bugprone-*,performance-*,portability-*,readability-*,-readability-braces-around-statements,-readability-magic-numbers,-readability-isolate-declaration -warnings-as-errors=* -header-filter '.*' ${SOURCES}
+	${CLANGTIDY} -quiet -p ${dir} ${SOURCES}
 done


### PR DESCRIPTION
Clangd (C LSP) will run some of the clang-tidy checks if it finds the config in the right place. This gives the developer immediate feedback.