### PR TITLE
debug: Make plus bootloader buildable

### DIFF
--- a/.ci/ci
+++ b/.ci/ci
@@ -50,6 +50,7 @@ make -j8 bootloader
 make -j8 bootloader-development
 make -j8 bootloader-development-locked
 make -j8 bootloader-production
+make -j8 bootloader-debug
 
 make -j8 bootloader-btc
 make -j8 bootloader-btc-development
@@ -57,6 +58,7 @@ make -j8 bootloader-btc-production
 
 make -j8 bootloader-plus
 make -j8 bootloader-plus-development
+make -j8 bootloader-plus-debug
 
 # Firmware
 make -j8 firmware

--- a/Makefile
+++ b/Makefile
@@ -71,12 +71,16 @@ bootloader-development-locked: | build
 	$(MAKE) -C build bb02-bl-multi-development-locked.elf
 bootloader-production: | build
 	$(MAKE) -C build bb02-bl-multi-production.elf
+bootloader-debug: | build-debug
+	$(MAKE) -C build-debug bb02-bl-multi-development.elf
 bootloader-plus: | build
 	$(MAKE) -C build bb02p-bl-multi.elf
 bootloader-plus-development: | build
 	$(MAKE) -C build bb02p-bl-multi-development.elf
 bootloader-plus-production: | build
 	$(MAKE) -C build bb02p-bl-multi-production.elf
+bootloader-plus-debug: | build-debug
+	$(MAKE) -C build-debug bb02p-bl-multi-development.elf
 bootloader-btc: | build
 	$(MAKE) -C build bb02-bl-btconly.elf
 bootloader-btc-development: | build

--- a/src/bootloader/startup.c
+++ b/src/bootloader/startup.c
@@ -196,7 +196,7 @@ int main(void)
                     payload,
                     sizeof(payload));
                 ASSERT(len <= sizeof(tmp));
-                ASSERT(ringbuffer_num(data->queue) + len <= data->queue->size);
+                ASSERT(ringbuffer_num(&uart_write_queue) + len <= uart_write_queue.size);
                 for (int i = 0; i < len; i++) {
                     ringbuffer_put(&uart_write_queue, tmp[i]);
                 }

--- a/src/rust/bitbox02-rust-c/src/lib.rs
+++ b/src/rust/bitbox02-rust-c/src/lib.rs
@@ -48,6 +48,7 @@ mod der;
 #[cfg_attr(feature = "bootloader", allow(unused_variables))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
+    #[cfg(feature = "firmware")]
     ::util::log::log!("{}", info);
     #[cfg(feature = "firmware")]
     bitbox02_rust::print_screen!(0, "Error: {}", info);


### PR DESCRIPTION
Include debug bootloaders in CI to avoid future breakage