### PR TITLE
da14531: invalid firmware

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 set(DBB-FIRMWARE-SOURCES
   ${CMAKE_SOURCE_DIR}/src/bip32.c
-  ${CMAKE_SOURCE_DIR}/src/communication_mode.c
   ${CMAKE_SOURCE_DIR}/src/firmware_main_loop.c
   ${CMAKE_SOURCE_DIR}/src/keystore.c
   ${CMAKE_SOURCE_DIR}/src/random.c
@@ -146,6 +145,7 @@ set(PLATFORM-BITBOX02-PLUS-SOURCES
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531.c
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531_protocol.c
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531_handler.c
+  ${CMAKE_SOURCE_DIR}/src/communication_mode.c
 )
 set(PLATFORM-BITBOX02-PLUS-SOURCES ${PLATFORM-BITBOX02-PLUS-SOURCES} PARENT_SCOPE)
 

--- a/src/da14531/da14531_protocol.c
+++ b/src/da14531/da14531_protocol.c
@@ -18,6 +18,7 @@
 #include "platform_config.h"
 #include "uart.h"
 #include "util.h"
+#include <communication_mode.h>
 #include <stdlib.h>
 #include <utils_assert.h>
 #ifndef TESTING
@@ -139,7 +140,8 @@ static void _firmware_loader_poll(
     case FIRMWARE_LOADER_STATE_IDLE:
         if (ble_fw == NULL) {
             if (!memory_spi_get_active_ble_firmware(&ble_fw, &ble_fw_size, &ble_fw_checksum)) {
-                Abort("TODO");
+                communication_mode_ble_disable();
+                util_log("da14531: no valid firmware");
             }
             *buf_in_len = 0;
             break;

--- a/src/memory/memory_spi.c
+++ b/src/memory/memory_spi.c
@@ -48,6 +48,8 @@ bool memory_spi_get_active_ble_firmware(
         if (!MEMEQ(fw_hash, metadata.allowed_firmware_hash, 32)) {
             free(*firmware_out);
             *firmware_out = NULL;
+            // TODO: Register this error with some component that can report the error to the end
+            // user.
             return false;
         }
     }
@@ -58,6 +60,8 @@ bool memory_spi_get_active_ble_firmware(
 
 USE_RESULT bool memory_spi_get_active_ble_firmware_version(struct da14531_firmware_version* version)
 {
+    memset(version, 0, sizeof(struct da14531_firmware_version));
+
     memory_ble_metadata_t metadata = {0};
     memory_get_ble_metadata(&metadata);
     util_log("ble active index: %d", metadata.active_index);
@@ -67,19 +71,21 @@ USE_RESULT bool memory_spi_get_active_ble_firmware_version(struct da14531_firmwa
 
     uint32_t ble_addr = metadata.active_index == 0 ? MEMORY_SPI_BLE_FIRMWARE_1_ADDR
                                                    : MEMORY_SPI_BLE_FIRMWARE_2_ADDR;
-    uint8_t* firmware = spi_mem_read(ble_addr + 0x110, sizeof(struct da14531_firmware_version));
-    ASSERT(firmware);
-    if (!firmware) {
+    uint8_t* firmware_bytes =
+        spi_mem_read(ble_addr + 0x110, sizeof(struct da14531_firmware_version));
+    ASSERT(firmware_bytes);
+    if (!firmware_bytes) {
         return false;
     }
 
-    memcpy((uint8_t*)version, firmware, sizeof(struct da14531_firmware_version));
-    free(firmware);
-
-    ASSERT(version->metadata_version == 1);
-
-    if (version->metadata_version == 1) {
-        return true;
+    struct da14531_firmware_version* firmware = (struct da14531_firmware_version*)firmware_bytes;
+    if (firmware->metadata_version == 1) {
+        memcpy((uint8_t*)version, firmware_bytes, sizeof(struct da14531_firmware_version));
+    } else {
+        util_log("Invalid metadata version! No firmware?");
     }
-    return false;
+
+    free(firmware_bytes);
+
+    return true;
 }

--- a/test/simulator/CMakeLists.txt
+++ b/test/simulator/CMakeLists.txt
@@ -23,9 +23,7 @@ set(DBB-FILTERED-SOURCES
   ${DBB-FIRMWARE-UI-SOURCES}
   ${FIRMWARE-U2F-SOURCES}
   ${DBB-FIRMWARE-USB-SOURCES}
-  "${CMAKE_SOURCE_DIR}/src/da14531/da14531.c"
-  "${CMAKE_SOURCE_DIR}/src/da14531/da14531_protocol.c"
-  "${CMAKE_SOURCE_DIR}/src/da14531/crc.c"
+  ${PLATFORM-BITBOX02-PLUS-SOURCES}
   "${CMAKE_SOURCE_DIR}/external/asf4-drivers/hal/utils/src/utils_ringbuffer.c"
   )
 


### PR DESCRIPTION
If there is no valid firmware UART communication is turned off to avoid spending a lot of cpu cycles trying to boot the da14531.

The firmware version reading function must also fail "gracefully" so that the "device info" endpoint gets some data. If the metadata_version is wrong we return all 0s.