### PR TITLE
Build: Minor bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ generate-atecc608-config:
 ci:
 	./.ci/ci
 prepare-tidy: | build build-build
-	make -C build rust-cbindgen
-	make -C build-build rust-cbindgen
+	$(MAKE) -C build rust-cbindgen
+	$(MAKE) -C build-build rust-cbindgen
 clean:
 	rm -rf build build-build build-debug build-build-rust-unit-tests

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -55,7 +55,6 @@ ExternalProject_Add(libwally-core
                   ${CMAKE_CURRENT_SOURCE_DIR}/libwally-core/configure
                   ${CONFIGURE_FLAGS}
                   ${LIBWALLY_CONFIGURE_FLAGS}
-  BUILD_COMMAND   ${CMAKE_MAKE_PROGRAM}
   INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
   COMMAND         ${CMAKE_COMMAND} -E copy
                   ${CMAKE_CURRENT_BINARY_DIR}/libwally-core/src/libwally-core-build/src/.libs/libwallycore.a


### PR DESCRIPTION
* make should always be called as $(MAKE) in makefiles
* CMake didn't keep job server fds open when explicilty specifying the build command. Starting with CMAKE 3.28 there is a new option to allow for that, but we support much older cmakes than that. (BUILD_JOB_SERVER_AWARE). Not sure when this broke in practice, might have been with some update of Make/CMake or wally. (concurrent builds (-j8) doesn't work right now)