### PR TITLE
ci: Fix clang-tidy false positive

### DIFF
--- a/.ci/check-tidy
+++ b/.ci/check-tidy
@@ -38,6 +38,9 @@ for dir in build build-build; do
 		grep -v "^test/unit-test/u2f/" |\
 		grep -E "\.c\$" || true)
 
+	# clang doesn't recognize the vfpcc register that GCC uses
+	sed -i 's/-mfloat-abi=softfp/-mfloat-abi=soft/g;' ${dir}/compile_commands.json
+
 	# Only check files if they are in the compile_commands.json file
 	SOURCES=""
 	for SOURCE in ${SOURCES1}; do


### PR DESCRIPTION
The headers from arm seem to use some gnu-isms that clang doesn't support when using float-abi=softfp. Using float-abi=soft seems to comment out the offending code.

Perhaps this is solved with a newer version of llvm in the future.

https://stackoverflow.com/questions/44204695/how-to-use-clang-static-analyzer-with-a-cortex-m-project