### PR TITLE
debugging: Run firmware without bootloader

### DIFF
--- a/scripts/jlink.gdb
+++ b/scripts/jlink.gdb
@@ -7,6 +7,13 @@ load
 # Reset the CPU
 monitor reset
 
+# Set VTOR (Vector Table Offset Register) to where the firmware is located
+set *(uint32_t*)0xE000ED08=0x10000
+# Set stack pointer to initial stack pointer according to exception table.
+set $sp = *(uint32_t*)0x10000
+# Set the program counter to the reset handler (second item in exception table)
+set $pc = *(uint32_t*)0x10004
+
 #break Reset_Handler
 #break HardFault_Handler
 #break NMI_Handler


### PR DESCRIPTION
When debugging firmware it is easier to skip the bootloader altogether and go straight to firmware code.

Since VTOR is reset on core reset we need to manually set the PC and SP registers. Issuing a reset will simply try to boot from address 0 again.

If we merge this PR `make run-debug` will always go straight to application code. 