### PR TITLE
securechip: make securechip_slot_t an internal type

### DIFF
--- a/src/securechip/securechip.h
+++ b/src/securechip/securechip.h
@@ -49,18 +49,6 @@ typedef struct {
     void (*const random_32_bytes)(uint8_t* buf);
 } securechip_interface_functions_t;
 
-typedef enum {
-    SECURECHIP_SLOT_IO_PROTECTION_KEY = 0,
-    SECURECHIP_SLOT_AUTHKEY = 1,
-    SECURECHIP_SLOT_ENCRYPTION_KEY = 2,
-    SECURECHIP_SLOT_ROLLKEY = 3,
-    SECURECHIP_SLOT_KDF = 4,
-    SECURECHIP_SLOT_ATTESTATION = 5,
-    SECURECHIP_SLOT_ECC_UNSAFE_SIGN = 6,
-    SECURECHIP_SLOT_DATA0 = 9,
-    // The other slots are currently not in use.
-} securechip_slot_t;
-
 /**
  * Initializes the cryptoauthlib communication, by providing a custom i2c chip
  * communication interface/bridge to cryptoauthlib. On first call, the chip
@@ -80,22 +68,26 @@ USE_RESULT int securechip_setup(const securechip_interface_functions_t* ifs);
 USE_RESULT bool securechip_update_keys(void);
 
 /**
- * Perform KDF using the key in predefined slot with the input msg.
- * Calling this function for SECURECHIP_SLOT_ROLLKEY also increments the
- * monotonic counter Counter0.
- * @param[in] slot should be one of SECURECHIP_SLOT_ROLLKEY and
- *            SECURECHIP_SLOT_KDF.
+ * Perform HMAC using the key in KDF slot with the input msg.
  * @param[in] msg Use this msg as input
  * @param[in] len Must be <= 127.
  * @param[out] kdf_out Must have size 32. Result of the kdf will be stored here.
  * Cannot be the same as `msg`.
  * @return values of `securechip_error_t` if negative, values of `ATCA_STATUS` if positive, 0 on
  */
-USE_RESULT int securechip_kdf(
-    securechip_slot_t slot,
-    const uint8_t* msg,
-    size_t len,
-    uint8_t* kdf_out);
+USE_RESULT int securechip_kdf(const uint8_t* msg, size_t len, uint8_t* kdf_out);
+
+/**
+ * Perform KDF using the key in rollkey slot with the input msg.
+ * Calling this function increments the
+ * monotonic counter Counter0.
+ * @param[in] msg Use this msg as input
+ * @param[in] len Must be <= 127.
+ * @param[out] kdf_out Must have size 32. Result of the kdf will be stored here.
+ * Cannot be the same as `msg`.
+ * @return values of `securechip_error_t` if negative, values of `ATCA_STATUS` if positive, 0 on
+ */
+USE_RESULT int securechip_kdf_rollkey(const uint8_t* msg, size_t len, uint8_t* kdf_out);
 
 /**
  * Generates a new attestation device key and outputs the public key.

--- a/test/simulator/framework/mock_securechip.c
+++ b/test/simulator/framework/mock_securechip.c
@@ -22,6 +22,11 @@
 #include <string.h>
 #include <wally_crypto.h>
 
+typedef enum {
+    SECURECHIP_SLOT_ROLLKEY = 3,
+    SECURECHIP_SLOT_KDF = 4,
+} securechip_slot_t;
+
 static uint32_t _u2f_counter;
 
 bool securechip_update_keys(void)
@@ -39,7 +44,7 @@ static const uint8_t _kdfkey[32] =
     "\xd2\xe1\xe6\xb1\x8b\x6c\x6b\x08\x43\x3e\xdb\xc1\xd1\x68\xc1\xa0\x04\x37\x74\xa4\x22\x18\x77"
     "\xe7\x9e\xd5\x66\x84\xbe\x5a\xc0\x1b";
 
-int securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
+static int _securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
 {
     const uint8_t* key;
     switch (slot) {
@@ -54,6 +59,14 @@ int securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8
     }
     wally_hmac_sha256(key, 32, msg, len, kdf_out, 32);
     return 0;
+}
+int securechip_kdf(const uint8_t* msg, size_t len, uint8_t* kdf_out)
+{
+    return _securechip_kdf(SECURECHIP_SLOT_KDF, msg, len, kdf_out);
+}
+int securechip_kdf_rollkey(const uint8_t* msg, size_t len, uint8_t* kdf_out)
+{
+    return _securechip_kdf(SECURECHIP_SLOT_ROLLKEY, msg, len, kdf_out);
 }
 
 bool securechip_u2f_counter_set(uint32_t counter)

--- a/test/unit-test/framework/mock_securechip.c
+++ b/test/unit-test/framework/mock_securechip.c
@@ -23,6 +23,11 @@
 #include <string.h>
 #include <wally_crypto.h>
 
+typedef enum {
+    SECURECHIP_SLOT_ROLLKEY = 3,
+    SECURECHIP_SLOT_KDF = 4,
+} securechip_slot_t;
+
 static uint32_t _u2f_counter;
 
 bool securechip_update_keys(void)
@@ -40,7 +45,7 @@ static const uint8_t _kdfkey[32] =
     "\xd2\xe1\xe6\xb1\x8b\x6c\x6b\x08\x43\x3e\xdb\xc1\xd1\x68\xc1\xa0\x04\x37\x74\xa4\x22\x18\x77"
     "\xe7\x9e\xd5\x66\x84\xbe\x5a\xc0\x1b";
 
-int securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
+static int _securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8_t* kdf_out)
 {
     const uint8_t* key;
     switch (slot) {
@@ -55,6 +60,14 @@ int securechip_kdf(securechip_slot_t slot, const uint8_t* msg, size_t len, uint8
     }
     wally_hmac_sha256(key, 32, msg, len, kdf_out, 32);
     return 0;
+}
+int securechip_kdf(const uint8_t* msg, size_t len, uint8_t* kdf_out)
+{
+    return _securechip_kdf(SECURECHIP_SLOT_KDF, msg, len, kdf_out);
+}
+int securechip_kdf_rollkey(const uint8_t* msg, size_t len, uint8_t* kdf_out)
+{
+    return _securechip_kdf(SECURECHIP_SLOT_ROLLKEY, msg, len, kdf_out);
 }
 
 bool securechip_u2f_counter_set(uint32_t counter)


### PR DESCRIPTION
A step towards making the securechip interface generic so other chips can be used instead of ATECC608.