### PR TITLE
Adding explicit build-args for linux amd64

### DIFF
--- a/releases/build.sh
+++ b/releases/build.sh
@@ -36,7 +36,7 @@ fi
 
 # Build the Docker image (this can take a while):
 # -  The firmware is only reproducible with the same host compiler. For now we force linux/amd64.
-docker build --pull --platform linux/amd64 --force-rm --no-cache -t bitbox02-firmware .
+docker build --pull --platform linux/amd64 --build-arg TARGETPLATFORM=linux --build-arg TARGETARCH=amd64 --force-rm --no-cache -t bitbox02-firmware .
 
 # Revert the above local patch to the Dockerfile again to have a clean state.
 git checkout -- Dockerfile


### PR DESCRIPTION
When attempting to build the latest firmware, the `TARGETPLATFORM` and `TARGETARCH` were not being automatically populated from the `--platform linux/amd64` as assumed here:
https://github.com/BitBoxSwiss/bitbox02-firmware/blob/master/Dockerfile#L24

This lead to confusing errors late in the build process.

Docker indicates these AARGs are **only set when using the _buildkit_ backend**: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope

I'm using docker commandline, on PopOS.

In order to prevent issues for myself and other users, I am making this PR to explicitly set these parameters instead of relying on invisible buildkit magic.

