### PR TITLE
rust: don't make bitcoin crate optional

### DIFF
--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -45,10 +45,6 @@ target-bootloader-btc-production = ["bootloader", "platform-bitbox02"]
 target-firmware = ["firmware", "platform-bitbox02", "app-bitcoin", "app-litecoin", "app-ethereum", "app-u2f", "app-cardano"]
 target-firmware-btc = ["firmware", "platform-bitbox02", "app-bitcoin"]
 target-factory-setup = [
-  # enable these features in dependencies
-  # enable the bitcoin dep as workaround, because the bitbox02-rust::bip32 crate etc. are not
-  # currently needed in the factorysetup, but not explicitly excluded from compilation.
-  "bitbox02-rust/bitcoin",
   # enable these features
   "firmware",
   "platform-bitbox02",

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -49,7 +49,7 @@ ed25519-dalek = { version = "2.1.1", default-features = false, features = ["hazm
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 
 miniscript = { version = "12.2.0", default-features = false, features = ["no-std"], optional = true }
-bitcoin = { workspace = true, optional = true }
+bitcoin = { workspace = true }
 # We don't rely on this dep directly, the miniscript/bitcoin deps do. We list it here to enable the
 # small-hash feature to reduce the binary size, saving around 2784 bytes (as measured at time of
 # writing, this might fluctuate over time).
@@ -81,7 +81,6 @@ app-bitcoin = [
   # enable these dependencies
   "bech32",
   "miniscript",
-  "bitcoin",
   # enable this feature in the deps
   "bitbox02/app-bitcoin",
 ]


### PR DESCRIPTION
It is used in bip32.rs, which is compiled unconditionally, so it is not only used by app-bitcoin.