### PR TITLE
ci: Stop if valgrind detects errors

### DIFF
--- a/.ci/ci
+++ b/.ci/ci
@@ -20,13 +20,20 @@ make -C py
 ./.ci/check-release-sigs
 
 # Make build directories so we can do some static analysis
+#  - prepare-tidy will create build dirs and more importantly the
+#    compile_commands.json needed for clang-tidy
 make prepare-tidy
 ./.ci/check-tidy
 
 # Build and run Unit tests
-make -j8 unit-test SANITIZE=OFF
+make -j8 unit-test
 make -j8 run-unit-tests
 make -j8 run-rust-unit-tests
+
+# Delete the build directories so that SANITIZE=OFF will take effect
+# Valgrind cannot run programs compiled with address sanitizing on.
+make clean
+make -j8 unit-test SANITIZE=OFF
 make -j8 run-valgrind-on-unit-tests
 
 # BUild simulator

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ coverage: | build-build
 #./build/bin/test_ui_component_gestures;
 run-valgrind-on-unit-tests:
 	$(MAKE) unit-test
-	bash -c 'find build-build/bin/ -name "test_*" -exec valgrind --leak-check=yes --track-origins=yes {} \;'
+	bash -ec 'for exe in build-build/bin/test_*; do  valgrind --leak-check=yes --track-origins=yes --error-exitcode=1 --exit-on-first-error=yes $$exe; done'
 flash-dev-firmware:
 	./py/load_firmware.py build/bin/firmware.bin --debug
 jlink-flash-bootloader-development: | build

--- a/test/unit-test/test_memory_functional.c
+++ b/test/unit-test/test_memory_functional.c
@@ -107,9 +107,9 @@ static void _test_memory_attestation(void** state)
     uint8_t expected_pubkey[64];
     memset(expected_pubkey, 0x55, sizeof(expected_pubkey));
     uint8_t expected_certificate[64];
-    memset(expected_pubkey, 0x66, sizeof(expected_certificate));
+    memset(expected_certificate, 0x66, sizeof(expected_certificate));
     uint8_t expected_root_pubkey_identifier[32];
-    memset(expected_pubkey, 0x77, sizeof(expected_root_pubkey_identifier));
+    memset(expected_root_pubkey_identifier, 0x77, sizeof(expected_root_pubkey_identifier));
 
     uint8_t pubkey[64];
     uint8_t certificate[64];


### PR DESCRIPTION
* In CI all tests failed to run under valgrind since we compiled with ASAN
* The way the tests were run meant that failing tests didn't fail the overall CI job.