### PR TITLE
usb: fix typo

### DIFF
--- a/src/usb/class/usb_desc_bitbox02plus.h
+++ b/src/usb/class/usb_desc_bitbox02plus.h
@@ -26,7 +26,7 @@
 #endif
 
 #if defined(BOOTLOADER)
-#if PRODUCT_BITBOX_BTCONLY == 1
+#if PRODUCT_BITBOX_PLUS_BTCONLY == 1
 #define USB_DESC_BB02PLUS_IPRODUCT_STR_DESC                                                     \
     52, /* bLength */                                                                           \
         0x03, /* bDescriptorType */                                                             \


### PR DESCRIPTION
In the bootloader, we have dedicated targets for bb02 and bb02+, while in the firmware we have one target for both, which lead to this.