### PR TITLE
use Hal trait to combine Ui, Sd and future traits

### DIFF
--- a/src/rust/bitbox02-rust-c/src/workflow.rs
+++ b/src/rust/bitbox02-rust-c/src/workflow.rs
@@ -40,13 +40,12 @@ static mut CONFIRM_TITLE: Option<String> = None;
 static mut CONFIRM_BODY: Option<String> = None;
 static mut CONFIRM_PARAMS: Option<confirm::Params> = None;
 static mut CONFIRM_STATE: TaskState<'static, Result<(), confirm::UserAbort>> = TaskState::Nothing;
-static mut REAL_WORKFLOWS: bitbox02_rust::workflow::RealWorkflows =
-    bitbox02_rust::workflow::RealWorkflows;
+static mut BITBOX02_HAL: bitbox02_rust::hal::BitBox02Hal = bitbox02_rust::hal::BitBox02Hal::new();
 
 #[no_mangle]
 pub unsafe extern "C" fn rust_workflow_spawn_unlock() {
     UNLOCK_STATE = TaskState::Running(Box::pin(bitbox02_rust::workflow::unlock::unlock(
-        &mut REAL_WORKFLOWS,
+        &mut BITBOX02_HAL,
     )));
 }
 

--- a/src/rust/bitbox02-rust/src/hal.rs
+++ b/src/rust/bitbox02-rust/src/hal.rs
@@ -1,0 +1,98 @@
+// Copyright 2025 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::workflow::RealWorkflows;
+pub use crate::workflow::Workflows as Ui;
+
+pub trait Sd {
+    fn sdcard_inserted(&mut self) -> bool;
+}
+
+/// Hardware abstraction layer for BitBox devices.
+pub trait Hal {
+    fn ui(&mut self) -> &mut impl Ui;
+    fn sd(&mut self) -> &mut impl Sd;
+}
+
+pub struct BitBox02Sd;
+
+impl Sd for BitBox02Sd {
+    fn sdcard_inserted(&mut self) -> bool {
+        bitbox02::sd::sdcard_inserted()
+    }
+}
+
+pub struct BitBox02Hal {
+    ui: RealWorkflows,
+    sd: BitBox02Sd,
+}
+
+impl BitBox02Hal {
+    pub const fn new() -> Self {
+        Self {
+            ui: crate::workflow::RealWorkflows,
+            sd: BitBox02Sd,
+        }
+    }
+}
+
+impl Hal for BitBox02Hal {
+    fn ui(&mut self) -> &mut impl Ui {
+        &mut self.ui
+    }
+    fn sd(&mut self) -> &mut impl Sd {
+        &mut self.sd
+    }
+}
+
+#[cfg(feature = "testing")]
+pub mod testing {
+    pub struct TestingSd {
+        pub inserted: Option<bool>,
+    }
+
+    impl TestingSd {
+        pub fn new() -> Self {
+            Self { inserted: None }
+        }
+    }
+    pub struct TestingHal<'a> {
+        pub ui: crate::workflow::testing::TestingWorkflows<'a>,
+        pub sd: TestingSd,
+    }
+
+    impl super::Sd for TestingSd {
+        fn sdcard_inserted(&mut self) -> bool {
+            self.inserted.unwrap()
+        }
+    }
+
+    impl TestingHal<'_> {
+        pub fn new() -> Self {
+            Self {
+                ui: crate::workflow::testing::TestingWorkflows::new(),
+                sd: TestingSd::new(),
+            }
+        }
+    }
+
+    impl super::Hal for TestingHal<'_> {
+        fn ui(&mut self) -> &mut impl super::Ui {
+            &mut self.ui
+        }
+        fn sd(&mut self) -> &mut impl super::Sd {
+            &mut self.sd
+        }
+    }
+}

--- a/src/rust/bitbox02-rust/src/hww/api/cardano.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano.rs
@@ -24,21 +24,17 @@ mod xpubs;
 use super::pb;
 use super::Error;
 
-use crate::workflow::Workflows;
-
 use pb::cardano_request::Request;
 use pb::cardano_response::Response;
 
 /// Handle a Cardano protobuf api call.
-pub async fn process_api<W: Workflows>(
-    workflows: &mut W,
+pub async fn process_api(
+    hal: &mut impl crate::hal::Hal,
     request: &Request,
 ) -> Result<Response, Error> {
     match request {
         Request::Xpubs(ref request) => xpubs::process(request),
-        Request::Address(ref request) => address::process(workflows, request).await,
-        Request::SignTransaction(ref request) => {
-            sign_transaction::process(workflows, request).await
-        }
+        Request::Address(ref request) => address::process(hal, request).await,
+        Request::SignTransaction(ref request) => sign_transaction::process(hal, request).await,
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction/certificates.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/cardano/sign_transaction/certificates.rs
@@ -25,11 +25,12 @@ use pb::cardano_sign_transaction_request::{
     Certificate,
 };
 
-use crate::workflow::{confirm, Workflows};
+use crate::hal::Ui;
+use crate::workflow::confirm;
 use util::bip32::HARDENED;
 
-pub async fn verify<'a, W: Workflows>(
-    workflows: &mut W,
+pub async fn verify<'a>(
+    hal: &mut impl crate::hal::Hal,
     params: &params::Params,
     certificates: &'a [Certificate],
     bip44_account: u32,
@@ -42,7 +43,7 @@ pub async fn verify<'a, W: Workflows>(
                 validate_address_shelley_stake(keypath, Some(bip44_account))?;
                 signing_keypaths.push(keypath);
                 // 2 ADA will be deposited and refunded once delegation stops, independent of the staking rewards.
-                workflows
+                hal.ui()
                     .confirm(&confirm::Params {
                         title: params.name,
                         body: &format!(
@@ -59,7 +60,7 @@ pub async fn verify<'a, W: Workflows>(
                 validate_address_shelley_stake(keypath, Some(bip44_account))?;
                 signing_keypaths.push(keypath);
                 // 2 ADA will be refunded back, independent of the staking rewards.
-                workflows
+                hal.ui()
                     .confirm(&confirm::Params {
                         title: params.name,
                         body: &format!(
@@ -78,7 +79,7 @@ pub async fn verify<'a, W: Workflows>(
             }) => {
                 validate_address_shelley_stake(keypath, Some(bip44_account))?;
                 signing_keypaths.push(keypath);
-                workflows
+                hal.ui()
                     .confirm(&confirm::Params {
                         title: params.name,
                         body: &format!(
@@ -112,7 +113,7 @@ pub async fn verify<'a, W: Workflows>(
                     };
                 match drep_credhash {
                     Some(hash) => {
-                        workflows
+                        hal.ui()
                             .confirm(&confirm::Params {
                                 title: params.name,
                                 body: &format!(
@@ -128,7 +129,7 @@ pub async fn verify<'a, W: Workflows>(
                             .await?;
                     }
                     None => {
-                        workflows
+                        hal.ui()
                             .confirm(&confirm::Params {
                                 title: params.name,
                                 body: &format!(

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum.rs
@@ -30,8 +30,6 @@ mod signmsg;
 use super::pb;
 use super::Error;
 
-use crate::workflow::Workflows;
-
 use pb::eth_request::Request;
 use pb::eth_response::Response;
 
@@ -77,21 +75,19 @@ pub async fn antiklepto_get_host_nonce(
 ///
 /// Returns `None` if the call was not handled by Rust, in which case it should be handled by
 /// the C commander.
-pub async fn process_api<W: Workflows>(
-    workflows: &mut W,
+pub async fn process_api(
+    hal: &mut impl crate::hal::Hal,
     request: &Request,
 ) -> Result<Response, Error> {
     match request {
-        Request::Pub(ref request) => pubrequest::process(workflows, request).await,
-        Request::SignMsg(ref request) => signmsg::process(workflows, request).await,
-        Request::Sign(ref request) => {
-            sign::process(workflows, &sign::Transaction::Legacy(request)).await
-        }
+        Request::Pub(ref request) => pubrequest::process(hal, request).await,
+        Request::SignMsg(ref request) => signmsg::process(hal, request).await,
+        Request::Sign(ref request) => sign::process(hal, &sign::Transaction::Legacy(request)).await,
         Request::SignEip1559(ref request) => {
-            sign::process(workflows, &sign::Transaction::Eip1559(request)).await
+            sign::process(hal, &sign::Transaction::Eip1559(request)).await
         }
         Request::AntikleptoSignature(_) => Err(Error::InvalidInput),
-        Request::SignTypedMsg(ref request) => sign_typed_msg::process(workflows, request).await,
+        Request::SignTypedMsg(ref request) => sign_typed_msg::process(hal, request).await,
         Request::TypedMsgValue(_) => Err(Error::InvalidInput),
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs
@@ -14,8 +14,8 @@
 
 use super::params::Params;
 use super::Error;
-use crate::workflow::{confirm, Workflows};
-
+use crate::hal::Ui;
+use crate::workflow::confirm;
 use util::bip32::HARDENED;
 
 const ACCOUNT_MAX: u32 = 99; // 100 accounts
@@ -29,8 +29,8 @@ const ACCOUNT_MAX: u32 = 99; // 100 accounts
 /// A warning suffices so the user does not accidentally send e.g. mainnet coins to a testnet path
 /// (m/44'/1'/...). It is safe to make a transaction on the 'wrong' keypath as the chain id is
 /// unique and part of the transaction sighash.
-pub async fn warn_unusual_keypath<W: Workflows>(
-    workflows: &mut W,
+pub async fn warn_unusual_keypath(
+    hal: &mut impl crate::hal::Hal,
     params: &Params,
     title: &str,
     keypath: &[u32],
@@ -43,7 +43,8 @@ pub async fn warn_unusual_keypath<W: Workflows>(
             "Warning: unusual keypath {}. Proceed only if you know what you are doing.",
             util::bip32::to_string(keypath)
         );
-        return Ok(workflows
+        return Ok(hal
+            .ui()
             .confirm(&confirm::Params {
                 title,
                 body: &body,

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/params.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/params.rs
@@ -16,7 +16,8 @@ use super::pb;
 use super::Error;
 use pb::EthCoin;
 
-use crate::workflow::{confirm, Workflows};
+use crate::hal::Ui;
+use crate::workflow::confirm;
 
 use util::bip32::HARDENED;
 
@@ -124,8 +125,8 @@ pub fn is_known_network(coin: Option<EthCoin>, chain_id: u64) -> bool {
 /// If no params could be found and `chain_id` is non-zero, the user is asked to confirm the chain
 /// ID, and params with this chain ID and "UNKNOWN" name is returned. The main reason for this is
 /// that users can rescue funds sent on an unsupported network.
-pub async fn get_and_warn_unknown<W: Workflows>(
-    workflows: &mut W,
+pub async fn get_and_warn_unknown(
+    hal: &mut impl crate::hal::Hal,
     coin: Option<EthCoin>,
     chain_id: u64,
 ) -> Result<Params, Error> {
@@ -135,7 +136,7 @@ pub async fn get_and_warn_unknown<W: Workflows>(
             if chain_id == 0 {
                 Err(Error::InvalidInput)
             } else {
-                workflows
+                hal.ui()
                     .confirm(&confirm::Params {
                         title: "Warning",
                         body: &format!("Unknown network\nwith chain ID:\n{}", chain_id),
@@ -143,7 +144,7 @@ pub async fn get_and_warn_unknown<W: Workflows>(
                         ..Default::default()
                     })
                     .await?;
-                workflows
+                hal.ui()
                     .confirm(&confirm::Params {
                         title: "Warning",
                         body: "Only proceed if\nyou recognize\nthis chain ID.",

--- a/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_mnemonic_passphrase_enabled.rs
@@ -17,10 +17,11 @@ use crate::pb;
 
 use pb::response::Response;
 
-use crate::workflow::{confirm, Workflows};
+use crate::hal::Ui;
+use crate::workflow::confirm;
 
-pub async fn process<W: Workflows>(
-    workflows: &mut W,
+pub async fn process(
+    hal: &mut impl crate::hal::Hal,
     &pb::SetMnemonicPassphraseEnabledRequest { enabled }: &pb::SetMnemonicPassphraseEnabledRequest,
 ) -> Result<Response, Error> {
     let params = confirm::Params {
@@ -30,7 +31,7 @@ pub async fn process<W: Workflows>(
         ..Default::default()
     };
 
-    workflows.confirm(&params).await?;
+    hal.ui().confirm(&params).await?;
 
     if bitbox02::memory::set_mnemonic_passphrase_enabled(enabled).is_err() {
         return Err(Error::Memory);
@@ -44,7 +45,8 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use crate::workflow::testing::{Screen, TestingWorkflows};
+    use crate::hal::testing::TestingHal;
+    use crate::workflow::testing::Screen;
     use alloc::boxed::Box;
     use bitbox02::testing::mock_memory;
 
@@ -53,16 +55,16 @@ mod tests {
         // All good.
         mock_memory();
         // Enable:
-        let mut mock_workflows = TestingWorkflows::new();
+        let mut mock_hal = TestingHal::new();
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetMnemonicPassphraseEnabledRequest { enabled: true }
             )),
             Ok(Response::Success(pb::Success {}))
         );
         assert_eq!(
-            mock_workflows.screens,
+            mock_hal.ui.screens,
             vec![Screen::Confirm {
                 title: "Enable".into(),
                 body: "Optional\npassphrase".into(),
@@ -72,16 +74,16 @@ mod tests {
 
         assert!(bitbox02::memory::is_mnemonic_passphrase_enabled());
         // Disable:
-        let mut mock_workflows = TestingWorkflows::new();
+        let mut mock_hal = TestingHal::new();
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetMnemonicPassphraseEnabledRequest { enabled: false }
             )),
             Ok(Response::Success(pb::Success {}))
         );
         assert_eq!(
-            mock_workflows.screens,
+            mock_hal.ui.screens,
             vec![Screen::Confirm {
                 title: "Disable".into(),
                 body: "Optional\npassphrase".into(),
@@ -91,11 +93,11 @@ mod tests {
         assert!(!bitbox02::memory::is_mnemonic_passphrase_enabled());
 
         // User aborted confirmation.
-        let mut mock_workflows = TestingWorkflows::new();
-        mock_workflows.abort_nth(0);
+        let mut mock_hal = TestingHal::new();
+        mock_hal.ui.abort_nth(0);
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetMnemonicPassphraseEnabledRequest { enabled: true }
             )),
             Err(Error::UserAbort)

--- a/src/rust/bitbox02-rust/src/hww/api/set_password.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_password.rs
@@ -15,7 +15,9 @@
 use super::Error;
 use crate::pb;
 
-use crate::workflow::{password, unlock, Workflows};
+use crate::hal::Ui;
+use crate::workflow::{password, unlock};
+
 use bitbox02::keystore;
 use pb::response::Response;
 
@@ -26,22 +28,22 @@ use pb::response::Response;
 /// seed. If 16 bytes are provided, the seed will also be 16 bytes long, corresponding to 12 BIP39
 /// recovery words. If 32 bytes are provided, the seed will also be 32 bytes long, corresponding to
 /// 24 BIP39 recovery words.
-pub async fn process<W: Workflows>(
-    workflows: &mut W,
+pub async fn process(
+    hal: &mut impl crate::hal::Hal,
     pb::SetPasswordRequest { entropy }: &pb::SetPasswordRequest,
 ) -> Result<Response, Error> {
     if entropy.len() != 16 && entropy.len() != 32 {
         return Err(Error::InvalidInput);
     }
-    let password = password::enter_twice(workflows).await?;
+    let password = password::enter_twice(hal).await?;
     if let Err(err) = keystore::create_and_store_seed(&password, entropy) {
-        workflows.status(&format!("Error\n{:?}", err), false).await;
+        hal.ui().status(&format!("Error\n{:?}", err), false).await;
         return Err(Error::Generic);
     }
     if keystore::unlock(&password).is_err() {
         panic!("Unexpected error during restore: unlock failed.");
     }
-    unlock::unlock_bip39(workflows).await;
+    unlock::unlock_bip39(hal).await;
     Ok(Response::Success(pb::Success {}))
 }
 
@@ -50,8 +52,8 @@ mod tests {
     use super::*;
 
     use crate::bb02_async::block_on;
-    use crate::workflow::testing::TestingWorkflows;
-    use bitbox02::testing::{mock, mock_memory, Data};
+    use crate::hal::testing::TestingHal;
+    use bitbox02::testing::mock_memory;
 
     use alloc::boxed::Box;
 
@@ -60,8 +62,8 @@ mod tests {
         mock_memory();
         keystore::lock();
         let mut counter = 0u32;
-        let mut mock_workflows = TestingWorkflows::new();
-        mock_workflows.set_enter_string(Box::new(|params| {
+        let mut mock_hal = TestingHal::new();
+        mock_hal.ui.set_enter_string(Box::new(|params| {
             counter += 1;
             match counter {
                 1 => assert_eq!(params.title, "Set password"),
@@ -72,14 +74,14 @@ mod tests {
         }));
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetPasswordRequest {
                     entropy: b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_vec(),
                 }
             )),
             Ok(Response::Success(pb::Success {}))
         );
-        drop(mock_workflows); // to remove mutable borrow of counter
+        drop(mock_hal); // to remove mutable borrow of counter
         assert_eq!(counter, 2);
         assert!(!keystore::is_locked());
         assert!(keystore::copy_seed().unwrap().len() == 32);
@@ -90,11 +92,13 @@ mod tests {
     fn test_process_16_bytes() {
         mock_memory();
         keystore::lock();
-        let mut mock_workflows = TestingWorkflows::new();
-        mock_workflows.set_enter_string(Box::new(|_params| Ok("password".into())));
+        let mut mock_hal = TestingHal::new();
+        mock_hal
+            .ui
+            .set_enter_string(Box::new(|_params| Ok("password".into())));
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetPasswordRequest {
                     entropy: b"aaaaaaaaaaaaaaaa".to_vec(),
                 }
@@ -110,12 +114,14 @@ mod tests {
     fn test_process_invalid_host_entropy() {
         mock_memory();
         keystore::lock();
-        let mut mock_workflows = TestingWorkflows::new();
-        mock_workflows.set_enter_string(Box::new(|_params| Ok("password".into())));
+        let mut mock_hal = TestingHal::new();
+        mock_hal
+            .ui
+            .set_enter_string(Box::new(|_params| Ok("password".into())));
         assert!(keystore::is_locked());
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetPasswordRequest {
                     entropy: b"aaaaaaaaaaaaaaaaa".to_vec(),
                 }
@@ -130,8 +136,8 @@ mod tests {
         mock_memory();
         keystore::lock();
         let mut counter = 0u32;
-        let mut mock_workflows = TestingWorkflows::new();
-        mock_workflows.set_enter_string(Box::new(|_params| {
+        let mut mock_hal = TestingHal::new();
+        mock_hal.ui.set_enter_string(Box::new(|_params| {
             counter += 1;
             Ok(match counter {
                 1 => "password".into(),
@@ -141,7 +147,7 @@ mod tests {
         }));
         assert_eq!(
             block_on(process(
-                &mut mock_workflows,
+                &mut mock_hal,
                 &pb::SetPasswordRequest {
                     entropy: b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_vec(),
                 }

--- a/src/rust/bitbox02-rust/src/lib.rs
+++ b/src/rust/bitbox02-rust/src/lib.rs
@@ -31,6 +31,7 @@ pub mod attestation;
 pub mod backup;
 pub mod bb02_async;
 mod bip32;
+pub mod hal;
 pub mod hww;
 pub mod keystore;
 mod version;

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic_c_unit_tests.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic_c_unit_tests.rs
@@ -14,12 +14,11 @@
 
 pub use super::cancel::Error as CancelError;
 
-use crate::workflow::Workflows;
 use alloc::string::String;
 use alloc::string::ToString;
 
-pub async fn show_and_confirm_mnemonic<W: Workflows>(
-    _workflows: &mut W,
+pub async fn show_and_confirm_mnemonic(
+    _hal: &mut impl crate::hal::Hal,
     words: &[&str],
 ) -> Result<(), CancelError> {
     for word in words.iter() {
@@ -30,8 +29,8 @@ pub async fn show_and_confirm_mnemonic<W: Workflows>(
     Ok(())
 }
 
-pub async fn get<W: Workflows>(
-    _workflows: &mut W,
+pub async fn get(
+    _hal: &mut impl crate::hal::Hal,
 ) -> Result<zeroize::Zeroizing<String>, CancelError> {
     let words = "boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple enact box walk height pull today solid off enable tide";
     bitbox02::println_stdout("Restored from recovery words below:");

--- a/src/rust/bitbox02-rust/src/workflow/transaction.rs
+++ b/src/rust/bitbox02-rust/src/workflow/transaction.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::hal::Ui;
+
 use crate::bb02_async::option_no_screensaver;
 use core::cell::RefCell;
 
@@ -54,8 +56,8 @@ pub async fn verify_total_fee(total: &str, fee: &str, longtouch: bool) -> Result
     option_no_screensaver(&result).await
 }
 
-pub async fn verify_total_fee_maybe_warn<W: super::Workflows>(
-    workflows: &mut W,
+pub async fn verify_total_fee_maybe_warn(
+    hal: &mut impl crate::hal::Hal,
     total: &str,
     fee: &str,
     fee_percentage: Option<f64>,
@@ -63,10 +65,11 @@ pub async fn verify_total_fee_maybe_warn<W: super::Workflows>(
     const FEE_WARNING_THRESHOLD: f64 = 10.;
     let fee_percentage = fee_percentage.filter(|&f| f >= FEE_WARNING_THRESHOLD);
     let longtouch = fee_percentage.is_none();
-    workflows.verify_total_fee(total, fee, longtouch).await?;
+    hal.ui().verify_total_fee(total, fee, longtouch).await?;
 
     if let Some(fee_percentage) = fee_percentage {
-        match workflows
+        match hal
+            .ui()
             .confirm(&super::confirm::Params {
                 title: "High fee",
                 body: &format!(

--- a/src/rust/bitbox02-rust/src/workflow/verify_message.rs
+++ b/src/rust/bitbox02-rust/src/workflow/verify_message.rs
@@ -40,8 +40,8 @@ impl core::convert::From<confirm::UserAbort> for Error {
 /// line screens, suffixed with the progress label (e.g. 1/3).
 ///
 /// is_final if this is the final step in a workflow. In this case,
-pub async fn verify<W: Workflows>(
-    workflows: &mut W,
+pub async fn verify(
+    hal: &mut impl crate::hal::Hal,
     title_long: &str,
     title_short: &str,
     msg: &[u8],
@@ -70,7 +70,7 @@ pub async fn verify<W: Workflows>(
                 longtouch: is_last && is_final,
                 ..Default::default()
             };
-            workflows.confirm(&params).await?;
+            hal.ui().confirm(&params).await?;
         }
         Ok(())
     } else {
@@ -83,7 +83,7 @@ pub async fn verify<W: Workflows>(
             longtouch: is_final,
             ..Default::default()
         };
-        workflows.confirm(&params).await?;
+        hal.ui().confirm(&params).await?;
         Ok(())
     }
 }

--- a/src/rust/bitbox02/src/sd.rs
+++ b/src/rust/bitbox02/src/sd.rs
@@ -19,15 +19,8 @@ use alloc::vec::Vec;
 use crate::util::str_to_cstr_vec;
 use bitbox02_sys::SD_MAX_FILE_SIZE;
 
-#[cfg(not(feature = "testing"))]
 pub fn sdcard_inserted() -> bool {
     unsafe { bitbox02_sys::sd_card_inserted() }
-}
-
-#[cfg(feature = "testing")]
-pub fn sdcard_inserted() -> bool {
-    let data = crate::testing::DATA.0.borrow();
-    data.sdcard_inserted.unwrap()
 }
 
 struct SdList(bitbox02_sys::sd_list_t);

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -14,30 +14,7 @@
 
 //! Small mocking infrastructure for testing.
 
-extern crate alloc;
-use core::cell::RefCell;
-
 use crate::keystore;
-
-#[derive(Default)]
-pub struct Data {
-    pub sdcard_inserted: Option<bool>,
-}
-
-pub struct SafeData(pub RefCell<Data>);
-
-// Safety: must not be accessed concurrently.
-unsafe impl Sync for SafeData {}
-
-pub static DATA: SafeData = SafeData(RefCell::new(Data {
-    sdcard_inserted: None,
-}));
-
-/// Provide mock implementations and data. This also locks the keystore - use `mock_unlocked()` to mock a seeded and unlocked keystore.
-pub fn mock(data: Data) {
-    *DATA.0.borrow_mut() = data;
-    keystore::lock();
-}
 
 /// This mocks an unlocked keystore with the given bip39 recovery words and bip39 passphrase.
 pub fn mock_unlocked_using_mnemonic(mnemonic: &str, passphrase: &str) {


### PR DESCRIPTION
We want to inject deps into, for BB02, testing and in the future for
other BitBox products.

For this we create a Hal trait that can be used anywhere with
`&mut impl Hal`, without needing to repeat the trait bounds in
every function.

The alternative was to have a trait that contains all functions, which
did not seem like a good thing for modularity.

Another alternative was to colour every function with `<U: Ui,
S: Sd, ...>` trait bounds, which is ugly and does not scale to more
traits easily.

The `Workflows` trait is renamed to `Ui` (in the `hal` module only for
now, later we will untangle the workflows module and rename things
there too).
