### PR TITLE
newlib-compat: macro conflict between asf4 and std

### DIFF
--- a/external/asf4-drivers/hal/utils/include/utils_assert.h
+++ b/external/asf4-drivers/hal/utils/include/utils_assert.h
@@ -44,6 +44,9 @@ extern "C" {
 //# define USE_SIMPLE_ASSERT
 #endif
 
+// Bitbox modification. `utils_assert.h` is not compatible with std `assert.h`
+#undef assert
+
 /**
  * \brief Assert macro
  *


### PR DESCRIPTION
When upgradeing to newer GCC toolchain and newlib this conflict of macro definitions breaks compilation.

More specifically without this I cannot compile on darwin with arm GCC 13 toolchain.