### PR TITLE
keystore: port get_ed25519_seed to Rust

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -186,16 +186,6 @@ USE_RESULT bool keystore_secp256k1_sign(
  */
 USE_RESULT bool keystore_get_u2f_seed(uint8_t* seed_out);
 
-/**
- * Get the seed to be used for ed25519 applications such as Cardano. The output is the root key to
- * BIP32-ED25519.
- * This implements a derivation compatible with Ledger according to
- * https://github.com/LedgerHQ/orakolo/blob/0b2d5e669ec61df9a824df9fa1a363060116b490/src/python/orakolo/HDEd25519.py.
- * @param seed_out Buffer for the seed. Must be 96 bytes. It will contain a 64 byte expanded
- * ed25519 private key followed by a 32 byte chain code.
- */
-USE_RESULT bool keystore_get_ed25519_seed(uint8_t* seed_out);
-
 #ifdef TESTING
 /**
  * convenience to mock the keystore state (locked, seed) in tests.

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -73,7 +73,6 @@ const ALLOWLIST_FNS: &[&str] = &[
     "keystore_create_and_store_seed",
     "keystore_encrypt_and_store_seed",
     "keystore_get_bip39_word",
-    "keystore_get_ed25519_seed",
     "keystore_get_u2f_seed",
     "keystore_is_locked",
     "keystore_lock",

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -220,14 +220,6 @@ pub fn encrypt_and_store_seed(seed: &[u8], password: &str) -> Result<(), Error> 
     }
 }
 
-pub fn get_ed25519_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let mut seed = zeroize::Zeroizing::new([0u8; 96].to_vec());
-    match unsafe { bitbox02_sys::keystore_get_ed25519_seed(seed.as_mut_ptr()) } {
-        true => Ok(seed),
-        false => Err(()),
-    }
-}
-
 // Currently only used in the functional tests below.
 #[cfg(feature = "testing")]
 pub fn get_u2f_seed() -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
@@ -368,46 +360,6 @@ mod tests {
         assert_eq!(
             copy_seed().unwrap().as_slice(),
             b"\xae\x45\xd4\x02\x3a\xfa\x4a\x48\x68\x77\x51\x69\xfe\xa5\xf5\xe4\x97\xf7\xa1\xa4\xd6\x22\x9a\xd0\x23\x9e\x68\x9b\x48\x2e\xd3\x5e",
-        );
-    }
-
-    #[test]
-    fn test_get_ed25519_seed() {
-        // No seed on a locked keystore.
-        lock();
-        assert!(get_ed25519_seed().is_err());
-
-        // Test vectors taken from:
-        // https://github.com/cardano-foundation/CIPs/blob/6c249ef48f8f5b32efc0ec768fadf4321f3173f2/CIP-0003/Ledger.md#test-vectors
-        // See also: https://github.com/cardano-foundation/CIPs/pull/132
-
-        mock_unlocked_using_mnemonic(
-            "recall grace sport punch exhibit mad harbor stand obey short width stem awkward used stairs wool ugly trap season stove worth toward congress jaguar",
-            "",
-        );
-        assert_eq!(
-            hex::encode(get_ed25519_seed().unwrap()),
-            "a08cf85b564ecf3b947d8d4321fb96d70ee7bb760877e371899b14e2ccf88658104b884682b57efd97decbb318a45c05a527b9cc5c2f64f7352935a049ceea60680d52308194ccef2a18e6812b452a5815fbd7f5babc083856919aaf668fe7e4",
-        );
-
-        // Multiple loop iterations.
-
-        mock_unlocked_using_mnemonic(
-            "correct cherry mammal bubble want mandate polar hazard crater better craft exotic choice fun tourist census gap lottery neglect address glow carry old business",
-            "",
-        );
-        assert_eq!(
-            hex::encode(get_ed25519_seed().unwrap()),
-            "587c6774357ecbf840d4db6404ff7af016dace0400769751ad2abfc77b9a3844cc71702520ef1a4d1b68b91187787a9b8faab0a9bb6b160de541b6ee62469901fc0beda0975fe4763beabd83b7051a5fd5cbce5b88e82c4bbaca265014e524bd",
-        );
-
-        mock_unlocked_using_mnemonic(
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-            "foo",
-        );
-        assert_eq!(
-            hex::encode(get_ed25519_seed().unwrap()),
-            "f053a1e752de5c26197b60f032a4809f08bb3e5d90484fe42024be31efcba7578d914d3ff992e21652fee6a4d99f6091006938fac2c0c0f9d2de0ba64b754e92a4f3723f23472077aa4cd4dd8a8a175dba07ea1852dad1cf268c61a2679c3890",
         );
     }
 


### PR DESCRIPTION
ed25519.rs already had a copy of the unit tests in `test_get_seed()`.