### PR TITLE
keystore: remove unused KDF_NUM_ITERATIONS define

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -30,10 +30,6 @@
 #include <secp256k1_extrakeys.h>
 #include <secp256k1_schnorrsig.h>
 
-// This number of KDF iterations on the 2nd kdf slot when stretching the device
-// password.
-#define KDF_NUM_ITERATIONS (2)
-
 // Change this ONLY via keystore_unlock() or keystore_lock()
 static bool _is_unlocked_device = false;
 // Stores a random key after unlock which, after stretching, is used to encrypt the retained seed.


### PR DESCRIPTION
In 75cb766d903d48ad76409edf07d85bfde82685d5 it was refactored to be a secure-chip implementation detail.