### PR TITLE
ci: Give write permissions to `packages` to workflow

### DIFF
--- a/.github/workflows/ci-dev-container.yml
+++ b/.github/workflows/ci-dev-container.yml
@@ -15,6 +15,9 @@ jobs:
     outputs:
       container-repo: ${{ steps.version.outputs.repo }}
       container-version: ${{ steps.version.outputs.version }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Clone the repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
   dev-container:
     uses: ./.github/workflows/ci-dev-container.yml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
   ci:
     needs: [dev-container]
     uses: ./.github/workflows/ci-common.yml

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,6 +11,9 @@ jobs:
   dev-container:
     uses: ./.github/workflows/ci-dev-container.yml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
 
   pr-head-ci:
     needs: [dev-container]


### PR DESCRIPTION
There was more stricted default permissions on the upstream repo than I had in the repo where I tested the CI. This change gives the workflow the permission that is needed to publish to GHCR.