### PR TITLE
usb_processing: increase watchdog timeout once

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -24,6 +24,7 @@
 #include "salt.h"
 #include "securechip/securechip.h"
 #include "util.h"
+#include <usb/usb_processing.h>
 
 #include <rust/rust.h>
 #include <secp256k1_ecdsa_s2c.h>
@@ -395,6 +396,11 @@ keystore_error_t keystore_unlock(
         reset_reset(false);
         return KEYSTORE_ERR_MAX_ATTEMPTS_EXCEEDED;
     }
+
+    // Unlocking the keystore take longer than the 500ms watchdog we have setup. Reset the watchdog
+    // counter to -70 (~7s) to avoid incorrectly assuming we lost communication with the app.
+    usb_processing_timeout_reset(-70);
+
     bitbox02_smarteeprom_increment_unlock_attempts();
     uint8_t seed[KEYSTORE_MAX_SEED_LENGTH] = {0};
     UTIL_CLEANUP_32(seed);

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -984,7 +984,7 @@ static void _process_wait_refresh(void)
     } else {
         _state.refresh_webpage_timeout++;
         /* Prevent the USB watchdog from killing this workflow. */
-        usb_processing_timeout_reset();
+        usb_processing_timeout_reset(0);
     }
 }
 

--- a/src/usb/usb_processing.h
+++ b/src/usb/usb_processing.h
@@ -73,7 +73,7 @@ void usb_processing_lock(struct usb_processing* ctx);
  * expected behaviour, one can call this function to prevent
  * the USB watchdog from aborting the outstanding operation.
  */
-void usb_processing_timeout_reset(void);
+void usb_processing_timeout_reset(int16_t val);
 
 void usb_processing_unlock(void);
 #endif


### PR DESCRIPTION
The firmware typically expects keep-alive requests every 300ms from the app. However keystore unlock takes about 5-6s so for that single call we reset the watchdog counter to a lower value allowing approximately a 7s gap between messages from the app.

In practice this has worked anyway for the usb stack due to the order of things in the main loop. I.e. check the next incoming message before checking the timeout counter.