### PR TITLE
keystore: remove bip86 tweak flag from C, do it in Rust

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -1003,18 +1003,8 @@ bool keystore_secp256k1_schnorr_bip86_sign(
 bool keystore_secp256k1_get_private_key(
     const uint32_t* keypath,
     const size_t keypath_len,
-    bool tweak_bip86,
     uint8_t* key_out)
 {
-    if (tweak_bip86) {
-        secp256k1_keypair __attribute__((__cleanup__(_cleanup_keypair))) keypair = {0};
-        secp256k1_xonly_pubkey pubkey = {0};
-        if (!_schnorr_bip86_keypair(keypath, keypath_len, &keypair, &pubkey)) {
-            return false;
-        }
-        const secp256k1_context* ctx = wally_get_secp_context();
-        return secp256k1_keypair_sec(ctx, key_out, &keypair) == 1;
-    }
     struct ext_key xprv __attribute__((__cleanup__(keystore_zero_xkey))) = {0};
     if (!_get_xprv_twice(keypath, keypath_len, &xprv)) {
         return false;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -308,13 +308,11 @@ USE_RESULT bool keystore_secp256k1_schnorr_bip86_sign(
  *
  * @param[in] keypath derivation keypath
  * @param[in] keypath_len number of elements in keypath
- * @param[in] tweak_bip86 if true, the resulting private key is tweaked with the BIP-86 tweak.
  * @param[out] key_out resulting private key, must be 32 bytes.
  */
 USE_RESULT bool keystore_secp256k1_get_private_key(
     const uint32_t* keypath,
     size_t keypath_len,
-    bool tweak_bip86,
     uint8_t* key_out);
 
 #ifdef TESTING

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -224,16 +224,12 @@ pub fn encode_xpub_at_keypath(keypath: &[u32]) -> Result<Vec<u8>, ()> {
     }
 }
 
-pub fn secp256k1_get_private_key(
-    keypath: &[u32],
-    tweak_bip86: bool,
-) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+pub fn secp256k1_get_private_key(keypath: &[u32]) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
     let mut key = zeroize::Zeroizing::new(vec![0u8; 32]);
     match unsafe {
         bitbox02_sys::keystore_secp256k1_get_private_key(
             keypath.as_ptr(),
             keypath.len() as _,
-            tweak_bip86,
             key.as_mut_ptr(),
         )
     } {
@@ -558,7 +554,7 @@ mod tests {
     fn test_secp256k1_get_private_key() {
         lock();
         let keypath = &[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0];
-        assert!(secp256k1_get_private_key(keypath, false).is_err());
+        assert!(secp256k1_get_private_key(keypath).is_err());
 
         mock_unlocked_using_mnemonic(
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
@@ -566,19 +562,8 @@ mod tests {
         );
 
         assert_eq!(
-            hex::encode(secp256k1_get_private_key(keypath, false).unwrap()),
+            hex::encode(secp256k1_get_private_key(keypath).unwrap()),
             "4604b4b710fe91f584fff084e1a9159fe4f8408fff380596a604948474ce4fa3"
-        );
-
-        // See first test vector in
-        // https://github.com/bitcoin/bips/blob/edffe529056f6dfd33d8f716fb871467c3c09263/bip-0086.mediawiki#test-vectors
-        // The below privte key's public key is: a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c.
-        assert_eq!(
-            hex::encode(
-                secp256k1_get_private_key(&[86 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0], true)
-                    .unwrap()
-            ),
-            "eaac016f36e8c18347fbacf05ab7966708fbfce7ce3bf1dc32a09dd0645db038",
         );
     }
 }

--- a/src/rust/streaming-silent-payments/src/lib.rs
+++ b/src/rust/streaming-silent-payments/src/lib.rs
@@ -169,6 +169,10 @@ impl SilentPayment {
         }
     }
 
+    pub fn get_secp(&self) -> &Secp256k1<secp256k1::All> {
+        &self.secp
+    }
+
     /// This must be called for *every* input of the transaction.
     ///
     /// Important: if the input type cannot be represented by `InputType`, the transaction must be


### PR DESCRIPTION
A conflicting PR (minitapscript) also does most Taproot tweaking in Rust, deleting the _schnorr_bip86_keypair util function. We can do this here too to avoid relying on that util function in `keystore_secp256k1_get_private_key()`, doing in in Rust instead.