### PR TITLE
asf4: Enable DEBUG and USE_SIMPLE_ASSERT in debug builds

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -133,6 +133,10 @@ if(CMAKE_CROSSCOMPILING)
 
     target_compile_options(asf4-drivers-min PRIVATE -Wno-cast-qual -Wno-unused-parameter -Wno-missing-prototypes -Wno-missing-declarations -Wno-bad-function-cast -Wno-strict-prototypes -Wno-old-style-definition)
 
+    if (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+        target_compile_definitions(asf4-drivers-min PUBLIC DEBUG USE_SIMPLE_ASSERT)
+    endif()
+
   target_link_libraries(asf4-drivers-min samd51a-ds)
   set_property(TARGET asf4-drivers-min PROPERTY INTERFACE_LINK_LIBRARIES "")
 


### PR DESCRIPTION
This enables "ASSERT" macros in asf4 in debug builds, which can find bugs. They will cause a break in execution so you can investigate why the assert was triggered. (this requires GDB to be connected).