### PR TITLE
rust: handle panics to show meaningful error

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -19,6 +19,7 @@ use pb::response::Response;
 
 use crate::workflow::{confirm, mnemonic, password, status, unlock};
 
+#[allow(clippy::empty_loop)]
 pub async fn from_file(request: &pb::RestoreBackupRequest) -> Result<Response, Error> {
     // This is a separate screen because 'Restore backup?' does not fit in the title field.
     confirm::confirm(&confirm::Params {
@@ -75,7 +76,13 @@ pub async fn from_file(request: &pb::RestoreBackupRequest) -> Result<Response, E
     }
 
     bitbox02::memory::set_initialized().or(Err(Error::Memory))?;
-    bitbox02::keystore::unlock(&password).expect("restore_from_file: unlock failed");
+    match bitbox02::keystore::unlock(&password) {
+        Err(_) => {
+            print_debug!(0, "restore_from_file: unlock failed");
+            loop {}
+        }
+        _ => (),
+    };
 
     // Ignore non-critical error.
     let _ = bitbox02::memory::set_device_name(&metadata.name);
@@ -84,6 +91,7 @@ pub async fn from_file(request: &pb::RestoreBackupRequest) -> Result<Response, E
     Ok(Response::Success(pb::Success {}))
 }
 
+#[allow(clippy::empty_loop)]
 pub async fn from_mnemonic(
     #[cfg_attr(not(feature = "app-u2f"), allow(unused_variables))]
     &pb::RestoreFromMnemonicRequest {
@@ -144,9 +152,15 @@ pub async fn from_mnemonic(
     }
 
     bitbox02::memory::set_initialized().or(Err(Error::Memory))?;
-
     // This should never fail.
-    bitbox02::keystore::unlock(&password).expect("restore_from_mnemonic: unlock failed");
+    match bitbox02::keystore::unlock(&password) {
+        Err(_) => {
+            print_debug!(0, "restore_from_mnemonic: unlock failed");
+            loop {}
+        }
+        _ => (),
+    };
+
     unlock::unlock_bip39().await;
     Ok(Response::Success(pb::Success {}))
 }

--- a/src/rust/bitbox02-rust/src/workflow/unlock.rs
+++ b/src/rust/bitbox02-rust/src/workflow/unlock.rs
@@ -95,6 +95,7 @@ pub async fn unlock_keystore(
 
 /// Performs the BIP39 keystore unlock, including unlock animation. If the optional passphrase
 /// feature is enabled, the user will be asked for the passphrase.
+#[allow(clippy::empty_loop)]
 pub async fn unlock_bip39() {
     // Empty passphrase by default.
     let mut mnemonic_passphrase = SafeInputString::new();
@@ -116,9 +117,16 @@ pub async fn unlock_bip39() {
         }
     }
 
-    bitbox02::ui::with_lock_animation(|| {
-        keystore::unlock_bip39(&mnemonic_passphrase).expect("bip39 unlock failed");
-    });
+    bitbox02::ui::lock_animation_start();
+    let result = keystore::unlock_bip39(&mnemonic_passphrase);
+    bitbox02::ui::lock_animation_stop();
+    match result {
+        Err(_) => {
+            print_debug!(0, "bip39 unlock failed");
+            loop {}
+        }
+        _ => (),
+    }
 }
 
 /// Invokes the unlock workflow. This function does not finish until the keystore is unlocked, or

--- a/src/rust/bitbox02/src/ui/ui.rs
+++ b/src/rust/bitbox02/src/ui/ui.rs
@@ -422,9 +422,11 @@ pub fn trinary_input_string_set_input(component: &mut Component, word: &str) {
     }
 }
 
-pub fn with_lock_animation<F: Fn()>(f: F) {
+pub fn lock_animation_start() {
     unsafe { bitbox02_sys::lock_animation_start() };
-    f();
+}
+
+pub fn lock_animation_stop() {
     unsafe { bitbox02_sys::lock_animation_stop() };
 }
 

--- a/src/rust/bitbox02/src/ui/ui_stub.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub.rs
@@ -151,9 +151,9 @@ pub fn trinary_input_string_set_input(_component: &mut Component, _word: &str) {
     panic!("not implemented")
 }
 
-pub fn with_lock_animation<F: Fn()>(f: F) {
-    f()
-}
+pub fn lock_animation_start() {}
+
+pub fn lock_animation_stop() {}
 
 pub fn screen_stack_pop_all() {}
 

--- a/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
+++ b/src/rust/bitbox02/src/ui/ui_stub_c_unit_tests.rs
@@ -162,9 +162,9 @@ pub fn trinary_input_string_set_input(_component: &mut Component, _word: &str) {
     panic!("not implemented")
 }
 
-pub fn with_lock_animation<F: Fn()>(f: F) {
-    f()
-}
+pub fn lock_animation_start() {}
+
+pub fn lock_animation_stop() {}
 
 pub fn screen_stack_pop_all() {}
 


### PR DESCRIPTION
In b09c333 we added the `panic_immediate_abort` to the rust cargo flags. This caused all the panics previously handled by the handler defined in lib.rs to just show the `hard fault` error message on the screen of the bitbox.

This adds the manual handling of some of those panics, to provide useful debug messages.