### PR TITLE
sdcard: solve backup bug when sd is re-inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Update manufacturer HID descriptor to bitbox.swiss
 - Ethereum: remove deprecated Goerli network
+- SD card: solve backup bug when sd card is re-inserted
 
 ### 9.21.0
 - Bitcoin: add support for sending to silent payment (BIP-352) addresses


### PR DESCRIPTION
This issue was existent for a long time. While using the BitBox02, when the sdcard is plugged into the device and the user unplugs and replugs it, backup operations (e.g., list backups, restore from backup) failed and throwed error from the firmware side.

Sdcard backup operations first check if the sdcard is inserted before calling sdcard interface funtions. This commit fixes the re-insertion problem by reinitializing the sdcard whenever it is checked if it is inserted.

The problem earlier most probably stems from sdcard being in an unexpected state when it is re-inserted. The forced initialization step fixes the broken states.