### PR TITLE
usb: Move usb handling out into main loop

### DIFF
--- a/src/firmware_main_loop.c
+++ b/src/firmware_main_loop.c
@@ -15,43 +15,94 @@
 #include "firmware_main_loop.h"
 
 #include "hardfault.h"
+#include "hid_hww.h"
 #include "hww.h"
 #include "touch/gestures.h"
-#include "u2f.h"
 #include "ui/screen_process.h"
 #include "ui/screen_stack.h"
+#include "usb/class/hid/hww/hid_hww.h"
 #include "usb/usb.h"
+#include "usb/usb_frame.h"
 #include "usb/usb_processing.h"
 #include "workflow/orientation_screen.h"
 #include <rust/rust.h>
+#if APP_U2F == 1
+#include "u2f.h"
+#include "u2f/u2f_packet.h"
+#include "usb/class/hid/u2f/hid_u2f.h"
+#endif
 
 void firmware_main_loop(void)
 {
     // This starts the async orientation screen workflow, which is processed by the loop below.
     orientation_screen();
 
+    const uint8_t* hww_data = NULL;
+    uint8_t hww_frame[USB_REPORT_SIZE] = {0};
+
+#if APP_U2F == 1
+    u2f_packet_init();
+    const uint8_t* u2f_data = NULL;
+    uint8_t u2f_frame[USB_REPORT_SIZE] = {0};
+#endif
+
     while (1) {
+        // Do USB I/O
+        if (!hww_data) {
+            hww_data = queue_pull(queue_hww_queue());
+        }
+#if APP_U2F == 1
+        // Generate timeout packets
+        uint32_t timeout_cid;
+        while (u2f_packet_timeout_get(&timeout_cid)) {
+            u2f_packet_timeout(timeout_cid);
+        }
+        if (!u2f_data) {
+            u2f_data = queue_pull(queue_u2f_queue());
+        }
+#endif
+        // Only read new messages if we have nothing to send
+        if (!hww_data && hid_hww_read(&hww_frame[0])) {
+            usb_packet_process((const USB_FRAME*)hww_frame);
+        }
+#if APP_U2F == 1
+        if (!u2f_data && hid_u2f_read(&u2f_frame[0])) {
+            u2f_packet_process((const USB_FRAME*)u2f_frame);
+        }
+#endif
+
+        if (hww_data) {
+            if (hid_hww_write_poll(hww_data)) {
+                hww_data = NULL;
+            }
+        }
+#if APP_U2F == 1
+        if (u2f_data) {
+            if (hid_u2f_write_poll(u2f_data)) {
+                u2f_data = NULL;
+            }
+        }
+#endif
+
+        /* First, process all the incoming USB traffic. */
+        usb_processing_process(usb_processing_hww());
+#if APP_U2F == 1
+        usb_processing_process(usb_processing_u2f());
+#endif
+        /*
+         * If USB has generated events at the application level,
+         * process them now.
+         */
+        hww_process();
+#if APP_U2F == 1
+        u2f_process();
+#endif
+
         screen_process();
         /* And finally, run the high-level event processing. */
 
         rust_workflow_spin();
 
-        if (usb_is_enabled()) {
-            rust_async_usb_spin();
-
-            /* First, process all the incoming USB traffic. */
-            usb_processing_process(usb_processing_hww());
-#if APP_U2F == 1
-            usb_processing_process(usb_processing_u2f());
-#endif
-            /*
-             * If USB has generated events at the application level,
-             * process them now.
-             */
-            hww_process();
-#if APP_U2F == 1
-            u2f_process();
-#endif
-        }
+        rust_async_usb_spin();
     }
 }

--- a/src/u2f/u2f_packet.c
+++ b/src/u2f/u2f_packet.c
@@ -65,6 +65,7 @@ static void _reset_state(void)
     queue_clear(queue_u2f_queue());
     _timeout_disable(_in_state.cid);
     memset(&_in_state, 0, sizeof(_in_state));
+    _in_state.buf_ptr = _in_state.data;
 }
 
 /**
@@ -179,4 +180,9 @@ bool u2f_packet_process(const USB_FRAME* frame)
         break;
     }
     return false;
+}
+
+void u2f_packet_init(void)
+{
+    _reset_state();
 }

--- a/src/u2f/u2f_packet.h
+++ b/src/u2f/u2f_packet.h
@@ -54,4 +54,6 @@ void u2f_packet_timeout_enable(uint32_t cid);
  */
 void u2f_invalid_endpoint(struct queue* queue, uint32_t cid);
 
+void u2f_packet_init(void);
+
 #endif

--- a/src/usb/class/hid/hid.h
+++ b/src/usb/class/hid/hid.h
@@ -26,6 +26,8 @@
 struct usbdc_handler;
 struct usbdf_handler;
 struct usbdf_driver;
+struct usb_req;
+enum usb_ctrl_stage { USB_SETUP_STAGE = 0, USB_DATA_STAGE = 1, USB_STATUS_STAGE = 2 };
 typedef void (*FUNC_PTR)(void);
 #endif
 

--- a/src/usb/class/hid/hww/hid_hww.h
+++ b/src/usb/class/hid/hww/hid_hww.h
@@ -60,4 +60,20 @@ int32_t hid_hww_register_callback(enum hid_trans_type trans_type, FUNC_PTR func)
  */
 void hid_hww_setup(void);
 
+/**
+ * Send out data
+ * returns true if data sent out, false if busy (need retry)
+ */
+bool hid_hww_write_poll(const uint8_t* data);
+
+/**
+ * Read data
+ *
+ * data must fit 64 bytes data.
+ * Returns true if there is valid data in the buffer. data is invalidated when this is called again.
+ * Returns false if USB subsystem was not ready to receive or there is a request in flight and data
+ * is not.
+ */
+bool hid_hww_read(uint8_t* data);
+
 #endif

--- a/src/usb/class/hid/u2f/hid_u2f.c
+++ b/src/usb/class/hid/u2f/hid_u2f.c
@@ -39,6 +39,13 @@ static struct usbdf_driver _func_driver;
  */
 static uint8_t _report_descriptor[] = {USB_DESC_U2F_REPORT};
 
+/*
+ * Flags for communication between main loop and ISR
+ */
+static volatile bool _send_busy = false;
+static volatile bool _has_data = false;
+static volatile bool _request_in_flight = false;
+
 /**
  * The USB device core request handler callback for the U2F interface.
  */
@@ -52,37 +59,39 @@ static int32_t _request(uint8_t ep, struct usb_req* req, enum usb_ctrl_stage sta
  */
 static struct usbdc_handler _request_handler = {NULL, (FUNC_PTR)_request};
 
-// Stores the reports for the U2F interface.
-static uint8_t _out_report[USB_HID_REPORT_OUT_SIZE];
-
 /**
  * Sets the buffer address for the incoming endpoint to `hid_hww_out_report`.
  */
-static int32_t _read(void)
+bool hid_u2f_read(uint8_t* data)
 {
-    return hid_read(&_func_data, _out_report, USB_HID_REPORT_OUT_SIZE);
+    if (_request_in_flight && _has_data) {
+        _request_in_flight = false;
+        return true;
+    }
+    if (_request_in_flight) {
+        return false;
+    }
+    if (hid_read(&_func_data, data, USB_HID_REPORT_OUT_SIZE) == ERR_NONE) {
+        _has_data = false;
+        _request_in_flight = true;
+    }
+    return false;
 }
-
-/** Set when the send channel is busy sending data. */
-static bool _send_busy = false;
 
 /**
  * Sends the next data, if the USB interface is ready.
  */
-static void _send_next(void)
+bool hid_u2f_write_poll(const uint8_t* data)
 {
+    ASSERT(data);
     if (_send_busy) {
-        /*
-         * We can't send yet. Whenever the current sender finished, it will
-         * flush anything that's still queued.
-         */
-        return;
+        return false;
     }
-    const uint8_t* data = queue_pull(queue_u2f_queue());
-    if (data != NULL) {
+    if (hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE) == ERR_NONE) {
         _send_busy = true;
-        hid_write(&_func_data, data, USB_HID_REPORT_OUT_SIZE);
+        return true;
     }
+    return false;
 }
 
 /**
@@ -90,15 +99,13 @@ static void _send_next(void)
  * This is a result of calling _read().
  * The received data is stored in '_out_report'.
  */
-static uint8_t _out(const uint8_t ep, const enum usb_xfer_code rc, const uint32_t count)
+static uint8_t _rx_cb(const uint8_t ep, const enum usb_xfer_code rc, const uint32_t count)
 {
     (void)ep;
     (void)rc;
     (void)count;
+    _has_data = true;
 
-    u2f_packet_process((const USB_FRAME*)_out_report);
-    /* Incoming data has been processed completely. Start a new read. */
-    _read();
     return ERR_NONE;
 }
 
@@ -106,15 +113,9 @@ static uint8_t _out(const uint8_t ep, const enum usb_xfer_code rc, const uint32_
  * Called when a usb frame has been replied to the host via the U2F interface
  * and the device is ready to send the next frame.
  */
-static void _sent_done(void)
+static void _tx_cb(void)
 {
     _send_busy = false;
-    /*
-     * If there is more data queued, push it immediately to save some time.
-     * Otherwise, sending will stop until somebody explicitely queues
-     * a frame again.
-     */
-    _send_next();
 }
 
 /**
@@ -137,14 +138,8 @@ int32_t hid_u2f_init(void (*callback)(void))
  */
 void hid_u2f_setup(void)
 {
-    hid_u2f_register_callback(HID_CB_READ, (FUNC_PTR)_out);
-    // usb_report_sent is called when the outgoing usb frame is fully transmitted.
-    hid_u2f_register_callback(HID_CB_WRITE, (FUNC_PTR)_sent_done);
-
-    usb_processing_set_send(usb_processing_u2f(), _send_next);
-
-    // Wait for data
-    _read();
+    hid_u2f_register_callback(HID_CB_READ, (FUNC_PTR)_rx_cb);
+    hid_u2f_register_callback(HID_CB_WRITE, (FUNC_PTR)_tx_cb);
 }
 
 /**

--- a/src/usb/class/hid/u2f/hid_u2f.h
+++ b/src/usb/class/hid/u2f/hid_u2f.h
@@ -60,4 +60,7 @@ int32_t hid_u2f_register_callback(enum hid_trans_type trans_type, FUNC_PTR func)
  */
 void hid_u2f_setup(void);
 
+bool hid_u2f_write_poll(const uint8_t* data);
+bool hid_u2f_read(uint8_t* data);
+
 #endif

--- a/src/usb/usb_processing.h
+++ b/src/usb/usb_processing.h
@@ -58,8 +58,6 @@ bool usb_processing_enqueue(
     uint32_t cid);
 void usb_processing_process(struct usb_processing* ctx);
 
-void usb_processing_set_send(struct usb_processing* ctx, void (*send)(void));
-
 struct usb_processing* usb_processing_u2f(void);
 struct usb_processing* usb_processing_hww(void);
 

--- a/test/unit-test/framework/mock_hidapi.c
+++ b/test/unit-test/framework/mock_hidapi.c
@@ -51,6 +51,10 @@ void* timer_task(void* args)
     for (;;) {
         // printf("tick\n");
         u2f_packet_timeout_tick();
+        uint32_t timeout_cid;
+        while (u2f_packet_timeout_get(&timeout_cid)) {
+            u2f_packet_timeout(timeout_cid);
+        }
         _delay(90);
         pthread_mutex_lock(&mutex);
         if (timer_thread_stop) {
@@ -89,7 +93,6 @@ hid_device* hid_open_path(const char* path)
     static char sham[] = "sham";
     usb_processing_init();
     u2f_device_setup();
-    usb_processing_set_send(usb_processing_u2f(), _send_packet_cb);
     timer_thread_stop = false;
     int res = pthread_create(&thread, NULL, &timer_task, NULL);
     if (res != 0) {

--- a/test/unit-test/test_simulator.c
+++ b/test/unit-test/test_simulator.c
@@ -44,14 +44,14 @@ int get_usb_message_socket(uint8_t* input)
 
 void send_usb_message_socket(void)
 {
-    struct queue* q = queue_hww_queue();
-    const uint8_t* data = queue_pull(q);
-    if (data != NULL) {
+    const uint8_t* data = queue_pull(queue_hww_queue());
+    while (data) {
         data_len = 256 * (int)data[5] + (int)data[6];
         if (!write(sockfd, data, USB_HID_REPORT_OUT_SIZE)) {
             perror("ERROR, could not write to socket");
             exit(1);
         }
+        data = queue_pull(queue_hww_queue());
     }
 }
 
@@ -89,7 +89,6 @@ int main(void)
 
     // BitBox02 simulation initializaition
     usb_processing_init();
-    usb_processing_set_send(usb_processing_hww(), send_usb_message_socket);
     printf("USB setup success\n");
 
     hww_setup();
@@ -136,6 +135,7 @@ int main(void)
             usb_processing_process(usb_processing_hww());
             temp_len -= (USB_HID_REPORT_OUT_SIZE - 5);
         }
+        send_usb_message_socket();
     }
     close(sockfd);
     return 0;


### PR DESCRIPTION
It best practice to do as little work as possible in the interrupt handlers. In this commit the parsing is moved from the interrupts handlers to the main loop.

This is also a requirement for having multiple transports.