### PR TITLE
fix null ptr deref

### DIFF
--- a/src/ui/components/confirm.c
+++ b/src/ui/components/confirm.c
@@ -157,7 +157,7 @@ component_t* confirm_create(
             confirm, icon_button_create(slider_position, ICON_BUTTON_CROSS, _on_cancel));
     }
     if (params->longtouch) {
-        ui_util_add_sub_component(confirm, confirm_gesture_create(confirm));
+        ui_util_add_sub_component(confirm, confirm_gesture_create());
     } else {
         ui_util_add_sub_component(
             confirm,

--- a/src/ui/components/confirm_button.c
+++ b/src/ui/components/confirm_button.c
@@ -28,7 +28,7 @@ static void _confirm(component_t* confirm_button)
 component_t* confirm_button_create(bool longtouch, icon_button_type_t button_type)
 {
     if (longtouch) {
-        return confirm_gesture_create(NULL);
+        return confirm_gesture_create();
     }
     return icon_button_create(top_slider, button_type, _confirm);
 }

--- a/src/ui/components/confirm_gesture.c
+++ b/src/ui/components/confirm_gesture.c
@@ -154,9 +154,8 @@ static component_functions_t _component_functions = {
 
 /**
  * Creates a confirm_gesture component on the top slider.
- * @param[in] parent The parent component.
  */
-component_t* confirm_gesture_create(component_t* parent)
+component_t* confirm_gesture_create(void)
 {
     confirm_data_t* data = malloc(sizeof(confirm_data_t));
     if (!data) {
@@ -176,9 +175,6 @@ component_t* confirm_gesture_create(component_t* parent)
     memset(confirm_gesture, 0, sizeof(component_t));
     confirm_gesture->data = data;
     confirm_gesture->f = &_component_functions;
-    confirm_gesture->parent = parent;
-
-    ui_util_position_right_top(parent, confirm_gesture);
 
     return confirm_gesture;
 }

--- a/src/ui/components/confirm_gesture.h
+++ b/src/ui/components/confirm_gesture.h
@@ -24,7 +24,7 @@
  * Creates a confirm_gesture component on the top slider.
  * @param[in] parent The parent component.
  */
-component_t* confirm_gesture_create(component_t* parent);
+component_t* confirm_gesture_create(void);
 
 bool confirm_gesture_is_active(component_t* component);
 


### PR DESCRIPTION
`confirm_gesture_create` was called with `NULL` as parent, so `ui_util_position_right_top(parent, confirm_gesture);` passed NULL, and the function derefed NULL to compute the position.

Though undefined behavior technically, 0 is a valid pointer in the BitBox02 (start of bootloader), so some bytes slightly offset from 0 were used for the positions.

None of that impacted the device behavior though as the positioning of the component was not needed in the first place. The component has a custom _render function that renders the confirm arrows in the right location without looking at `component->position`, so we can just remove the offendling line.

The parent param is removed as it is unused.