### PR TITLE
keystore: pass private key to nonce_commit() and sign()

### DIFF
--- a/src/keystore.c
+++ b/src/keystore.c
@@ -528,19 +528,11 @@ bool keystore_get_bip39_word(uint16_t idx, char** word_out)
 }
 
 bool keystore_secp256k1_nonce_commit(
-    const uint32_t* keypath,
-    size_t keypath_len,
+    const uint8_t* private_key,
     const uint8_t* msg32,
     const uint8_t* host_commitment,
     uint8_t* signer_commitment_out)
 {
-    uint8_t private_key[32] = {0};
-    UTIL_CLEANUP_32(private_key);
-    if (!rust_secp256k1_get_private_key(
-            keypath, keypath_len, rust_util_bytes_mut(private_key, sizeof(private_key)))) {
-        return false;
-    }
-
     const secp256k1_context* ctx = wally_get_secp_context();
     secp256k1_ecdsa_s2c_opening signer_commitment;
     if (!secp256k1_ecdsa_anti_exfil_signer_commit(
@@ -555,23 +547,12 @@ bool keystore_secp256k1_nonce_commit(
 }
 
 bool keystore_secp256k1_sign(
-    const uint32_t* keypath,
-    size_t keypath_len,
+    const uint8_t* private_key,
     const uint8_t* msg32,
     const uint8_t* host_nonce32,
     uint8_t* sig_compact_out,
     int* recid_out)
 {
-    if (keystore_is_locked()) {
-        return false;
-    }
-    uint8_t private_key[32] = {0};
-    UTIL_CLEANUP_32(private_key);
-    if (!rust_secp256k1_get_private_key(
-            keypath, keypath_len, rust_util_bytes_mut(private_key, sizeof(private_key)))) {
-        return false;
-    }
-
     const secp256k1_context* ctx = wally_get_secp_context();
     secp256k1_ecdsa_signature secp256k1_sig = {0};
     if (!secp256k1_anti_exfil_sign(

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -157,8 +157,7 @@ USE_RESULT bool keystore_get_bip39_word(uint16_t idx, char** word_out);
  * Get a commitment to the original nonce before tweaking it with the host nonce. This is part of
  * the ECDSA Anti-Klepto Protocol. For more details, check the docs of
  * `secp256k1_ecdsa_anti_exfil_signer_commit`.
- * @param[in] keypath derivation keypath
- * @param[in] keypath_len size of keypath buffer
+ * @param[in] private_key 32 byte private key
  * @param[in] msg32 32 byte message which will be signed by `keystore_secp256k1_sign`.
  * @param[in] host_commitment must be `sha256(sha256(tag)||shas256(tag)||host_nonce)` where
  * host_nonce is passed to `keystore_secp256k1_sign()`. See
@@ -166,15 +165,14 @@ USE_RESULT bool keystore_get_bip39_word(uint16_t idx, char** word_out);
  * @param[out] client_commitment_out EC_PUBLIC_KEY_LEN bytes compressed signer nonce pubkey.
  */
 USE_RESULT bool keystore_secp256k1_nonce_commit(
-    const uint32_t* keypath,
-    size_t keypath_len,
+    const uint8_t* private_key,
     const uint8_t* msg32,
     const uint8_t* host_commitment,
     uint8_t* client_commitment_out);
 
 // clang-format off
 /**
- * Sign message with private key at the given keypath. Keystore must be unlocked.
+ * Sign message with private key using the given private key.
  *
  * Details about `host_nonce32`, the host nonce contribution.
  * Instead of using plain rfc6979 to generate the nonce in this signature, the following formula is used:
@@ -187,8 +185,7 @@ USE_RESULT bool keystore_secp256k1_nonce_commit(
  * This is part of the ECSDA Anti-Klepto protocol, preventing this function to leak any secrets via
  * the signatures (see the ecdsa-s2c module in secp256k1-zpk for more details).
  *
- * @param[in] keypath derivation keypath
- * @param[in] keypath_len size of keypath buffer
+ * @param[in] private_key 32 byte private key
  * @param[in] msg32 32 byte message to sign
  * @param[in] host_nonce32 32 byte nonce contribution. Cannot be NULL.
  * Intended to be a contribution by the host. If there is none available, use 32 zero bytes.
@@ -199,8 +196,7 @@ USE_RESULT bool keystore_secp256k1_nonce_commit(
  */
 // clang-format on
 USE_RESULT bool keystore_secp256k1_sign(
-    const uint32_t* keypath,
-    size_t keypath_len,
+    const uint8_t* private_key,
     const uint8_t* msg32,
     const uint8_t* host_nonce32,
     uint8_t* sig_compact_out,

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -98,7 +98,10 @@ pub async fn process(
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.
         Some(pb::AntiKleptoHostNonceCommitment { ref commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                keypath,
+                crate::keystore::secp256k1_get_private_key(keypath)?
+                    .as_slice()
+                    .try_into()
+                    .unwrap(),
                 &sighash,
                 commitment
                     .as_slice()
@@ -114,8 +117,14 @@ pub async fn process(
         None => [0; 32],
     };
 
-    let sign_result = bitbox02::keystore::secp256k1_sign(keypath, &sighash, &host_nonce)?;
-
+    let sign_result = bitbox02::keystore::secp256k1_sign(
+        crate::keystore::secp256k1_get_private_key(keypath)?
+            .as_slice()
+            .try_into()
+            .unwrap(),
+        &sighash,
+        &host_nonce,
+    )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);
 

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -389,7 +389,10 @@ pub async fn _process(
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.
         Some(pb::AntiKleptoHostNonceCommitment { ref commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                request.keypath(),
+                &crate::keystore::secp256k1_get_private_key(request.keypath())?
+                    .as_slice()
+                    .try_into()
+                    .unwrap(),
                 &hash,
                 commitment
                     .as_slice()
@@ -404,8 +407,14 @@ pub async fn _process(
         // Return signature directly without the anti-klepto protocol, for backwards compatibility.
         None => [0; 32],
     };
-    let sign_result = keystore::secp256k1_sign(request.keypath(), &hash, &host_nonce)?;
-
+    let sign_result = keystore::secp256k1_sign(
+        &crate::keystore::secp256k1_get_private_key(request.keypath())?
+            .as_slice()
+            .try_into()
+            .unwrap(),
+        &hash,
+        &host_nonce,
+    )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);
 

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -67,7 +67,10 @@ pub async fn process(
         // Engage in the anti-klepto protocol if the host sends a host nonce commitment.
         Some(pb::AntiKleptoHostNonceCommitment { ref commitment }) => {
             let signer_commitment = keystore::secp256k1_nonce_commit(
-                &request.keypath,
+                crate::keystore::secp256k1_get_private_key(&request.keypath)?
+                    .as_slice()
+                    .try_into()
+                    .unwrap(),
                 &sighash,
                 commitment
                     .as_slice()
@@ -83,8 +86,14 @@ pub async fn process(
         None => [0; 32],
     };
 
-    let sign_result = bitbox02::keystore::secp256k1_sign(&request.keypath, &sighash, &host_nonce)?;
-
+    let sign_result = bitbox02::keystore::secp256k1_sign(
+        crate::keystore::secp256k1_get_private_key(&request.keypath)?
+            .as_slice()
+            .try_into()
+            .unwrap(),
+        &sighash,
+        &host_nonce,
+    )?;
     let mut signature: Vec<u8> = sign_result.signature.to_vec();
     signature.push(sign_result.recid);
 

--- a/test/unit-test/test_keystore_antiklepto.c
+++ b/test/unit-test/test_keystore_antiklepto.c
@@ -93,10 +93,11 @@ static void _test_keystore_antiklepto(void** state)
 
         // Commit - protocol step 2.
         assert_true(keystore_secp256k1_nonce_commit(
-            keypath, 5, msg, host_nonce_commitment, signer_commitment));
+            xprv_derived.priv_key + 1, msg, host_nonce_commitment, signer_commitment));
         // Protocol step 3: host_nonce sent from host to signer to be used in step 4
         // Sign - protocol step 4.
-        assert_true(keystore_secp256k1_sign(keypath, 5, msg, host_nonce, sig, &recid));
+        assert_true(
+            keystore_secp256k1_sign(xprv_derived.priv_key + 1, msg, host_nonce, sig, &recid));
 
         // Protocol step 5: host verification.
         secp256k1_ecdsa_signature parsed_signature;


### PR DESCRIPTION
End-goal: reduce the number of secure chip ops when signing a BTC transaction, to reduce the chance of going over the Optiga chip's "rate limit", which induces throttling.

With antiklepto, we derived the private key twice for each input that is signed: once to commit to the nonce, and after that to sign.

This commit decouples the nonce commit and sign functions from the underlying keystore, and allows reusing a private key instead of re-deriving it, which requires secure chip operations.

This halves the number of secure chip ops needed per input when signing a BTC transaction.

We do not reuse the privkey for the other instances of antiklepto (signing a msg, signing an ETH tx), as there it's one commit/sign pair only and unlikely to cause secure chip throttling.