### PR TITLE
simulator: enable Litecoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - Ethereum: add confirmation screen for known networks, change base unit to ETH for Arbitrum and Optimism
 - Ethereum: add Base and Gnosis Chain to known networks
 - Bitcoin: enable message signing on testnet and regtest
+- Enable Litecoin in the simulator
 
 ### 9.22.0
 - Update manufacturer HID descriptor to bitbox.swiss

--- a/src/rust/bitbox02-rust-c/Cargo.toml
+++ b/src/rust/bitbox02-rust-c/Cargo.toml
@@ -55,6 +55,7 @@ target-factory-setup = [
 target-c-unit-tests = [
   "dep:bitcoin", # for rust_base58_encode_check()
   "app-bitcoin",
+  "app-litecoin",
   "app-ethereum",
   "app-cardano",
   "firmware",


### PR DESCRIPTION
Was accidentally not included in the simulator, which is supposed to simulate the Multi edition.