### PR TITLE
bootloader: add OP_HARDWARE api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,10 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ## Bootloader
 
-### v1.0.7
+### v1.1.0
 - Update manufacturer HID descriptor to bitbox.swiss
 - Remove qtouch code from production bootloader
+- Implement OP_HARDWARE endpoint, to identify the secure chip model
 
 ### v1.0.6
 - Replace root pubkeys

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 # Example 'v1.0.0'. They MUST not contain a pre-release label such as '-beta'.
 set(FIRMWARE_VERSION "v9.22.0")
 set(FIRMWARE_BTC_ONLY_VERSION "v9.22.0")
-set(BOOTLOADER_VERSION "v1.0.7")
+set(BOOTLOADER_VERSION "v1.1.0")
 
 find_package(PythonInterp 3.6 REQUIRED)
 

--- a/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
+++ b/py/bitbox02/bitbox02/communication/bitbox_api_protocol.py
@@ -557,9 +557,7 @@ class BitBoxCommonAPI:
 
         # Delete the prelease part, as it messes with the comparison (e.g. 3.0.0-pre < 3.0.0 is
         # True, but the 3.0.0-pre has already the same API breaking changes like 3.0.0...).
-        self.version = semver.VersionInfo(
-            self.version.major, self.version.minor, self.version.patch, build=self.version.build
-        )
+        self.version = self.version.replace(prerelease=None)
 
         # raises exceptions if the library is out of date
         self._check_max_version()

--- a/py/send_message.py
+++ b/py/send_message.py
@@ -1482,6 +1482,11 @@ class SendMessageBootloader:
             version = self._device.versions()
             print(f"Firmware version: {version[0]}, Pubkeys version: {version[1]}")
 
+    def _get_hardware(self) -> None:
+        secure_chip = self._device.hardware()["secure_chip_model"]
+        print(f"Hardware variant:")
+        print(f"- Secure Chip: {secure_chip.value}")
+
     def _erase(self) -> None:
         self._device.erase()
 
@@ -1506,6 +1511,7 @@ class SendMessageBootloader:
         choices = (
             ("Boot", self._boot),
             ("Print versions", self._get_versions),
+            ("Print hardware variant", self._get_hardware),
             ("Erase firmware", self._erase),
             ("Show firmware hash at startup", self._show_fw_hash),
             ("Don't show firmware hash at startup", self._dont_show_fw_hash),

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -67,6 +67,8 @@
 #define OP_SCREEN_ROTATE ((uint8_t)'f') /* 0x66 */
 // OP_SET_SHOW_FIRMWARE_HASH - Enable or disable the flag to automatically show the firmware hash.
 #define OP_SET_SHOW_FIRMWARE_HASH ((uint8_t)'H') /* 0x4A */
+// OP_HARDWARE - Return the secure chip variant.
+#define OP_HARDWARE ((uint8_t)'W') /* 0x57 */
 
 // API return codes
 #define OP_STATUS_OK ((uint8_t)0)
@@ -766,6 +768,16 @@ static size_t _api_screen_rotate(uint8_t* output)
     return _report_status(OP_STATUS_OK, output);
 }
 
+static size_t _api_hardware(uint8_t* output)
+{
+    uint8_t type = 0;
+    if (memory_get_securechip_type() == MEMORY_SECURECHIP_TYPE_OPTIGA) {
+        type = 1;
+    }
+    output[BOOT_OP_LEN] = type;
+    return _report_status(OP_STATUS_OK, output) + 1;
+}
+
 static size_t _api_command(const uint8_t* input, uint8_t* output, const size_t max_out_len)
 {
     memset(output, 0, max_out_len);
@@ -808,6 +820,9 @@ static size_t _api_command(const uint8_t* input, uint8_t* output, const size_t m
         break;
     case OP_SCREEN_ROTATE:
         len = _api_screen_rotate(output);
+        break;
+    case OP_HARDWARE:
+        len = _api_hardware(output);
         break;
     default:
         len = _report_status(OP_STATUS_ERR_INVALID_CMD, output);

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -731,7 +731,7 @@ static size_t _api_set_show_firmware_hash(const uint8_t* input, uint8_t* output)
 }
 
 /*
- * output filled with bootloader version | firmware version | signing pubkeys version
+ * output filled with firmware version | signing pubkeys version
  */
 static size_t _api_versions(uint8_t* output)
 {
@@ -742,7 +742,7 @@ static size_t _api_versions(uint8_t* output)
         (const uint8_t*)&data->fields.signing_pubkeys_version,
         sizeof(version_t));
     _report_status(OP_STATUS_OK, output);
-    return BOOT_OP_LEN + sizeof(version_t) * 3;
+    return BOOT_OP_LEN + sizeof(version_t) * 2;
 }
 
 static void _api_reboot(void)


### PR DESCRIPTION
This will allow the bbapp to flash different FW versions, depending on the PCB variants. The initial implementation will respond with a single byte that identifies the Secure Chip: 0 for ATECC, 1 for Optiga.

Note: Based on the changes from #1341 