### PR TITLE
DX: Publish the simulators port

### DIFF
--- a/scripts/dockerenv.sh
+++ b/scripts/dockerenv.sh
@@ -72,13 +72,15 @@ dockerdev () {
         $RUNTIME rm "$CONTAINER_NAME"
     fi
 
-    # SYS_PTRACE is needed to run address sanitizer
+    # * `SYS_PTRACE` is needed to run address sanitizer
+    # * `-p 15423` publishes the default port the simulator listens on
     $RUNTIME run \
            --detach \
            --interactive --tty \
            --name="$CONTAINER_NAME" \
            -v "$repo_path":"$MOUNT_DIR" \
            --cap-add SYS_PTRACE \
+           -p 15423:15423 \
            ${CONTAINER_IMAGE}:${CONTAINER_VERSION} bash
 
     if [ "$RUNTIME" = "docker" ] ; then


### PR DESCRIPTION
This commit publishes the simulators default port 15423 on the development container so that processes on the host can access it