### PR TITLE
reset: give app some time to see disconnect

### DIFF
--- a/src/reset.c
+++ b/src/reset.c
@@ -58,6 +58,8 @@ void reset_ble(void)
     while (ringbuffer_num(&uart_queue)) {
         uart_poll(NULL, 0, NULL, &uart_queue);
     }
+    // Make sure the ble chip is turned off long enough that the app gets disconnected
+    delay_ms(100);
 #endif
 }
 
@@ -101,7 +103,8 @@ void reset_reset(bool status)
         reset_ble();
     }
 
-    reboot();
+    // We don't need to "gracefully" reboot since we reset the BLE chip
+    _reset_mcu();
 #else
     (void)status;
 #endif

--- a/src/system.c
+++ b/src/system.c
@@ -36,6 +36,8 @@ static void _ble_clear_product(void)
         ringbuffer_flush(&uart_queue);
 #endif
     }
+    // Wait 100ms to ensure that the product has had time to clear
+    delay_ms(100);
 }
 
 void reboot_to_bootloader(void)


### PR DESCRIPTION
After the reset signal is sent to the BLE chip, we busy-wait for 100ms (leaving it turned off), to let the app see the disconnection properly.

After we update the product string we also wait a while before resetting ourselves to let the app react to the change.