### PR TITLE
ethereum: allow fetching xpub at m/44'/60'/0' and m/44'/1'/0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ### [Unreleased]
 - Ethereum: add confirmation screen for known networks, change base unit to ETH for Arbitrum and Optimism
 - Ethereum: add Base and Gnosis Chain to known networks
+- Ethereum: allow fetching xpub at m/44'/60'/0' and m/44'/1'/0'
 - Bitcoin: enable message signing on testnet and regtest
 - Enable Litecoin in the simulator
 

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs
@@ -59,14 +59,16 @@ pub async fn warn_unusual_keypath(
 }
 
 /// Does limit checks the keypath, whitelisting bip44 purpose, account and change.
-/// Only allows the well-known xpubs of m'/44'/60'/0'/0 and m'/44'/1'/0'/0 for now.
+/// Only allows the well-known xpubs of m/44'/60'/0'/0 and m/44'/1'/0'/0 for now,
+/// as well m/44'/60'/0' and m/44'/1'/0' (same but only the hardened prefix).
 /// Since ethereum doesn't use the "change" path part it is always 0 and have become part of the
 /// xpub keypath.
-/// @return true if the keypath is valid, false if it is invalid.
+/// Returns true if the keypath is valid, false if it is invalid.
 pub fn is_valid_keypath_xpub(keypath: &[u32]) -> bool {
-    keypath.len() == 4
-        && (keypath[..4] == [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0]
-            || keypath[..4] == [44 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0])
+    keypath == [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0]
+        || keypath == [44 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0]
+        || keypath == [44 + HARDENED, 60 + HARDENED, 0 + HARDENED]
+        || keypath == [44 + HARDENED, 1 + HARDENED, 0 + HARDENED]
 }
 
 /// Does limit checks the keypath, whitelisting bip44 purpose, account and change.
@@ -98,9 +100,20 @@ mod tests {
         ]));
         assert!(is_valid_keypath_xpub(&[
             44 + HARDENED,
+            60 + HARDENED,
+            0 + HARDENED,
+        ]));
+        assert!(is_valid_keypath_xpub(&[
+            44 + HARDENED,
             1 + HARDENED,
             0 + HARDENED,
             0
+        ]));
+
+        assert!(is_valid_keypath_xpub(&[
+            44 + HARDENED,
+            1 + HARDENED,
+            0 + HARDENED,
         ]));
         // wrong coin.
         assert!(!is_valid_keypath_xpub(&[
@@ -109,12 +122,13 @@ mod tests {
             0 + HARDENED,
             0
         ]));
-        // too short
         assert!(!is_valid_keypath_xpub(&[
             44 + HARDENED,
-            60 + HARDENED,
-            0 + HARDENED
+            0 + HARDENED,
+            0 + HARDENED,
         ]));
+        // too short
+        assert!(!is_valid_keypath_xpub(&[44 + HARDENED, 60 + HARDENED]));
         // too long
         assert!(!is_valid_keypath_xpub(&[
             44 + HARDENED,


### PR DESCRIPTION
NuFi wants to fetch the xpub at the hardened prefix only and derive children from there on the host for consitency with other HWWs.

The BitBox still only allows displaying addresses and signing txs at `m/44'/coin'/0'/0/*`.