### PR TITLE
bootloader: qtouch only in devdevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### v1.0.7
 - Update manufacturer HID descriptor to bitbox.swiss
+- Remove qtouch code from production bootloader
 
 ### v1.0.6
 - Replace root pubkeys

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,11 +125,15 @@ set(DBB-BOOTLOADER-SOURCES ${DBB-BOOTLOADER-SOURCES} PARENT_SCOPE)
 set(DRIVER-SOURCES
   ${CMAKE_SOURCE_DIR}/src/platform/platform_init.c
   ${CMAKE_SOURCE_DIR}/src/platform/driver_init.c
-  ${CMAKE_SOURCE_DIR}/src/qtouch/qtouch.c
   ${CMAKE_SOURCE_DIR}/src/ui/oled/oled.c
   ${CMAKE_SOURCE_DIR}/src/ui/oled/oled_writer.c
 )
 set(DRIVER-SOURCES ${DRIVER-SOURCES} PARENT_SCOPE)
+
+set(QTOUCH-SOURCES
+  ${CMAKE_SOURCE_DIR}/src/qtouch/qtouch.c
+)
+set(QTOUCH-SOURCES ${DRIVER-SOURCES} PARENT_SCOPE)
 
 set(PLATFORM-BITBOX02-SOURCES
   ${CMAKE_SOURCE_DIR}/src/sd_mmc/sd_mmc_start.c
@@ -180,6 +184,7 @@ set(FIRMWARE-SOURCES
   ${DBB-FIRMWARE-UI-SOURCES}
   ${FIRMWARE-DRIVER-SOURCES}
   ${DRIVER-SOURCES}
+  ${QTOUCH-SOURCES}
   ${SECURECHIP-SOURCES}
   ${CMAKE_SOURCE_DIR}/src/common_main.c
 )
@@ -337,6 +342,12 @@ set(BOOTLOADERS
   )
 set(BOOTLOADERS ${BOOTLOADERS} PARENT_SCOPE)
 
+set(DEVDEVICE-BOOTLOADERS
+  bootloader-development
+  bootloader-development-locked
+  bootloader-btc-development
+)
+
 set(FIRMWARES
   firmware # Firmware MULTI
   firmware-btc # Firmware BTC-ONLY
@@ -416,7 +427,6 @@ if(CMAKE_CROSSCOMPILING)
     target_include_directories(${elf} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/bootloader)
     target_link_libraries(${elf} PRIVATE "-Wl,-Map=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${bootloader}.map\" -T\"${CMAKE_SOURCE_DIR}/bootloader.ld\"")
     target_link_libraries(${elf} PRIVATE -Wl,--defsym=STACK_SIZE=${STACK_SIZE} -Wl,-defsym=HEAP_SIZE=${HEAP_SIZE})
-    target_link_libraries(${elf} PRIVATE ${QTOUCHLIB_A} ${QTOUCHLIB_B} ${QTOUCHLIB_T})
 
     target_link_libraries(${elf} PRIVATE ${bootloader}_rust_c)
 
@@ -425,6 +435,12 @@ if(CMAKE_CROSSCOMPILING)
     target_link_libraries(${elf} PRIVATE --specs=nano.specs)
     target_compile_options(${elf} PRIVATE --specs=nosys.specs)
     target_link_libraries(${elf} PRIVATE --specs=nosys.specs)
+  endforeach(bootloader)
+
+  foreach(bootloader ${DEVDEVICE-BOOTLOADERS})
+    set(elf ${bootloader}.elf)
+    target_link_libraries(${elf} PRIVATE ${QTOUCHLIB_A} ${QTOUCHLIB_B} ${QTOUCHLIB_T})
+    target_sources(${elf} PRIVATE ${QTOUCH-SOURCES})
   endforeach(bootloader)
 
   foreach(bootloader ${BOOTLOADERS-BITBOX02})

--- a/src/bootloader/startup.c
+++ b/src/bootloader/startup.c
@@ -19,7 +19,9 @@
 
 #include <driver_init.h>
 #include <hardfault.h>
+#ifdef BOOTLOADER_DEVDEVICE
 #include <qtouch.h>
+#endif
 #include <screen.h>
 #include <string.h>
 #include <usb/usb_processing.h>
@@ -49,7 +51,9 @@ int main(void)
     platform_init();
     __stack_chk_guard = rand_sync_read32(&RAND_0);
     screen_init();
+#ifdef BOOTLOADER_DEVDEVICE
     qtouch_init();
+#endif
     bootloader_jump();
 
     // If did not jump to firmware code, begin USB processing

--- a/src/platform/driver_init.c
+++ b/src/platform/driver_init.c
@@ -306,7 +306,10 @@ void bootloader_init(void)
     _oled_set_pins();
     _ptc_clock_init();
 
+#ifdef BOOTLOADER_DEVDEVICE
+    // Only needed for qtouch, which is only needed in the devdevice bootloader.
     _timer_peripheral_init();
+#endif
     _delay_driver_init();
 
     // OLED


### PR DESCRIPTION
We don't make use of touch in the production bootloader.