### PR TITLE
Nickez/rust version optional

### DIFF
--- a/src/rust/bitbox02-rust/build.rs
+++ b/src/rust/bitbox02-rust/build.rs
@@ -1,0 +1,26 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Emit a warning if FIRMWARE_VERSION_SHORT isn't set. We don't want this to be a hard error during
+// development so that rust tools are happy.
+fn main() {
+    let version = option_env!("FIRMWARE_VERSION_SHORT");
+    if let Some(version) = version {
+        if version.is_empty() {
+            println!("cargo::warning=FIRMWARE_VERSION_SHORT is empty");
+        }
+    } else {
+        println!("cargo::warning=FIRMWARE_VERSION_SHORT is not set");
+    }
+}

--- a/src/rust/bitbox02-rust/src/version.rs
+++ b/src/rust/bitbox02-rust/src/version.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 /// Firmware version, short format, e.g. "v9.12.0".
-// This is evaluated at compile time, if the env var is missing or not set, there will be a compiler error.
+// We don't want this to be a hard error during development so that rust tools are happy.
 pub static FIRMWARE_VERSION_SHORT: &str = {
-    let version = env!("FIRMWARE_VERSION_SHORT");
-    // Need explicit check as the env var could be set to an empty string accidentally (env!() only
-    // panics if it is not set at all).
-    if version.is_empty() {
-        panic!("FIRMWARE_VERSION_SHORT is not set");
+    let version = option_env!("FIRMWARE_VERSION_SHORT");
+    if let Some(version) = version {
+        version
+    } else {
+        ""
     }
-    version
 };

--- a/src/rust/bitbox02/build.rs
+++ b/src/rust/bitbox02/build.rs
@@ -2,27 +2,28 @@ fn main() {
     #[cfg(feature = "testing")]
     {
         if let Ok(cmake_dir) = std::env::var("CMAKE_CURRENT_BINARY_DIR") {
-            println!("cargo:rustc-link-search={}/../lib", cmake_dir);
+            println!("cargo::rustc-link-search={}/../lib", cmake_dir);
             // c and rust code merged :O
-            println!("cargo:rustc-link-lib=bitbox_merged");
+            println!("cargo::rustc-link-lib=bitbox_merged");
             println!(
-                "cargo:rerun-if-changed={}/../lib/libbitbox_merged.a",
+                "cargo::rerun-if-changed={}/../lib/libbitbox_merged.a",
                 cmake_dir
             );
+            println!("cargo::rerun-if-changed=build.rs");
 
             // external libs
-            println!("cargo:rustc-link-lib=wallycore");
-            println!("cargo:rustc-link-lib=secp256k1");
-            println!("cargo:rustc-link-lib=ctaes");
-            println!("cargo:rustc-link-lib=fatfs");
-            println!("cargo:rustc-link-lib=sd-mock");
+            println!("cargo::rustc-link-lib=wallycore");
+            println!("cargo::rustc-link-lib=secp256k1");
+            println!("cargo::rustc-link-lib=ctaes");
+            println!("cargo::rustc-link-lib=fatfs");
+            println!("cargo::rustc-link-lib=sd-mock");
 
             // system libs
-            println!("cargo:rustc-link-lib=cmocka");
+            println!("cargo::rustc-link-lib=cmocka");
         } else {
             // This is useful in case project is built by tool that doesn't need to link the final
             // target, like rust-analyzer and clippy.
-            eprintln!("Missing env variable CMAKE_CURRENT_BINARY_DIR, linking will fail");
+            println!("cargo::warning=Missing env variable CMAKE_CURRENT_BINARY_DIR, linking will fail");
         }
     }
 }


### PR DESCRIPTION
I broke this out of https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1293 since it has an impact on the final binary.

Unfortunately adding a `build.rs` script, even if it doesn't do anything, ends up changing symbol names. This in turn means that the linker outputs a slightly different binary where functions are placed differently.

I put the build script in its own commit so that you can verify that this is the reason for the binary output difference.

depends on https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1294.

