### PR TITLE
cardano: Allow vote delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Bitcoin: add support for sending to silent payment (BIP-352) addresses
 - Bitcoin: add support for regtest
+- Cardano: add support for vote delegation
 
 ### 9.20.0
 - Bitcoin: UX improvements for payment request confirmations

--- a/messages/cardano.proto
+++ b/messages/cardano.proto
@@ -85,16 +85,30 @@ message CardanoSignTransactionRequest {
     repeated AssetGroup asset_groups = 4;
   }
 
-  // See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L150
+  // See https://github.com/IntersectMBO/cardano-ledger/blob/cardano-ledger-conway-1.12.0.0/eras/conway/impl/cddl-files/conway.cddl#L273
   message Certificate {
     message StakeDelegation {
       repeated uint32 keypath = 1;
       bytes pool_keyhash = 2;
     }
+    message VoteDelegation {
+      enum CardanoDRepType {
+        KEY_HASH = 0;
+        SCRIPT_HASH = 1;
+        ALWAYS_ABSTAIN = 2;
+        ALWAYS_NO_CONFIDENCE = 3;
+      }
+
+      // keypath in this instance refers to stake credential
+      repeated uint32 keypath = 1;
+      CardanoDRepType type = 2;
+      optional bytes drep_credhash = 3;
+    }
     oneof cert {
       Keypath stake_registration = 1;
       Keypath stake_deregistration = 2;
       StakeDelegation stake_delegation = 3;
+      VoteDelegation vote_delegation = 10;
     }
   }
 

--- a/py/bitbox02/bitbox02/communication/generated/cardano_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/cardano_pb2.py
@@ -14,15 +14,15 @@ _sym_db = _symbol_database.Default()
 from . import common_pb2 as common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rcardano.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"F\n\x13\x43\x61rdanoXpubsRequest\x12/\n\x08keypaths\x18\x01 \x03(\x0b\x32\x1d.shiftcrypto.bitbox02.Keypath\"%\n\x14\x43\x61rdanoXpubsResponse\x12\r\n\x05xpubs\x18\x01 \x03(\x0c\"\x9e\x01\n\x13\x43\x61rdanoScriptConfig\x12\x43\n\x07pkh_skh\x18\x01 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.CardanoScriptConfig.PkhSkhH\x00\x1a\x38\n\x06PkhSkh\x12\x17\n\x0fkeypath_payment\x18\x01 \x03(\r\x12\x15\n\rkeypath_stake\x18\x02 \x03(\rB\x08\n\x06\x63onfig\"\xa1\x01\n\x15\x43\x61rdanoAddressRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12\x0f\n\x07\x64isplay\x18\x02 \x01(\x08\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\"\x8e\n\n\x1d\x43\x61rdanoSignTransactionRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12I\n\x06inputs\x18\x02 \x03(\x0b\x32\x39.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Input\x12K\n\x07outputs\x18\x03 \x03(\x0b\x32:.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Output\x12\x0b\n\x03\x66\x65\x65\x18\x04 \x01(\x04\x12\x0b\n\x03ttl\x18\x05 \x01(\x04\x12U\n\x0c\x63\x65rtificates\x18\x06 \x03(\x0b\x32?.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate\x12S\n\x0bwithdrawals\x18\x07 \x03(\x0b\x32>.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Withdrawal\x12\x1f\n\x17validity_interval_start\x18\x08 \x01(\x04\x12\x16\n\x0e\x61llow_zero_ttl\x18\t \x01(\x08\x1aG\n\x05Input\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x15\n\rprev_out_hash\x18\x02 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x03 \x01(\r\x1a\xa1\x01\n\nAssetGroup\x12\x11\n\tpolicy_id\x18\x01 \x01(\x0c\x12T\n\x06tokens\x18\x02 \x03(\x0b\x32\x44.shiftcrypto.bitbox02.CardanoSignTransactionRequest.AssetGroup.Token\x1a*\n\x05Token\x12\x12\n\nasset_name\x18\x01 \x01(\x0c\x12\r\n\x05value\x18\x02 \x01(\x04\x1a\xc8\x01\n\x06Output\x12\x17\n\x0f\x65ncoded_address\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x04\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\x12T\n\x0c\x61sset_groups\x18\x04 \x03(\x0b\x32>.shiftcrypto.bitbox02.CardanoSignTransactionRequest.AssetGroup\x1a\xb8\x02\n\x0b\x43\x65rtificate\x12;\n\x12stake_registration\x18\x01 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12=\n\x14stake_deregistration\x18\x02 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12k\n\x10stake_delegation\x18\x03 \x01(\x0b\x32O.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.StakeDelegationH\x00\x1a\x38\n\x0fStakeDelegation\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x14\n\x0cpool_keyhash\x18\x02 \x01(\x0c\x42\x06\n\x04\x63\x65rt\x1a,\n\nWithdrawal\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\r\n\x05value\x18\x02 \x01(\x04\"\xb9\x01\n\x1e\x43\x61rdanoSignTransactionResponse\x12^\n\x11shelley_witnesses\x18\x01 \x03(\x0b\x32\x43.shiftcrypto.bitbox02.CardanoSignTransactionResponse.ShelleyWitness\x1a\x37\n\x0eShelleyWitness\x12\x12\n\npublic_key\x18\x01 \x01(\x0c\x12\x11\n\tsignature\x18\x02 \x01(\x0c\"\xe8\x01\n\x0e\x43\x61rdanoRequest\x12:\n\x05xpubs\x18\x01 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoXpubsRequestH\x00\x12>\n\x07\x61\x64\x64ress\x18\x02 \x01(\x0b\x32+.shiftcrypto.bitbox02.CardanoAddressRequestH\x00\x12O\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.CardanoSignTransactionRequestH\x00\x42\t\n\x07request\"\xde\x01\n\x0f\x43\x61rdanoResponse\x12;\n\x05xpubs\x18\x01 \x01(\x0b\x32*.shiftcrypto.bitbox02.CardanoXpubsResponseH\x00\x12\x30\n\x03pub\x18\x02 \x01(\x0b\x32!.shiftcrypto.bitbox02.PubResponseH\x00\x12P\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.CardanoSignTransactionResponseH\x00\x42\n\n\x08response*8\n\x0e\x43\x61rdanoNetwork\x12\x12\n\x0e\x43\x61rdanoMainnet\x10\x00\x12\x12\n\x0e\x43\x61rdanoTestnet\x10\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rcardano.proto\x12\x14shiftcrypto.bitbox02\x1a\x0c\x63ommon.proto\"F\n\x13\x43\x61rdanoXpubsRequest\x12/\n\x08keypaths\x18\x01 \x03(\x0b\x32\x1d.shiftcrypto.bitbox02.Keypath\"%\n\x14\x43\x61rdanoXpubsResponse\x12\r\n\x05xpubs\x18\x01 \x03(\x0c\"\x9e\x01\n\x13\x43\x61rdanoScriptConfig\x12\x43\n\x07pkh_skh\x18\x01 \x01(\x0b\x32\x30.shiftcrypto.bitbox02.CardanoScriptConfig.PkhSkhH\x00\x1a\x38\n\x06PkhSkh\x12\x17\n\x0fkeypath_payment\x18\x01 \x03(\r\x12\x15\n\rkeypath_stake\x18\x02 \x03(\rB\x08\n\x06\x63onfig\"\xa1\x01\n\x15\x43\x61rdanoAddressRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12\x0f\n\x07\x64isplay\x18\x02 \x01(\x08\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\"\x99\r\n\x1d\x43\x61rdanoSignTransactionRequest\x12\x35\n\x07network\x18\x01 \x01(\x0e\x32$.shiftcrypto.bitbox02.CardanoNetwork\x12I\n\x06inputs\x18\x02 \x03(\x0b\x32\x39.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Input\x12K\n\x07outputs\x18\x03 \x03(\x0b\x32:.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Output\x12\x0b\n\x03\x66\x65\x65\x18\x04 \x01(\x04\x12\x0b\n\x03ttl\x18\x05 \x01(\x04\x12U\n\x0c\x63\x65rtificates\x18\x06 \x03(\x0b\x32?.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate\x12S\n\x0bwithdrawals\x18\x07 \x03(\x0b\x32>.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Withdrawal\x12\x1f\n\x17validity_interval_start\x18\x08 \x01(\x04\x12\x16\n\x0e\x61llow_zero_ttl\x18\t \x01(\x08\x1aG\n\x05Input\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x15\n\rprev_out_hash\x18\x02 \x01(\x0c\x12\x16\n\x0eprev_out_index\x18\x03 \x01(\r\x1a\xa1\x01\n\nAssetGroup\x12\x11\n\tpolicy_id\x18\x01 \x01(\x0c\x12T\n\x06tokens\x18\x02 \x03(\x0b\x32\x44.shiftcrypto.bitbox02.CardanoSignTransactionRequest.AssetGroup.Token\x1a*\n\x05Token\x12\x12\n\nasset_name\x18\x01 \x01(\x0c\x12\r\n\x05value\x18\x02 \x01(\x04\x1a\xc8\x01\n\x06Output\x12\x17\n\x0f\x65ncoded_address\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x04\x12@\n\rscript_config\x18\x03 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoScriptConfig\x12T\n\x0c\x61sset_groups\x18\x04 \x03(\x0b\x32>.shiftcrypto.bitbox02.CardanoSignTransactionRequest.AssetGroup\x1a\xc3\x05\n\x0b\x43\x65rtificate\x12;\n\x12stake_registration\x18\x01 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12=\n\x14stake_deregistration\x18\x02 \x01(\x0b\x32\x1d.shiftcrypto.bitbox02.KeypathH\x00\x12k\n\x10stake_delegation\x18\x03 \x01(\x0b\x32O.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.StakeDelegationH\x00\x12i\n\x0fvote_delegation\x18\n \x01(\x0b\x32N.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.VoteDelegationH\x00\x1a\x38\n\x0fStakeDelegation\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\x14\n\x0cpool_keyhash\x18\x02 \x01(\x0c\x1a\x9d\x02\n\x0eVoteDelegation\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12l\n\x04type\x18\x02 \x01(\x0e\x32^.shiftcrypto.bitbox02.CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType\x12\x1a\n\rdrep_credhash\x18\x03 \x01(\x0cH\x00\x88\x01\x01\"^\n\x0f\x43\x61rdanoDRepType\x12\x0c\n\x08KEY_HASH\x10\x00\x12\x0f\n\x0bSCRIPT_HASH\x10\x01\x12\x12\n\x0e\x41LWAYS_ABSTAIN\x10\x02\x12\x18\n\x14\x41LWAYS_NO_CONFIDENCE\x10\x03\x42\x10\n\x0e_drep_credhashB\x06\n\x04\x63\x65rt\x1a,\n\nWithdrawal\x12\x0f\n\x07keypath\x18\x01 \x03(\r\x12\r\n\x05value\x18\x02 \x01(\x04\"\xb9\x01\n\x1e\x43\x61rdanoSignTransactionResponse\x12^\n\x11shelley_witnesses\x18\x01 \x03(\x0b\x32\x43.shiftcrypto.bitbox02.CardanoSignTransactionResponse.ShelleyWitness\x1a\x37\n\x0eShelleyWitness\x12\x12\n\npublic_key\x18\x01 \x01(\x0c\x12\x11\n\tsignature\x18\x02 \x01(\x0c\"\xe8\x01\n\x0e\x43\x61rdanoRequest\x12:\n\x05xpubs\x18\x01 \x01(\x0b\x32).shiftcrypto.bitbox02.CardanoXpubsRequestH\x00\x12>\n\x07\x61\x64\x64ress\x18\x02 \x01(\x0b\x32+.shiftcrypto.bitbox02.CardanoAddressRequestH\x00\x12O\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x33.shiftcrypto.bitbox02.CardanoSignTransactionRequestH\x00\x42\t\n\x07request\"\xde\x01\n\x0f\x43\x61rdanoResponse\x12;\n\x05xpubs\x18\x01 \x01(\x0b\x32*.shiftcrypto.bitbox02.CardanoXpubsResponseH\x00\x12\x30\n\x03pub\x18\x02 \x01(\x0b\x32!.shiftcrypto.bitbox02.PubResponseH\x00\x12P\n\x10sign_transaction\x18\x03 \x01(\x0b\x32\x34.shiftcrypto.bitbox02.CardanoSignTransactionResponseH\x00\x42\n\n\x08response*8\n\x0e\x43\x61rdanoNetwork\x12\x12\n\x0e\x43\x61rdanoMainnet\x10\x00\x12\x12\n\x0e\x43\x61rdanoTestnet\x10\x01\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'cardano_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _CARDANONETWORK._serialized_start=2434
-  _CARDANONETWORK._serialized_end=2490
+  _CARDANONETWORK._serialized_start=2829
+  _CARDANONETWORK._serialized_end=2885
   _CARDANOXPUBSREQUEST._serialized_start=53
   _CARDANOXPUBSREQUEST._serialized_end=123
   _CARDANOXPUBSRESPONSE._serialized_start=125
@@ -34,7 +34,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _CARDANOADDRESSREQUEST._serialized_start=326
   _CARDANOADDRESSREQUEST._serialized_end=487
   _CARDANOSIGNTRANSACTIONREQUEST._serialized_start=490
-  _CARDANOSIGNTRANSACTIONREQUEST._serialized_end=1784
+  _CARDANOSIGNTRANSACTIONREQUEST._serialized_end=2179
   _CARDANOSIGNTRANSACTIONREQUEST_INPUT._serialized_start=985
   _CARDANOSIGNTRANSACTIONREQUEST_INPUT._serialized_end=1056
   _CARDANOSIGNTRANSACTIONREQUEST_ASSETGROUP._serialized_start=1059
@@ -44,17 +44,21 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _CARDANOSIGNTRANSACTIONREQUEST_OUTPUT._serialized_start=1223
   _CARDANOSIGNTRANSACTIONREQUEST_OUTPUT._serialized_end=1423
   _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE._serialized_start=1426
-  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE._serialized_end=1738
-  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_STAKEDELEGATION._serialized_start=1674
-  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_STAKEDELEGATION._serialized_end=1730
-  _CARDANOSIGNTRANSACTIONREQUEST_WITHDRAWAL._serialized_start=1740
-  _CARDANOSIGNTRANSACTIONREQUEST_WITHDRAWAL._serialized_end=1784
-  _CARDANOSIGNTRANSACTIONRESPONSE._serialized_start=1787
-  _CARDANOSIGNTRANSACTIONRESPONSE._serialized_end=1972
-  _CARDANOSIGNTRANSACTIONRESPONSE_SHELLEYWITNESS._serialized_start=1917
-  _CARDANOSIGNTRANSACTIONRESPONSE_SHELLEYWITNESS._serialized_end=1972
-  _CARDANOREQUEST._serialized_start=1975
-  _CARDANOREQUEST._serialized_end=2207
-  _CARDANORESPONSE._serialized_start=2210
-  _CARDANORESPONSE._serialized_end=2432
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE._serialized_end=2133
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_STAKEDELEGATION._serialized_start=1781
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_STAKEDELEGATION._serialized_end=1837
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_VOTEDELEGATION._serialized_start=1840
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_VOTEDELEGATION._serialized_end=2125
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_VOTEDELEGATION_CARDANODREPTYPE._serialized_start=2013
+  _CARDANOSIGNTRANSACTIONREQUEST_CERTIFICATE_VOTEDELEGATION_CARDANODREPTYPE._serialized_end=2107
+  _CARDANOSIGNTRANSACTIONREQUEST_WITHDRAWAL._serialized_start=2135
+  _CARDANOSIGNTRANSACTIONREQUEST_WITHDRAWAL._serialized_end=2179
+  _CARDANOSIGNTRANSACTIONRESPONSE._serialized_start=2182
+  _CARDANOSIGNTRANSACTIONRESPONSE._serialized_end=2367
+  _CARDANOSIGNTRANSACTIONRESPONSE_SHELLEYWITNESS._serialized_start=2312
+  _CARDANOSIGNTRANSACTIONRESPONSE_SHELLEYWITNESS._serialized_end=2367
+  _CARDANOREQUEST._serialized_start=2370
+  _CARDANOREQUEST._serialized_end=2602
+  _CARDANORESPONSE._serialized_start=2605
+  _CARDANORESPONSE._serialized_end=2827
 # @@protoc_insertion_point(module_scope)

--- a/py/bitbox02/bitbox02/communication/generated/cardano_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/cardano_pb2.pyi
@@ -182,7 +182,7 @@ class CardanoSignTransactionRequest(google.protobuf.message.Message):
         def ClearField(self, field_name: typing_extensions.Literal["asset_groups",b"asset_groups","encoded_address",b"encoded_address","script_config",b"script_config","value",b"value"]) -> None: ...
 
     class Certificate(google.protobuf.message.Message):
-        """See https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L150"""
+        """See https://github.com/IntersectMBO/cardano-ledger/blob/cardano-ledger-conway-1.12.0.0/eras/conway/impl/cddl-files/conway.cddl#L273"""
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
         class StakeDelegation(google.protobuf.message.Message):
             DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -198,24 +198,66 @@ class CardanoSignTransactionRequest(google.protobuf.message.Message):
                 ) -> None: ...
             def ClearField(self, field_name: typing_extensions.Literal["keypath",b"keypath","pool_keyhash",b"pool_keyhash"]) -> None: ...
 
+        class VoteDelegation(google.protobuf.message.Message):
+            DESCRIPTOR: google.protobuf.descriptor.Descriptor
+            class _CardanoDRepType:
+                ValueType = typing.NewType('ValueType', builtins.int)
+                V: typing_extensions.TypeAlias = ValueType
+            class _CardanoDRepTypeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[CardanoSignTransactionRequest.Certificate.VoteDelegation._CardanoDRepType.ValueType], builtins.type):
+                DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
+                KEY_HASH: CardanoSignTransactionRequest.Certificate.VoteDelegation._CardanoDRepType.ValueType  # 0
+                SCRIPT_HASH: CardanoSignTransactionRequest.Certificate.VoteDelegation._CardanoDRepType.ValueType  # 1
+                ALWAYS_ABSTAIN: CardanoSignTransactionRequest.Certificate.VoteDelegation._CardanoDRepType.ValueType  # 2
+                ALWAYS_NO_CONFIDENCE: CardanoSignTransactionRequest.Certificate.VoteDelegation._CardanoDRepType.ValueType  # 3
+            class CardanoDRepType(_CardanoDRepType, metaclass=_CardanoDRepTypeEnumTypeWrapper):
+                pass
+
+            KEY_HASH: CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ValueType  # 0
+            SCRIPT_HASH: CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ValueType  # 1
+            ALWAYS_ABSTAIN: CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ValueType  # 2
+            ALWAYS_NO_CONFIDENCE: CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ValueType  # 3
+
+            KEYPATH_FIELD_NUMBER: builtins.int
+            TYPE_FIELD_NUMBER: builtins.int
+            DREP_CREDHASH_FIELD_NUMBER: builtins.int
+            @property
+            def keypath(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]:
+                """keypath in this instance refers to stake credential"""
+                pass
+            type: global___CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ValueType
+            drep_credhash: builtins.bytes
+            def __init__(self,
+                *,
+                keypath: typing.Optional[typing.Iterable[builtins.int]] = ...,
+                type: global___CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ValueType = ...,
+                drep_credhash: typing.Optional[builtins.bytes] = ...,
+                ) -> None: ...
+            def HasField(self, field_name: typing_extensions.Literal["_drep_credhash",b"_drep_credhash","drep_credhash",b"drep_credhash"]) -> builtins.bool: ...
+            def ClearField(self, field_name: typing_extensions.Literal["_drep_credhash",b"_drep_credhash","drep_credhash",b"drep_credhash","keypath",b"keypath","type",b"type"]) -> None: ...
+            def WhichOneof(self, oneof_group: typing_extensions.Literal["_drep_credhash",b"_drep_credhash"]) -> typing.Optional[typing_extensions.Literal["drep_credhash"]]: ...
+
         STAKE_REGISTRATION_FIELD_NUMBER: builtins.int
         STAKE_DEREGISTRATION_FIELD_NUMBER: builtins.int
         STAKE_DELEGATION_FIELD_NUMBER: builtins.int
+        VOTE_DELEGATION_FIELD_NUMBER: builtins.int
         @property
         def stake_registration(self) -> common_pb2.Keypath: ...
         @property
         def stake_deregistration(self) -> common_pb2.Keypath: ...
         @property
         def stake_delegation(self) -> global___CardanoSignTransactionRequest.Certificate.StakeDelegation: ...
+        @property
+        def vote_delegation(self) -> global___CardanoSignTransactionRequest.Certificate.VoteDelegation: ...
         def __init__(self,
             *,
             stake_registration: typing.Optional[common_pb2.Keypath] = ...,
             stake_deregistration: typing.Optional[common_pb2.Keypath] = ...,
             stake_delegation: typing.Optional[global___CardanoSignTransactionRequest.Certificate.StakeDelegation] = ...,
+            vote_delegation: typing.Optional[global___CardanoSignTransactionRequest.Certificate.VoteDelegation] = ...,
             ) -> None: ...
-        def HasField(self, field_name: typing_extensions.Literal["cert",b"cert","stake_delegation",b"stake_delegation","stake_deregistration",b"stake_deregistration","stake_registration",b"stake_registration"]) -> builtins.bool: ...
-        def ClearField(self, field_name: typing_extensions.Literal["cert",b"cert","stake_delegation",b"stake_delegation","stake_deregistration",b"stake_deregistration","stake_registration",b"stake_registration"]) -> None: ...
-        def WhichOneof(self, oneof_group: typing_extensions.Literal["cert",b"cert"]) -> typing.Optional[typing_extensions.Literal["stake_registration","stake_deregistration","stake_delegation"]]: ...
+        def HasField(self, field_name: typing_extensions.Literal["cert",b"cert","stake_delegation",b"stake_delegation","stake_deregistration",b"stake_deregistration","stake_registration",b"stake_registration","vote_delegation",b"vote_delegation"]) -> builtins.bool: ...
+        def ClearField(self, field_name: typing_extensions.Literal["cert",b"cert","stake_delegation",b"stake_delegation","stake_deregistration",b"stake_deregistration","stake_registration",b"stake_registration","vote_delegation",b"vote_delegation"]) -> None: ...
+        def WhichOneof(self, oneof_group: typing_extensions.Literal["cert",b"cert"]) -> typing.Optional[typing_extensions.Literal["stake_registration","stake_deregistration","stake_delegation","vote_delegation"]]: ...
 
     class Withdrawal(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -1289,6 +1289,41 @@ class SendMessage:
             )
             print(response)
 
+        def delegate_vote() -> None:
+            response = self._device.cardano_sign_transaction(
+                transaction=bitbox02.cardano.CardanoSignTransactionRequest(
+                    network=bitbox02.cardano.CardanoMainnet,
+                    inputs=[
+                        bitbox02.cardano.CardanoSignTransactionRequest.Input(
+                            keypath=[2147485500, 2147485463, 2147483648, 0, 0],
+                            prev_out_hash=bytes.fromhex(
+                                "b7b2333e72f2670ab82051f426cc84000431975a34e71d5edf70ea6c0ddc9bf8"
+                            ),
+                            prev_out_index=0,
+                        ),
+                    ],
+                    outputs=[
+                        bitbox02.cardano.CardanoSignTransactionRequest.Output(
+                            encoded_address=get_address(False),
+                            value=2741512,
+                            script_config=script_config,
+                        )
+                    ],
+                    fee=191681,
+                    ttl=41539125,
+                    certificates=[
+                        bitbox02.cardano.CardanoSignTransactionRequest.Certificate(
+                            vote_delegation=bitbox02.cardano.CardanoSignTransactionRequest.Certificate.VoteDelegation(
+                                # keypath used here is the stake credential
+                                keypath=[2147485500, 2147485463, 2147483648, 2, 0],
+                                type=bitbox02.cardano.CardanoSignTransactionRequest.Certificate.VoteDelegation.CardanoDRepType.ALWAYS_ABSTAIN,
+                            )
+                        ),
+                    ],
+                )
+            )
+            print(response)
+
         def withdraw() -> None:
             response = self._device.cardano_sign_transaction(
                 transaction=bitbox02.cardano.CardanoSignTransactionRequest(
@@ -1328,6 +1363,7 @@ class SendMessage:
             ("Sign a transaction with TTL=0", sign_zero_ttl),
             ("Sign a transaction sending tokens", sign_tokens),
             ("Delegate staking to a pool", delegate),
+            ("Delegate vote to a dRep", delegate_vote),
             ("Withdraw staking rewards", withdraw),
         )
         choice = ask_user(choices)

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -1066,11 +1066,11 @@ pub mod cardano_sign_transaction_request {
         #[prost(message, repeated, tag = "4")]
         pub asset_groups: ::prost::alloc::vec::Vec<AssetGroup>,
     }
-    /// See <https://github.com/input-output-hk/cardano-ledger-specs/blob/d0aa86ded0b973b09b629e5aa62aa1e71364d088/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L150>
+    /// See <https://github.com/IntersectMBO/cardano-ledger/blob/cardano-ledger-conway-1.12.0.0/eras/conway/impl/cddl-files/conway.cddl#L273>
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Certificate {
-        #[prost(oneof = "certificate::Cert", tags = "1, 2, 3")]
+        #[prost(oneof = "certificate::Cert", tags = "1, 2, 3, 10")]
         pub cert: ::core::option::Option<certificate::Cert>,
     }
     /// Nested message and enum types in `Certificate`.
@@ -1084,6 +1084,62 @@ pub mod cardano_sign_transaction_request {
             pub pool_keyhash: ::prost::alloc::vec::Vec<u8>,
         }
         #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct VoteDelegation {
+            /// keypath in this instance refers to stake credential
+            #[prost(uint32, repeated, tag = "1")]
+            pub keypath: ::prost::alloc::vec::Vec<u32>,
+            #[prost(enumeration = "vote_delegation::CardanoDRepType", tag = "2")]
+            pub r#type: i32,
+            #[prost(bytes = "vec", optional, tag = "3")]
+            pub drep_credhash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+        }
+        /// Nested message and enum types in `VoteDelegation`.
+        pub mod vote_delegation {
+            #[derive(
+                Clone,
+                Copy,
+                Debug,
+                PartialEq,
+                Eq,
+                Hash,
+                PartialOrd,
+                Ord,
+                ::prost::Enumeration
+            )]
+            #[repr(i32)]
+            pub enum CardanoDRepType {
+                KeyHash = 0,
+                ScriptHash = 1,
+                AlwaysAbstain = 2,
+                AlwaysNoConfidence = 3,
+            }
+            impl CardanoDRepType {
+                /// String value of the enum field names used in the ProtoBuf definition.
+                ///
+                /// The values are not transformed in any way and thus are considered stable
+                /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+                pub fn as_str_name(&self) -> &'static str {
+                    match self {
+                        CardanoDRepType::KeyHash => "KEY_HASH",
+                        CardanoDRepType::ScriptHash => "SCRIPT_HASH",
+                        CardanoDRepType::AlwaysAbstain => "ALWAYS_ABSTAIN",
+                        CardanoDRepType::AlwaysNoConfidence => "ALWAYS_NO_CONFIDENCE",
+                    }
+                }
+                /// Creates an enum from field names used in the ProtoBuf definition.
+                pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                    match value {
+                        "KEY_HASH" => Some(Self::KeyHash),
+                        "SCRIPT_HASH" => Some(Self::ScriptHash),
+                        "ALWAYS_ABSTAIN" => Some(Self::AlwaysAbstain),
+                        "ALWAYS_NO_CONFIDENCE" => Some(Self::AlwaysNoConfidence),
+                        _ => None,
+                    }
+                }
+            }
+        }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Cert {
             #[prost(message, tag = "1")]
@@ -1092,6 +1148,8 @@ pub mod cardano_sign_transaction_request {
             StakeDeregistration(super::super::Keypath),
             #[prost(message, tag = "3")]
             StakeDelegation(StakeDelegation),
+            #[prost(message, tag = "10")]
+            VoteDelegation(VoteDelegation),
         }
     }
     #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
Allow cardano based on [conway.cddl](https://github.com/IntersectMBO/cardano-ledger/blob/cardano-ledger-conway-1.12.0.0/eras/conway/impl/cddl-files/conway.cddl#L273) to sign messages containing Vote Delegation certificate. This is needed for withdrawing rewards.

I will add tests for firmware soon, just wanted to begin the review process as soon as possible. It has been tested through simulator and works as expected.
