### PR TITLE
platform: start timer independently of qtouch

### DIFF
--- a/src/platform/driver_init.c
+++ b/src/platform/driver_init.c
@@ -78,6 +78,7 @@ static void _timer_peripheral_init(void)
 {
     hri_mclk_set_APBAMASK_RTC_bit(MCLK);
     timer_init(&TIMER_0, RTC, _rtc_get_timer());
+    timer_start(&TIMER_0);
 }
 
 /**

--- a/src/qtouch/qtouch.c
+++ b/src/qtouch/qtouch.c
@@ -520,7 +520,6 @@ void qtouch_timer_config(void)
     Timer_task.mode = TIMER_TASK_REPEAT;
 
     timer_add_task(&TIMER_0, &Timer_task);
-    timer_start(&TIMER_0);
 }
 
 uint16_t qtouch_get_sensor_node_signal(uint16_t sensor_node)


### PR DESCRIPTION
If factorysetup, qtouch_init() is not called. We still need a timer there to talk to the Optiga Trust M, which requires a timer task for communication.

We start the timer at init time, tasks can be added to the timer afterwards