### PR TITLE
external: add the optiga-trust-m dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "tools/ttf2ugui"]
 	path = tools/ttf2ugui
 	url = https://github.com/BitBoxSwiss/ttf2ugui
+[submodule "external/optiga-trust-m"]
+	path = external/optiga-trust-m
+	url = https://github.com/BitBoxSwiss/optiga-trust-m.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -258,3 +258,39 @@ target_compile_options(rtt PRIVATE "-Wno-cast-qual")
 # we define it anyway here in case the default changes.
 target_compile_definitions(rtt PUBLIC "BUFFER_SIZE_DOWN=(1024)" "BUFFER_SIZE_UP=(1024)")
 target_include_directories(rtt SYSTEM PUBLIC SEGGER_RTT_V796b/RTT SEGGER_RTT_V796b/Config)
+
+
+# optiga-trust-m
+# The below build instructions are loosely based on optiga-trust-m/tests/linux_i2c.cmake
+aux_source_directory(optiga-trust-m/src/cmd SRC_CMD_FILES)
+aux_source_directory(optiga-trust-m/src/common SRC_COMMON_FILES)
+aux_source_directory(optiga-trust-m/external/mbedtls/library MBEDTLS_FILES)
+aux_source_directory(optiga-trust-m/src/comms/ifx_i2c SRC_COMMS_IFX_I2C_FILES)
+aux_source_directory(optiga-trust-m/src/crypt SRC_CRYPT_FILES)
+aux_source_directory(optiga-trust-m/src/util SRC_UTIL_FILES)
+set(PAL_FILES optiga-trust-m/extras/pal/pal_crypt_mbedtls.c)
+add_library(optiga
+  ${SRC_CMD_FILES}
+  ${SRC_COMMON_FILES}
+  ${SRC_COMMS_IFX_I2C_FILES}
+  optiga-trust-m/src/comms/optiga_comms_ifx_i2c.c
+  ${SRC_CRYPT_FILES}
+  ${SRC_UTIL_FILES}
+  ${PAL_FILES}
+  ${MBEDTLS_FILES}
+)
+target_compile_definitions(optiga PRIVATE MBEDTLS_USER_CONFIG_FILE="mbedtls_config.h")
+# Ignore warnings in external lib.
+target_compile_options(optiga PRIVATE "-w")
+target_compile_definitions(optiga PRIVATE OPTIGA_LIB_EXTERNAL="optiga_config.h")
+target_include_directories(optiga SYSTEM PUBLIC
+  optiga-trust-m/config
+  optiga-trust-m/include
+  optiga-trust-m/include/cmd
+  optiga-trust-m/include/common
+  optiga-trust-m/include/ifx_i2c
+  optiga-trust-m/include/pal
+  optiga-trust-m/include/comms
+  optiga-trust-m/external/mbedtls/include
+  ${CMAKE_CURRENT_SOURCE_DIR} # for the BitBox-custom "optiga_config.h"
+)

--- a/external/mbedtls_config.h
+++ b/external/mbedtls_config.h
@@ -1,0 +1,92 @@
+/**
+ * \file config-ccm-psk-tls1_2.h
+ *
+ * \brief Minimal configuration for TLS 1.2 with PSK and AES-CCM ciphersuites
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+/*
+ * Minimal configuration for TLS 1.2 with PSK and AES-CCM ciphersuites
+ *
+ * Distinguishing features:
+ * - Optimized for small code size, low bandwidth (on a reliable transport),
+ *   and low RAM usage.
+ * - No asymmetric cryptography (no certificates, no Diffie-Hellman key
+ *   exchange).
+ * - Fully modern and secure (provided the pre-shared keys are generated and
+ *   stored securely).
+ * - Very low record overhead with CCM-8.
+ *
+ * See README.txt for usage instructions.
+ */
+
+/* System support */
+//#define MBEDTLS_HAVE_TIME /* Optionally used in Hello messages */
+/* Other MBEDTLS_HAVE_XXX flags irrelevant for this configuration */
+
+// This undefines everything as a basis. Specific settings are re-enabled below.
+#include <mbedtls_default_config.h>
+
+/* Mbed TLS modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_CCM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_MD_C
+
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_TLS_C
+
+/* TLS protocol feature support */
+#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/*
+ * Use only CCM_8 ciphersuites, and
+ * save ROM and a few bytes of RAM by specifying our own ciphersuite list
+ */
+#define MBEDTLS_SSL_CIPHERSUITES                        \
+    MBEDTLS_TLS_PSK_WITH_AES_256_CCM_8,             \
+    MBEDTLS_TLS_PSK_WITH_AES_128_CCM_8
+
+/*
+ * Save RAM at the expense of interoperability: do this only if you control
+ * both ends of the connection!  (See comments in "mbedtls/ssl.h".)
+ * The optimal size here depends on the typical size of records.
+ */
+#define MBEDTLS_SSL_IN_CONTENT_LEN              1024
+#define MBEDTLS_SSL_OUT_CONTENT_LEN             1024
+
+/* Save RAM at the expense of ROM */
+#define MBEDTLS_AES_ROM_TABLES
+
+/* Save some RAM by adjusting to your exact needs */
+#define MBEDTLS_PSK_MAX_LEN    16 /* 128-bits keys are generally enough */
+
+/*
+ * You should adjust this to the exact number of sources you're using: default
+ * is the "platform_entropy_poll" source, but you may want to add other ones
+ * Minimum is 2 for the entropy test suite.
+ */
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_ENTROPY_MAX_SOURCES 2
+
+/* These defines are present so that the config modifying scripts can enable
+ * them during tests/scripts/test-ref-configs.pl */
+//#define MBEDTLS_USE_PSA_CRYPTO
+//#define MBEDTLS_PSA_CRYPTO_C
+
+/* Error messages and TLS debugging traces
+ * (huge code size increase, needed for tests/ssl-opt.sh) */
+//#define MBEDTLS_DEBUG_C
+//#define MBEDTLS_ERROR_C
+
+// Change to a buffer allocator
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_MEMORY_BUFFER_ALLOC_C

--- a/external/optiga_config.h
+++ b/external/optiga_config.h
@@ -1,0 +1,117 @@
+#ifndef _OPTIGA_LIB_CONFIG_BITBOX02_H_
+#define _OPTIGA_LIB_CONFIG_BITBOX02_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /** @brief OPTIGA CRYPT random number generation feature enable/disable macro */
+    #define OPTIGA_CRYPT_RANDOM_ENABLED
+    /** @brief OPTIGA CRYPT hash feature enable/disable macro */
+    #define OPTIGA_CRYPT_HASH_ENABLED
+    /** @brief OPTIGA CRYPT ECC generate keypair feature enable/disable macro */
+    #define OPTIGA_CRYPT_ECC_GENERATE_KEYPAIR_ENABLED
+    /** @brief OPTIGA CRYPT ECDSA signature feature enable/disable macro */
+    #define OPTIGA_CRYPT_ECDSA_SIGN_ENABLED
+    /** @brief OPTIGA CRYPT verify ECDSA signature feature enable/disable macro */
+    #define OPTIGA_CRYPT_ECDSA_VERIFY_ENABLED
+    /** @brief OPTIGA CRYPT ECDH feature enable/disable macro */
+    #define OPTIGA_CRYPT_ECDH_ENABLED
+    /** @brief OPTIGA CRYPT ECC 521 feature enable/disable macro */
+    #define OPTIGA_CRYPT_ECC_NIST_P_521_ENABLED
+    /** @brief OPTIGA CRYPT ECC Brainpool feature enable/disable macro */
+    #define OPTIGA_CRYPT_ECC_BRAINPOOL_P_R1_ENABLED
+    /** @brief OPTIGA CRYPT TLS PRF sha256 feature enable/disable macro */
+    #define OPTIGA_CRYPT_TLS_PRF_SHA256_ENABLED
+    /** @brief OPTIGA CRYPT TLS PRF sha384 feature enable/disable macro */
+    #define OPTIGA_CRYPT_TLS_PRF_SHA384_ENABLED
+    /** @brief OPTIGA CRYPT TLS PRF sha512 feature enable/disable macro */
+    #define OPTIGA_CRYPT_TLS_PRF_SHA512_ENABLED
+    /** @brief OPTIGA CRYPT RSA generate keypair feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_GENERATE_KEYPAIR_ENABLED
+    /** @brief OPTIGA CRYPT RSA sign feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_SIGN_ENABLED
+    /** @brief OPTIGA CRYPT RSA verify sign feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_VERIFY_ENABLED
+    /** @brief OPTIGA CRYPT RSA Encrypt feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_ENCRYPT_ENABLED
+    /** @brief OPTIGA CRYPT RSA Decrypt feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_DECRYPT_ENABLED
+    /** @brief OPTIGA CRYPT RSA pre-master feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_PRE_MASTER_SECRET_ENABLED
+    /** @brief OPTIGA CRYPT RSA SSA with SHA512 as digest feature enable/disable macro */
+    #define OPTIGA_CRYPT_RSA_SSA_SHA512_ENABLED
+    /** @brief OPTIGA CRYPT symmetric encrypt feature enable/disable macro */
+    #define OPTIGA_CRYPT_SYM_ENCRYPT_ENABLED
+    /** @brief OPTIGA CRYPT symmetric decrypt feature enable/disable macro */
+    #define OPTIGA_CRYPT_SYM_DECRYPT_ENABLED
+    /** @brief OPTIGA CRYPT HMAC feature enable/disable macro */
+    #define OPTIGA_CRYPT_HMAC_ENABLED
+    /** @brief OPTIGA CRYPT HKDF feature enable/disable macro */
+    #define OPTIGA_CRYPT_HKDF_ENABLED
+    /** @brief OPTIGA CRYPT symmetric generate key feature enable/disable macro */
+    #define OPTIGA_CRYPT_SYM_GENERATE_KEY_ENABLED
+    /** @brief OPTIGA CRYPT generate auth code feature enable/disable macro */
+    #define OPTIGA_CRYPT_GENERATE_AUTH_CODE_ENABLED
+    /** @brief OPTIGA CRYPT HMAC verify feature enable/disable macro */
+    #define OPTIGA_CRYPT_HMAC_VERIFY_ENABLED
+    /** @brief OPTIGA CRYPT clear AUTO state feature enable/disable macro */
+    #define OPTIGA_CRYPT_CLEAR_AUTO_STATE_ENABLED
+
+    /** @brief OPTIGA COMMS shielded connection feature.
+     *         To disable the feature, undefine the macro
+     */
+    #define OPTIGA_COMMS_SHIELDED_CONNECTION
+
+    /** @brief Default reset protection level for OPTIGA CRYPT and UTIL APIs */
+    #define OPTIGA_COMMS_DEFAULT_PROTECTION_LEVEL           OPTIGA_COMMS_FULL_PROTECTION
+    //#define OPTIGA_COMMS_DEFAULT_PROTECTION_LEVEL           OPTIGA_COMMS_NO_PROTECTION
+
+  /** @brief Default reset type in optiga_comms_open.             \n
+     *         Cold Reset - (0) : This is applicable if the host platform has GPIO option for RST and VDD.    \n
+     *         Soft Reset - (1) : This is applicable if the host platform doesn't have GPIO options for VDD and RST.  \n
+     *         Warm Reset - (2) : This is applicable if the host platform doesn't have GPIO option for VDD. \n
+     *         Any other value will lead to error
+     */
+    #define OPTIGA_COMMS_DEFAULT_RESET_TYPE     (1U)
+
+    /** @brief NULL parameter check.
+     *         To disable the check, undefine the macro
+     */
+    #define OPTIGA_LIB_DEBUG_NULL_CHECK
+    /** @brief Maximum number of instance registration */
+    #define OPTIGA_CMD_MAX_REGISTRATIONS                (0x02)
+    /** @brief Maximum buffer size required to communicate with OPTIGA */
+    #define OPTIGA_MAX_COMMS_BUFFER_SIZE                (0x615) //1557 in decimal
+
+    /** @brief Macro to enable logger \n
+    * Enable macro OPTIGA_LIB_ENABLE_UTIL_LOGGING for Util Service layer logging     \n
+    * Enable macro OPTIGA_LIB_ENABLE_CRYPT_LOGGING for Crypt Service layer logging     \n
+    * Enable macro OPTIGA_LIB_ENABLE_CMD_LOGGING for Command layer logging     \n
+    * Enable macro OPTIGA_LIB_ENABLE_COMMS_LOGGING for Communication layer logging     */
+    // #define OPTIGA_LIB_ENABLE_LOGGING
+    /** @brief Enable macro OPTIGA_PAL_INIT_ENABLED for calling pal_init functionality */
+    //#define OPTIGA_PAL_INIT_ENABLED
+/// @cond
+#ifdef OPTIGA_LIB_ENABLE_LOGGING
+    /** @brief Macro to enable logger for Util service */
+    #define OPTIGA_LIB_ENABLE_UTIL_LOGGING
+    /** @brief Macro to enable logger for Crypt service */
+    #define OPTIGA_LIB_ENABLE_CRYPT_LOGGING
+    /** @brief Macro to enable logger for Command layer */
+    #define OPTIGA_LIB_ENABLE_CMD_LOGGING
+    /** @brief Macro to enable logger for Communication layer */
+    #define OPTIGA_LIB_ENABLE_COMMS_LOGGING
+#endif
+/// @endcond
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _OPTIGA_LIB_CONFIG_BITBOX02_*/
+
+/**
+* @}
+*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -451,6 +451,7 @@ if(CMAKE_CROSSCOMPILING)
     # Must manually link against C so that malloc can find _sbrk
     target_link_libraries(${elf}
       PRIVATE
+        optiga
         cryptoauthlib
         fatfs
         ctaes
@@ -477,6 +478,12 @@ if(CMAKE_CROSSCOMPILING)
     target_link_libraries(${elf} PRIVATE --specs=nosys.specs)
 
     target_link_libraries(${elf} PRIVATE ${firmware}_rust_c)
+
+    # Optiga config must be defined both when compiling the optiga lib, and also when compiling our
+    # sources. We can verify this include is indeed used by our sources - when you point it to a
+    # non-existing file, compilation fails.
+    # This definition is also added in external/CMakeLists.txt for the optiga lib.
+    target_compile_definitions(${elf} PRIVATE OPTIGA_LIB_EXTERNAL="optiga_config.h")
   endforeach(firmware)
 
   target_sources(firmware.elf PRIVATE firmware.c)


### PR DESCRIPTION
Needed to interact with the Optiga secure chip.

The optiga-trust-m module was forked to the BitBoxSwiss org, along with its own submodule mbedtls, so we are safe against deps disappearing.