### PR TITLE
xpubcache: allow choosing if xpub computation should be repeated

### DIFF
--- a/src/rust/bitbox02-rust/src/bip32.rs
+++ b/src/rust/bitbox02-rust/src/bip32.rs
@@ -54,7 +54,7 @@ impl From<bitcoin::bip32::Xpriv> for Xprv {
     }
 }
 
-#[derive(Clone)]
+#[derive(PartialEq, Clone)]
 pub struct Xpub {
     xpub: pb::XPub,
 }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin.rs
@@ -125,7 +125,7 @@ async fn xpub(
             })
             .await?
     }
-    let xpub = keystore::get_xpub(keypath)
+    let xpub = keystore::get_xpub_twice(keypath)
         .or(Err(Error::InvalidInput))?
         .serialize_str(xpub_type)?;
     if display {
@@ -163,7 +163,7 @@ pub fn derive_address_simple(
     )
     .or(Err(Error::InvalidInput))?;
     Ok(common::Payload::from_simple(
-        &mut crate::xpubcache::XpubCache::new(),
+        &mut crate::xpubcache::XpubCache::new(crate::xpubcache::Compute::Twice),
         coin_params,
         simple_type,
         keypath,
@@ -1083,7 +1083,7 @@ mod tests {
             root_fingerprint: keystore::root_fingerprint().unwrap(),
             keypath: KEYPATH_ACCOUNT_TESTNET.to_vec(),
             xpub: Some(
-                crate::keystore::get_xpub(KEYPATH_ACCOUNT_TESTNET)
+                crate::keystore::get_xpub_once(KEYPATH_ACCOUNT_TESTNET)
                     .unwrap()
                     .into(),
             ),
@@ -1092,7 +1092,7 @@ mod tests {
             root_fingerprint: keystore::root_fingerprint().unwrap(),
             keypath: KEYPATH_ACCOUNT_MAINNET.to_vec(),
             xpub: Some(
-                crate::keystore::get_xpub(KEYPATH_ACCOUNT_MAINNET)
+                crate::keystore::get_xpub_once(KEYPATH_ACCOUNT_MAINNET)
                     .unwrap()
                     .into(),
             ),

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/common.rs
@@ -577,7 +577,7 @@ mod tests {
             "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
             "",
         );
-        let mut xpub_cache = Bip32XpubCache::new();
+        let mut xpub_cache = Bip32XpubCache::new(crate::xpubcache::Compute::Once);
         let coin_params = super::super::params::get(pb::BtcCoin::Btc);
         // p2wpkh
         assert_eq!(

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/multisig.rs
@@ -270,7 +270,7 @@ pub fn validate(multisig: &Multisig, keypath: &[u32]) -> Result<(), Error> {
         return Err(Error::InvalidInput);
     }
 
-    let our_xpub = crate::keystore::get_xpub(keypath)?.serialize(None)?;
+    let our_xpub = crate::keystore::get_xpub_once(keypath)?.serialize(None)?;
     let maybe_our_xpub =
         bip32::Xpub::from(&multisig.xpubs[multisig.our_xpub_index as usize]).serialize(None)?;
     if our_xpub != maybe_our_xpub {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
@@ -58,7 +58,7 @@ fn is_our_key(key: &pb::KeyOriginInfo, our_root_fingerprint: &[u8]) -> Result<bo
             xpub: Some(xpub),
             ..
         } if root_fingerprint.as_slice() == our_root_fingerprint => {
-            let our_xpub = crate::keystore::get_xpub(keypath)?.serialize(None)?;
+            let our_xpub = crate::keystore::get_xpub_once(keypath)?.serialize(None)?;
             let maybe_our_xpub = bip32::Xpub::from(xpub).serialize(None)?;
             Ok(our_xpub == maybe_our_xpub)
         }
@@ -787,7 +787,7 @@ mod tests {
 
     // Creates a policy for one of our own keys at keypath.
     fn make_our_key(keypath: &[u32]) -> pb::KeyOriginInfo {
-        let our_xpub = crate::keystore::get_xpub(keypath).unwrap();
+        let our_xpub = crate::keystore::get_xpub_once(keypath).unwrap();
         pb::KeyOriginInfo {
             root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
             keypath: keypath.to_vec(),

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/script_configs.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/script_configs.rs
@@ -126,7 +126,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -24,7 +24,7 @@ use super::{bip143, bip341, common, keypath};
 
 use crate::hal::Ui;
 use crate::workflow::{confirm, transaction};
-use crate::xpubcache::Bip32XpubCache;
+use crate::xpubcache::{Bip32XpubCache, Compute};
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -681,7 +681,7 @@ async fn _process(
     let validated_output_script_configs =
         validate_script_configs(coin_params, &request.output_script_configs)?;
 
-    let mut xpub_cache = Bip32XpubCache::new();
+    let mut xpub_cache = Bip32XpubCache::new(Compute::Once);
     setup_xpub_cache(&mut xpub_cache, &request.script_configs);
 
     // For now we only allow one payment request with one output per transaction.  In the future,
@@ -1804,7 +1804,7 @@ mod tests {
             let multisig = pb::btc_script_config::Multisig {
                 threshold: 1,
                 xpubs: vec![
-                    crate::keystore::get_xpub(keypath).unwrap().into(),
+                    crate::keystore::get_xpub_once(keypath).unwrap().into(),
                     parse_xpub("xpub6ERxBysTYfQyY4USv6c6J1HNVv9hpZFN9LHVPu47Ac4rK8fLy6NnAeeAHyEsMvG4G66ay5aFZii2VM7wT3KxLKX8Q8keZPd67kRGmrD1WJj").unwrap(),
                 ],
                 our_xpub_index: 0,
@@ -3160,7 +3160,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath_account.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath_account).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],
@@ -3280,7 +3280,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath_account.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath_account).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],
@@ -3345,7 +3345,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath_account.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath_account).unwrap().into()),
                 },
             ],
         };
@@ -3452,7 +3452,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath_account.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath_account).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],
@@ -3504,7 +3504,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath_account.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath_account).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],
@@ -3553,7 +3553,7 @@ mod tests {
                 pb::KeyOriginInfo {
                     root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
                     keypath: keypath_account.to_vec(),
-                    xpub: Some(crate::keystore::get_xpub(keypath_account).unwrap().into()),
+                    xpub: Some(crate::keystore::get_xpub_once(keypath_account).unwrap().into()),
                 },
                 pb::KeyOriginInfo {
                     root_fingerprint: vec![],

--- a/src/rust/bitbox02-rust/src/hww/api/electrum.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/electrum.rs
@@ -39,7 +39,7 @@ pub async fn process(
     {
         return Err(Error::InvalidInput);
     }
-    let xpub = keystore::get_xpub(keypath)
+    let xpub = keystore::get_xpub_twice(keypath)
         .or(Err(Error::InvalidInput))?
         .serialize_str(bip32::XPubType::Xpub)?;
 

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/pubrequest.rs
@@ -45,7 +45,7 @@ async fn process_address(
     if !super::keypath::is_valid_keypath_address(&request.keypath) {
         return Err(Error::InvalidInput);
     }
-    let pubkey = crate::keystore::get_xpub(&request.keypath)
+    let pubkey = crate::keystore::get_xpub_twice(&request.keypath)
         .or(Err(Error::InvalidInput))?
         .pubkey_uncompressed()?;
     let address = super::address::from_pubkey(&pubkey);
@@ -79,7 +79,7 @@ fn process_xpub(request: &pb::EthPubRequest) -> Result<Response, Error> {
     if !super::keypath::is_valid_keypath_xpub(&request.keypath) {
         return Err(Error::InvalidInput);
     }
-    let xpub = keystore::get_xpub(&request.keypath)
+    let xpub = keystore::get_xpub_twice(&request.keypath)
         .or(Err(Error::InvalidInput))?
         .serialize_str(bip32::XPubType::Xpub)?;
 

--- a/src/rust/bitbox02-rust/src/xpubcache.rs
+++ b/src/rust/bitbox02-rust/src/xpubcache.rs
@@ -37,7 +37,7 @@ pub trait Xpub: Sized {
 
 /// Implements a cache for xpubs. Cached intermediate xpubs are used to derive child xpubs.
 ///
-/// The cache must be configured using `cache_keypath()`, otherwise no caching occurs. The reason
+/// The cache must be configured using `add_keypath()`, otherwise no caching occurs. The reason
 /// for this is that automatic caching is harder to get right and reason about, e.g. in a BTC tx, we
 /// shouldn't cache xpubs at the address level (e.g. m/84/0'/0'/0/0), as they don't repeat and there
 /// can be many of them.

--- a/src/rust/bitbox02-rust/src/xpubcache.rs
+++ b/src/rust/bitbox02-rust/src/xpubcache.rs
@@ -17,12 +17,22 @@ use super::keystore;
 use crate::bip32;
 use alloc::vec::Vec;
 
+#[derive(Copy, Clone)]
+pub enum Compute {
+    /// The xpubs are derived once. Use for non-critical operations like signing a transaction,
+    /// where a compute error will lead to an invalid signature only.
+    Once,
+    /// The xpubs are derive twice, to mitigate the risk of bitflips or similar compute corruption.
+    /// Used for critical operations, like delivering xpubs to the host.
+    Twice,
+}
+
 pub trait Xpub: Sized {
     /// Derives a child xpub using the provided keypath.
-    fn derive(&self, keypath: &[u32]) -> Result<Self, ()>;
+    fn derive(&self, keypath: &[u32], compute: Compute) -> Result<Self, ()>;
 
     /// Derives an xpub from the root xpub using the provided keypath.
-    fn from_keypath(keypath: &[u32]) -> Result<Self, ()>;
+    fn from_keypath(keypath: &[u32], compute: Compute) -> Result<Self, ()>;
 }
 
 /// Implements a cache for xpubs. Cached intermediate xpubs are used to derive child xpubs.
@@ -37,13 +47,15 @@ pub struct XpubCache<X> {
     // Cached xpubs. First tuple element is the keypath for which the xpub was cached, the second
     // element is the cached xpub.
     xpubs: Vec<(Vec<u32>, X)>,
+    compute: Compute,
 }
 
 impl<X: Xpub + Clone> XpubCache<X> {
-    pub fn new() -> Self {
+    pub fn new(compute: Compute) -> Self {
         XpubCache {
             keypaths: Vec::new(),
             xpubs: Vec::new(),
+            compute,
         }
     }
 
@@ -71,9 +83,9 @@ impl<X: Xpub + Clone> XpubCache<X> {
         // from an xpub (hardened elements require the xprv).
         const UNHARDENED_LAST: u32 = util::bip32::HARDENED - 1;
         let xpub = if let [prefix @ .., last @ 0..=UNHARDENED_LAST] = keypath {
-            self.get_xpub(prefix)?.derive(&[*last])?
+            self.get_xpub(prefix)?.derive(&[*last], self.compute)?
         } else {
-            X::from_keypath(keypath)?
+            X::from_keypath(keypath, self.compute)?
         };
         self.xpubs.push((keypath.to_vec(), xpub.clone()));
         Ok(xpub)
@@ -95,19 +107,32 @@ impl<X: Xpub + Clone> XpubCache<X> {
             .max_by_key(|(kp, _)| kp.len());
         if let Some((cached_prefix, suffix)) = search_result {
             let xpub = self.cache_get_set(&cached_prefix.clone())?;
-            return xpub.derive(suffix);
+            return xpub.derive(suffix, self.compute);
         }
-        X::from_keypath(keypath)
+        X::from_keypath(keypath, self.compute)
     }
 }
 
 impl Xpub for bip32::Xpub {
-    fn derive(&self, keypath: &[u32]) -> Result<Self, ()> {
-        bip32::Xpub::derive(self, keypath)
+    fn derive(&self, keypath: &[u32], compute: Compute) -> Result<Self, ()> {
+        match compute {
+            Compute::Once => bip32::Xpub::derive(self, keypath),
+            Compute::Twice => {
+                let res1 = bip32::Xpub::derive(self, keypath)?;
+                let res2 = bip32::Xpub::derive(self, keypath)?;
+                if res1 != res2 {
+                    return Err(());
+                }
+                Ok(res2)
+            }
+        }
     }
 
-    fn from_keypath(keypath: &[u32]) -> Result<Self, ()> {
-        keystore::get_xpub(keypath)
+    fn from_keypath(keypath: &[u32], compute: Compute) -> Result<Self, ()> {
+        match compute {
+            Compute::Once => keystore::get_xpub_once(keypath),
+            Compute::Twice => keystore::get_xpub_twice(keypath),
+        }
     }
 }
 
@@ -133,7 +158,7 @@ mod tests {
             bitbox02::testing::UnsafeSyncRefCell::new(0);
 
         impl Xpub for MockXpub {
-            fn derive(&self, keypath: &[u32]) -> Result<Self, ()> {
+            fn derive(&self, keypath: &[u32], _compute: Compute) -> Result<Self, ()> {
                 let mut kp = Vec::new();
                 kp.extend_from_slice(&self.0);
                 kp.extend_from_slice(keypath);
@@ -141,7 +166,7 @@ mod tests {
                 Ok(MockXpub(kp))
             }
 
-            fn from_keypath(keypath: &[u32]) -> Result<Self, ()> {
+            fn from_keypath(keypath: &[u32], _compute: Compute) -> Result<Self, ()> {
                 *ROOT_DERIVATIONS.borrow_mut() += 1;
                 Ok(MockXpub(keypath.to_vec()))
             }
@@ -149,7 +174,7 @@ mod tests {
 
         type MockCache = XpubCache<MockXpub>;
 
-        let mut cache = MockCache::new();
+        let mut cache = MockCache::new(crate::xpubcache::Compute::Once);
 
         assert_eq!(cache.get_xpub(&[]).unwrap().0.as_slice(), &[]);
         assert_eq!(*CHILD_DERIVATIONS.borrow(), 0u32);
@@ -210,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_bip32_xpub_cache() {
-        let mut cache = Bip32XpubCache::new();
+        let mut cache = Bip32XpubCache::new(crate::xpubcache::Compute::Twice);
         cache.add_keypath(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED, 1]);
         cache.add_keypath(&[84 + HARDENED, 0 + HARDENED, 0 + HARDENED]);
 


### PR DESCRIPTION
End-goal: reduce the number of secure chip ops when signing a BTC transaction, to reduce the chance of going over the Optiga chip's "rate limit", which induces throttling.

By default keystore::get_xpub computed the xpub twice, to mitigate potential bitflips, which could be bad when delivering the wrong xpub (or derivatives) to the host.

When signing a transaction however, one does not need the extra protection - if there is a bit flip, the resulting signature will be invalid.

This commit reduces the number of secure chip ops needed when the bitflip mitigation is not required.

The existing method `get_xpub` was renamed so the compiler can tell us all the instances where we need to decide between one or the other.