### PR TITLE
api: centralize state check

### DIFF
--- a/src/rust/bitbox02-rust/src/hww.rs
+++ b/src/rust/bitbox02-rust/src/hww.rs
@@ -119,12 +119,6 @@ pub async fn process_packet(usb_in: Vec<u8>) -> Vec<u8> {
         _ => (),
     }
 
-    // No other message than the attestation and unlock calls shall pass until the device is
-    // unlocked or ready to be initialized.
-    if bitbox02::memory::is_initialized() && bitbox02::keystore::is_locked() {
-        return Vec::new();
-    }
-
     let mut out = [OP_STATUS_SUCCESS].to_vec();
     match noise::process(usb_in, &mut out).await {
         Ok(()) => out,
@@ -417,7 +411,14 @@ mod tests {
 
         // Can't reboot when initialized but locked.
         bitbox02::keystore::lock();
-        assert!(make_request(reboot_request.encode_to_vec().as_ref()).is_err());
+        let response_encoded = make_request(&reboot_request.encode_to_vec()).unwrap();
+        let response = crate::pb::Response::decode(&response_encoded[..]).unwrap();
+        assert_eq!(
+            response,
+            crate::pb::Response {
+                response: Some(api::error::make_error(api::error::Error::InvalidState))
+            },
+        );
 
         // Unlock.
         assert_eq!(


### PR DESCRIPTION
We had two separate checks to decide if we will allow a protobuf message API call to proceed: in hww.rs (forbid if initialized and locked) and in api.rs in the can_call() function that defines which states the API call can run in.

This makes it a bit hard to follow as split into two locations, and it also prevents us from introducing a protobuf call that is only allowed to run if the device is initialized but still locked. `Unlock` would be such a useful new API call if we want to allow entering the passphrase on the host.

The hww.rs check passed if `!initialized || !locked`, which means the same as `uninitialized || seeded || unlocked`.

We change the `can_call` state checks to include this condition. For this we split the local `Initialized` state into
`InitializedAndLocked` and `InitializedAndUnlocked`. For each line in can_call, the two conditions are combined. The equivalent state check in the end is simply to convert all `Initialized` checks to `InitializedAndUnlocked`.

The `true` entries become explicit as they can't include `InitializedAndLocked` (e.g. can't change the name using `DeviceName` if initialized but not yet unlocked).