### PR TITLE
rust: Don't panic in build.rs script

### DIFF
--- a/src/rust/bitbox02/build.rs
+++ b/src/rust/bitbox02/build.rs
@@ -1,23 +1,28 @@
 fn main() {
     #[cfg(feature = "testing")]
     {
-        let cmake_dir = std::env::var("CMAKE_CURRENT_BINARY_DIR").unwrap();
-        println!("cargo:rustc-link-search={}/../lib", cmake_dir);
-        // c and rust code merged :O
-        println!("cargo:rustc-link-lib=bitbox_merged");
-        println!(
-            "cargo:rerun-if-changed={}/../lib/libbitbox_merged.a",
-            cmake_dir
-        );
+        if let Ok(cmake_dir) = std::env::var("CMAKE_CURRENT_BINARY_DIR") {
+            println!("cargo:rustc-link-search={}/../lib", cmake_dir);
+            // c and rust code merged :O
+            println!("cargo:rustc-link-lib=bitbox_merged");
+            println!(
+                "cargo:rerun-if-changed={}/../lib/libbitbox_merged.a",
+                cmake_dir
+            );
 
-        // external libs
-        println!("cargo:rustc-link-lib=wallycore");
-        println!("cargo:rustc-link-lib=secp256k1");
-        println!("cargo:rustc-link-lib=ctaes");
-        println!("cargo:rustc-link-lib=fatfs");
-        println!("cargo:rustc-link-lib=sd-mock");
+            // external libs
+            println!("cargo:rustc-link-lib=wallycore");
+            println!("cargo:rustc-link-lib=secp256k1");
+            println!("cargo:rustc-link-lib=ctaes");
+            println!("cargo:rustc-link-lib=fatfs");
+            println!("cargo:rustc-link-lib=sd-mock");
 
-        // system libs
-        println!("cargo:rustc-link-lib=cmocka");
+            // system libs
+            println!("cargo:rustc-link-lib=cmocka");
+        } else {
+            // This is useful in case project is built by tool that doesn't need to link the final
+            // target, like rust-analyzer and clippy.
+            eprintln!("Missing env variable CMAKE_CURRENT_BINARY_DIR, linking will fail");
+        }
     }
 }


### PR DESCRIPTION
In this commit the error of missing the cmake build directory is downgraded to a warning. When rust-analyzer and clippy builds the project they will not link the final binary. Therefore it is OK if we are missing the cmake build directory.