### PR TITLE
ble-bootloader: Add device name to default screen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,12 +141,12 @@ set(QTOUCH-SOURCES ${DRIVER-SOURCES} PARENT_SCOPE)
 
 # The additional files required for the plus platform
 set(PLATFORM-BITBOX02-PLUS-SOURCES
-  ${CMAKE_SOURCE_DIR}/src/uart.c
+  ${CMAKE_SOURCE_DIR}/src/communication_mode.c
   ${CMAKE_SOURCE_DIR}/src/da14531/crc.c
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531.c
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531_protocol.c
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531_handler.c
-  ${CMAKE_SOURCE_DIR}/src/communication_mode.c
+  ${CMAKE_SOURCE_DIR}/src/uart.c
 )
 set(PLATFORM-BITBOX02-PLUS-SOURCES ${PLATFORM-BITBOX02-PLUS-SOURCES} PARENT_SCOPE)
 

--- a/src/bootloader/bootloader.c
+++ b/src/bootloader/bootloader.c
@@ -19,6 +19,7 @@
 
 #include <driver_init.h>
 #include <flags.h>
+#include <memory/memory.h>
 #include <memory/memory_shared.h>
 #include <memory/nvmctrl.h>
 #include <pukcc/curve_p256.h>
@@ -41,6 +42,7 @@
 #endif
 
 #if PLATFORM_BITBOX02PLUS == 1
+#include <communication_mode.h>
 #include <da14531/da14531.h>
 #include <da14531/da14531_protocol.h>
 #include <uart.h>
@@ -336,10 +338,22 @@ void bootloader_render_default_screen(void)
 {
     UG_ClearBuffer();
     _load_logo();
+#if PLATFORM_BITBOX02PLUS == 1
+    UG_PutString(0, SCREEN_HEIGHT - 9 * 2 - 5, "See the BitBoxApp", false);
+    if (communication_mode_ble_enabled() &&
+        da14531_connected_state < DA14531_CONNECTED_CONNECTED_SECURED) {
+        char buf[MEMORY_DEVICE_NAME_MAX_LEN] = {0};
+        memory_random_name(buf);
+        UG_PutString(0, SCREEN_HEIGHT - 9, buf, false);
+    } else if (_is_app_flash_empty) {
+        UG_PutString(0, SCREEN_HEIGHT - 9, "Let's get started!", false);
+    }
+#else
     if (_is_app_flash_empty) {
         UG_PutString(0, SCREEN_HEIGHT - 9 * 2, "Let's get started!", false);
     }
     UG_PutString(0, SCREEN_HEIGHT - 9, "See the BitBoxApp", false);
+#endif
     UG_SendBuffer();
 }
 
@@ -356,7 +370,6 @@ void bootloader_render_ble_confirm_screen(bool confirmed)
     snprintf(code_str, sizeof(code_str), "%06u", (unsigned)pairing_code_int);
     UG_ClearBuffer();
     uint16_t check_width = IMAGE_DEFAULT_CHECKMARK_HEIGHT + IMAGE_DEFAULT_CHECKMARK_HEIGHT / 2 - 1;
-    UG_FontSelect(&font_font_a_11X10);
     if (confirmed) {
         UG_PutString(15, 0, "Confirm on app", false);
     } else {
@@ -366,6 +379,7 @@ void bootloader_render_ble_confirm_screen(bool confirmed)
     }
     UG_FontSelect(&font_monogram_5X9);
     UG_PutString(45, SCREEN_HEIGHT / 2 - 9, code_str, false);
+    UG_FontSelect(&font_font_a_9X9);
     UG_SendBuffer();
 }
 #endif

--- a/src/da14531/da14531.c
+++ b/src/da14531/da14531.c
@@ -17,6 +17,8 @@
 #include "util.h"
 #include "utils_ringbuffer.h"
 
+enum da14531_connected_state da14531_connected_state = DA14531_CONNECTED_ADVERTISING;
+
 void da14531_reset(struct ringbuffer* uart_out)
 {
     util_log("da14531_reset");
@@ -58,6 +60,34 @@ void da14531_set_product(
     uint8_t tmp[128];
     uint16_t tmp_len = da14531_protocol_format(
         &tmp[0], sizeof(tmp), DA14531_PROTOCOL_PACKET_TYPE_CTRL_DATA, &payload[0], 1 + product_len);
+    ASSERT(tmp_len <= sizeof(tmp));
+    ASSERT(ringbuffer_num(uart_out) + tmp_len <= uart_out->size);
+    for (int i = 0; i < tmp_len; i++) {
+        ringbuffer_put(uart_out, tmp[i]);
+    }
+}
+
+void da14531_set_name(const char* name, size_t name_len, struct ringbuffer* uart_out)
+{
+    uint8_t payload[64] = {0};
+    payload[0] = CTRL_CMD_DEVICE_NAME;
+    memcpy(&payload[1], name, name_len);
+    uint8_t tmp[128];
+    uint16_t tmp_len = da14531_protocol_format(
+        &tmp[0], sizeof(tmp), DA14531_PROTOCOL_PACKET_TYPE_CTRL_DATA, &payload[0], 1 + name_len);
+    ASSERT(tmp_len <= sizeof(tmp));
+    ASSERT(ringbuffer_num(uart_out) + tmp_len <= uart_out->size);
+    for (int i = 0; i < tmp_len; i++) {
+        ringbuffer_put(uart_out, tmp[i]);
+    }
+}
+
+void da14531_get_connection_state(struct ringbuffer* uart_out)
+{
+    uint8_t payload = CTRL_CMD_BLE_STATUS;
+    uint8_t tmp[16];
+    uint16_t tmp_len = da14531_protocol_format(
+        &tmp[0], sizeof(tmp), DA14531_PROTOCOL_PACKET_TYPE_CTRL_DATA, &payload, 1);
     ASSERT(tmp_len <= sizeof(tmp));
     ASSERT(ringbuffer_num(uart_out) + tmp_len <= uart_out->size);
     for (int i = 0; i < tmp_len; i++) {

--- a/src/da14531/da14531.h
+++ b/src/da14531/da14531.h
@@ -32,6 +32,14 @@
 #define CTRL_CMD_BLE_POWER_DOWN 12
 #define CTRL_CMD_DEBUG 254
 
+enum da14531_connected_state {
+    DA14531_CONNECTED_ADVERTISING = 0,
+    DA14531_CONNECTED_CONNECTED = 1,
+    DA14531_CONNECTED_CONNECTED_SECURED = 2,
+};
+
+extern enum da14531_connected_state da14531_connected_state;
+
 void da14531_power_down(struct ringbuffer* uart_out);
 
 void da14531_reset(struct ringbuffer* uart_out);
@@ -43,5 +51,9 @@ void da14531_set_product(
     volatile const uint8_t* product,
     volatile uint16_t product_len,
     struct ringbuffer* uart_out);
+
+void da14531_set_name(const char* name, size_t name_len, struct ringbuffer* uart_out);
+
+void da14531_get_connection_state(struct ringbuffer* uart_out);
 
 #endif

--- a/src/da14531/da14531_handler.c
+++ b/src/da14531/da14531_handler.c
@@ -163,13 +163,16 @@ static void _ctrl_handler(struct da14531_ctrl_frame* frame, struct ringbuffer* q
 #endif
     } break;
     case CTRL_CMD_BLE_STATUS:
+        if (frame->cmd_data[0] <= DA14531_CONNECTED_CONNECTED_SECURED) {
+            da14531_connected_state = frame->cmd_data[0];
+        }
         // util_log("da14531: BLE status update");
 #if defined(BOOTLOADER)
         bootloader_pairing_request = false;
         bootloader_render_default_screen();
 #endif
         switch (frame->cmd_data[0]) {
-        case 0:
+        case DA14531_CONNECTED_ADVERTISING:
             util_log("da14531: adveritising");
 #if !defined(BOOTLOADER)
             if (_ble_pairing_component != NULL && ui_screen_stack_top() == _ble_pairing_component) {
@@ -179,10 +182,10 @@ static void _ctrl_handler(struct da14531_ctrl_frame* frame, struct ringbuffer* q
 #endif
             break;
 #if !defined(NDEBUG)
-        case 1:
+        case DA14531_CONNECTED_CONNECTED:
             util_log("da14531: connected");
             break;
-        case 2:
+        case DA14531_CONNECTED_CONNECTED_SECURED:
             util_log("da14531: connected secure");
             break;
 #endif


### PR DESCRIPTION
The user needs the device name to pair

requires ble firmware v3