### PR TITLE
screen.c: do not call delay_ms if duration is 0

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -43,7 +43,7 @@ void screen_print_debug(const char* message, int duration)
     UG_FontSelect(&font_font_a_9X9);
     UG_PutString(0, 0, print, false);
     UG_SendBuffer();
-    delay_ms(duration);
+    if (duration > 0) delay_ms(duration);
 }
 
 void screen_sprintf_debug(int duration, const char* fmt, ...)


### PR DESCRIPTION
The new ASF drivers changed the behavior of delay_ms. Calling it with 0 seems to mean delay forever and not 0 ms.