### PR TITLE
usb: Fix timeout bug

### DIFF
--- a/src/usb/class/hid/hid.c
+++ b/src/usb/class/hid/hid.c
@@ -290,9 +290,9 @@ int32_t hid_read(struct hid_func_data* func_data, uint8_t* buf, uint32_t size)
         return ERR_DENIED;
     }
     struct usb_d_ep_status status;
-    usb_d_ep_get_status(func_data->func_ep_in, &status);
+    usb_d_ep_get_status(func_data->func_ep_out, &status);
     while (status.state != USB_EP_S_IDLE) {
-        usb_d_ep_get_status(func_data->func_ep_in, &status);
+        usb_d_ep_get_status(func_data->func_ep_out, &status);
     }
     return usbdc_xfer(func_data->func_ep_out, buf, size, false);
 }


### PR DESCRIPTION
The FW was waiting for the "IN" endpoint to be ready when it should've been waiting for the "OUT" endpoint.