### PR TITLE
hal: add rest of the functions to the Sd trait

### DIFF
--- a/src/rust/bitbox02-rust/src/hal.rs
+++ b/src/rust/bitbox02-rust/src/hal.rs
@@ -15,8 +15,15 @@
 use crate::workflow::RealWorkflows;
 pub use crate::workflow::Workflows as Ui;
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 pub trait Sd {
     fn sdcard_inserted(&mut self) -> bool;
+    fn list_subdir(&mut self, subdir: Option<&str>) -> Result<Vec<String>, ()>;
+    fn erase_file_in_subdir(&mut self, filename: &str, dir: &str) -> Result<(), ()>;
+    fn load_bin(&mut self, filename: &str, dir: &str) -> Result<zeroize::Zeroizing<Vec<u8>>, ()>;
+    fn write_bin(&mut self, filename: &str, dir: &str, data: &[u8]) -> Result<(), ()>;
 }
 
 /// Hardware abstraction layer for BitBox devices.
@@ -28,8 +35,29 @@ pub trait Hal {
 pub struct BitBox02Sd;
 
 impl Sd for BitBox02Sd {
+    #[inline(always)]
     fn sdcard_inserted(&mut self) -> bool {
         bitbox02::sd::sdcard_inserted()
+    }
+
+    #[inline(always)]
+    fn list_subdir(&mut self, subdir: Option<&str>) -> Result<Vec<String>, ()> {
+        bitbox02::sd::list_subdir(subdir)
+    }
+
+    #[inline(always)]
+    fn erase_file_in_subdir(&mut self, filename: &str, dir: &str) -> Result<(), ()> {
+        bitbox02::sd::erase_file_in_subdir(filename, dir)
+    }
+
+    #[inline(always)]
+    fn load_bin(&mut self, filename: &str, dir: &str) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+        bitbox02::sd::load_bin(filename, dir)
+    }
+
+    #[inline(always)]
+    fn write_bin(&mut self, filename: &str, dir: &str, data: &[u8]) -> Result<(), ()> {
+        bitbox02::sd::write_bin(filename, dir, data)
     }
 }
 
@@ -58,24 +86,71 @@ impl Hal for BitBox02Hal {
 
 #[cfg(feature = "testing")]
 pub mod testing {
+    use alloc::collections::BTreeMap;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
     pub struct TestingSd {
         pub inserted: Option<bool>,
+        files: BTreeMap<String, BTreeMap<String, Vec<u8>>>,
     }
 
     impl TestingSd {
         pub fn new() -> Self {
-            Self { inserted: None }
+            Self {
+                inserted: None,
+                files: BTreeMap::new(),
+            }
         }
-    }
-    pub struct TestingHal<'a> {
-        pub ui: crate::workflow::testing::TestingWorkflows<'a>,
-        pub sd: TestingSd,
     }
 
     impl super::Sd for TestingSd {
         fn sdcard_inserted(&mut self) -> bool {
             self.inserted.unwrap()
         }
+
+        fn list_subdir(&mut self, subdir: Option<&str>) -> Result<Vec<String>, ()> {
+            match subdir {
+                Some(key) => Ok(self
+                    .files
+                    .get(key)
+                    .map(|files| files.keys().cloned().collect())
+                    .unwrap_or_default()),
+                None => Ok(self.files.keys().cloned().collect()),
+            }
+        }
+
+        fn erase_file_in_subdir(&mut self, filename: &str, dir: &str) -> Result<(), ()> {
+            self.files
+                .get_mut(dir)
+                .and_then(|files| files.remove(filename).map(|_| ()))
+                .ok_or(())
+        }
+
+        fn load_bin(
+            &mut self,
+            filename: &str,
+            dir: &str,
+        ) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
+            self.files
+                .get(dir)
+                .and_then(|files| files.get(filename))
+                .map(|data| zeroize::Zeroizing::new(data.clone()))
+                .ok_or(())
+        }
+
+        fn write_bin(&mut self, filename: &str, dir: &str, data: &[u8]) -> Result<(), ()> {
+            self.files
+                .entry(dir.into())
+                .or_default()
+                .insert(filename.into(), data.to_vec());
+            Ok(())
+        }
+    }
+
+    pub struct TestingHal<'a> {
+        pub ui: crate::workflow::testing::TestingWorkflows<'a>,
+        pub sd: TestingSd,
     }
 
     impl TestingHal<'_> {
@@ -93,6 +168,37 @@ pub mod testing {
         }
         fn sd(&mut self) -> &mut impl super::Sd {
             &mut self.sd
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::hal::Sd;
+
+        // Quick check if our mock TestingSd implementation makes sense.
+        #[test]
+        fn test_sd_list_write_read_erase() {
+            let mut sd = TestingSd::new();
+            assert_eq!(sd.list_subdir(None), Ok(vec![]));
+            assert_eq!(sd.list_subdir(Some("dir1")), Ok(vec![]));
+
+            assert!(sd.load_bin("file1.txt", "dir1").is_err());
+            assert!(sd.write_bin("file1.txt", "dir1", b"data").is_ok());
+            assert_eq!(sd.list_subdir(None), Ok(vec!["dir1".into()]));
+            assert_eq!(sd.list_subdir(Some("dir1")), Ok(vec!["file1.txt".into()]));
+            assert_eq!(
+                sd.load_bin("file1.txt", "dir1").unwrap().as_slice(),
+                b"data"
+            );
+            assert!(sd.write_bin("file1.txt", "dir1", b"replaced data").is_ok());
+            assert_eq!(
+                sd.load_bin("file1.txt", "dir1").unwrap().as_slice(),
+                b"replaced data"
+            );
+            assert!(sd.erase_file_in_subdir("doesnt-exist.txt", "dir1").is_err());
+            assert!(sd.erase_file_in_subdir("file1.txt", "dir1").is_ok());
+            assert_eq!(sd.list_subdir(Some("dir1")), Ok(vec![]));
         }
     }
 }

--- a/src/rust/bitbox02-rust/src/hww.rs
+++ b/src/rust/bitbox02-rust/src/hww.rs
@@ -139,7 +139,7 @@ mod tests {
     use crate::bb02_async::block_on;
     use crate::hal::testing::TestingHal;
     use crate::workflow::testing::Screen;
-    use bitbox02::testing::{mock_memory, mock_sd};
+    use bitbox02::testing::mock_memory;
 
     use prost::Message;
 
@@ -236,7 +236,6 @@ mod tests {
     #[test]
     fn test_noise() {
         mock_memory();
-        mock_sd();
         let mut make_request = init_noise();
         let request = crate::pb::Request {
             request: Some(crate::pb::request::Request::ListBackups(
@@ -477,7 +476,6 @@ mod tests {
         ] {
             bitbox02::keystore::lock();
             mock_memory();
-            mock_sd();
 
             bitbox02::memory::set_device_name("test device name").unwrap();
 
@@ -508,8 +506,7 @@ mod tests {
                 }]
             );
 
-            let mut mock_hal = TestingHal::new();
-            mock_hal.sd.inserted = Some(true);
+            mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             make_request(
                 &mut mock_hal,
                 (crate::pb::Request {
@@ -541,7 +538,7 @@ mod tests {
 
             let seed = bitbox02::keystore::copy_seed().unwrap();
             assert_eq!(seed.len(), host_entropy.len());
-            let mut mock_hal = TestingHal::new();
+            mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             assert!(matches!(
                 crate::pb::Response::decode(
                     make_request(
@@ -566,7 +563,7 @@ mod tests {
             ));
             assert_eq!(mock_hal.ui.screens, vec![]);
 
-            let mut mock_hal = TestingHal::new();
+            mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             make_request(
                 &mut mock_hal,
                 (crate::pb::Request {
@@ -587,7 +584,7 @@ mod tests {
                 }]
             );
 
-            let mut mock_hal = TestingHal::new();
+            mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             assert!(matches!(
                 crate::pb::Response::decode(
                     make_request(
@@ -612,7 +609,7 @@ mod tests {
             ));
             assert_eq!(mock_hal.ui.screens, vec![]);
 
-            let mut mock_hal = TestingHal::new();
+            mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             let backup_id = match crate::pb::Response::decode(
                 make_request(
                     &mut mock_hal,
@@ -647,7 +644,7 @@ mod tests {
             };
             assert_eq!(mock_hal.ui.screens, vec![]);
 
-            let mut mock_hal = TestingHal::new();
+            mock_hal.ui = crate::workflow::testing::TestingWorkflows::new();
             mock_hal
                 .ui
                 .set_enter_string(Box::new(|_params| Ok("password".into())));

--- a/src/rust/bitbox02-rust/src/hww/api.rs
+++ b/src/rust/bitbox02-rust/src/hww/api.rs
@@ -46,6 +46,8 @@ use pb::request::Request;
 use pb::response::Response;
 use prost::Message;
 
+use crate::hal::Sd;
+
 /// Encodes a protobuf Response message.
 pub fn encode(response: Response) -> Vec<u8> {
     let response = pb::Response {
@@ -168,9 +170,9 @@ async fn process_api(hal: &mut impl crate::hal::Hal, request: &Request) -> Resul
             set_mnemonic_passphrase_enabled::process(hal, request).await
         }
         Request::InsertRemoveSdcard(ref request) => sdcard::process(hal, request).await,
-        Request::ListBackups(_) => backup::list(),
+        Request::ListBackups(_) => backup::list(hal),
         Request::CheckSdcard(_) => Ok(Response::CheckSdcard(pb::CheckSdCardResponse {
-            inserted: bitbox02::sd::sdcard_inserted(),
+            inserted: hal.sd().sdcard_inserted(),
         })),
         Request::CheckBackup(ref request) => backup::check(hal, request).await,
         Request::CreateBackup(ref request) => backup::create(hal, request).await,

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -34,7 +34,7 @@ pub async fn from_file(
         })
         .await?;
 
-    let (data, metadata) = match crate::backup::load(&request.id) {
+    let (data, metadata) = match crate::backup::load(hal, &request.id) {
         Ok(d) => d,
         Err(_) => {
             hal.ui().status("Could not\nrestore backup", false).await;

--- a/src/rust/bitbox02/src/sd.rs
+++ b/src/rust/bitbox02/src/sd.rs
@@ -102,11 +102,12 @@ pub fn write_bin(filename: &str, dir: &str, data: &[u8]) -> Result<(), ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::mock_sd;
 
     #[test]
     fn test_list_write_read_erase() {
-        mock_sd();
+        unsafe {
+            bitbox02_sys::sd_format();
+        }
 
         assert_eq!(list_subdir(None), Ok(vec![]));
         assert_eq!(list_subdir(Some("dir1")), Ok(vec![]));

--- a/src/rust/bitbox02/src/testing.rs
+++ b/src/rust/bitbox02/src/testing.rs
@@ -33,13 +33,6 @@ pub fn mock_unlocked() {
     mock_unlocked_using_mnemonic(TEST_MNEMONIC, "")
 }
 
-/// This mounts a new FAT32 volume in RAM for use in unit tests. As there is only one volume, access only serially.
-pub fn mock_sd() {
-    unsafe {
-        bitbox02_sys::sd_format();
-    }
-}
-
 unsafe extern "C" fn c_mock_random_32_bytes(buf_out: *mut u8) {
     let s = core::slice::from_raw_parts_mut(buf_out, 32);
     s.copy_from_slice(b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");


### PR DESCRIPTION
And use the hal layer to access sdcard. This allows local mocking in unit tests and other BitBox products to plug their own impl.