### PR TITLE
make noise pairing confirmation optional over BLE

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/noise.rs
+++ b/src/rust/bitbox02-rust/src/hww/noise.rs
@@ -106,7 +106,9 @@ pub(crate) async fn process(
                 bitbox02_noise::HandshakeResult::Done => {
                     let already_verified =
                         memory::check_noise_remote_static_pubkey(&state.remote_static_pubkey()?);
-                    if already_verified {
+                    // When communicating over BLE, we don't require noise pairing code
+                    // confirmation, as BLE already requires pairing with a pairing code.
+                    if bitbox02::communication_mode_ble_enabled() || already_verified {
                         state.set_pairing_verified()?;
                         usb_out.push(0); // let app know we don't require verification
                     } else {


### PR DESCRIPTION
Connecting over Bluetooth requires Bluetooth pairing including pairing code confirmation, so a second noise pairing confirmation is redundant.

This does not prevent the host from requesting a pairing code confirmation on demand anyway at any time, it just does not require confirmation on the device to proceed with communicating over noise, when communicting through the BLE chip.