### PR TITLE
Makefile: added targets for  missing jlink scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,14 @@ jlink-flash-factory-setup: | build
 	JLinkExe -NoGui 1 -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build/scripts/factory-setup.jlink
 jlink-flash-firmware-debug: | build
 	JLinkExe -NoGui 1 -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./build-debug/scripts/firmware.jlink
+jlink-flash-set-new-screen:
+	JLinkExe -NoGui 1 -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./scripts/set-new-screen.jlink
+jlink-flash-set-original-screen:
+	JLinkExe -NoGui 1 -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./scripts/set-original-screen.jlink
+jlink-flash-reset-version:
+	JLinkExe -NoGui 1 -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./scripts/reset-version.jlink
+jlink-flash-set-securechip-optiga:
+	JLinkExe -NoGui 1 -if SWD -device ATSAMD51J20 -speed 4000 -autoconnect 1 -CommanderScript ./scripts/set-securechip-optiga.jlink
 jlink-gdb-server:
 	JLinkGDBServer -nogui -if SWD -device ATSAMD51J20 -speed 4000
 rtt-client:


### PR DESCRIPTION
This simplifies the execution of some jlink scripts available in the scripts/ folder.