### PR TITLE
test: fix typo in filename

### DIFF
--- a/test/simulator/CMakeLists.txt
+++ b/test/simulator/CMakeLists.txt
@@ -29,7 +29,7 @@ set(IGNORE_SOURCES
     "src/screen.c"
     "src/memory/nvmctrl.c"
     "src/memory/smarteeprom.c"
-    "src/memory.mpu.c"
+    "src/memory/mpu.c"
     )
 
 # Exclude some files which depends on the hardware.

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -29,7 +29,7 @@ set(IGNORE_SOURCES
     "src/screen.c"
     "src/memory/nvmctrl.c"
     "src/memory/smarteeprom.c"
-    "src/memory.mpu.c"
+    "src/memory/mpu.c"
     )
 
 # Exclude some files which depends on the hardware.


### PR DESCRIPTION
`.` worked because it's regexp, but not what was meant.