### PR TITLE
scripts/jlink.gdb: default to `continue` over `stepi`

### DIFF
--- a/scripts/jlink.gdb
+++ b/scripts/jlink.gdb
@@ -13,4 +13,5 @@ monitor reset
 #break MemManage_Handler
 
 # start running
-stepi
+# change `continue` to `stepi` to stop execution at the start if you want to set breakpoints etc.
+continue


### PR DESCRIPTION
99% of the time we want to `make run-debug` and execute immediately to see logs, not to set breakpoints. `stepi` is less convenient as one has to manually enter `c`/`continue` to start everytime.