### PR TITLE
securechip: count optiga security events and integrate into tests

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/set_password.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/set_password.rs
@@ -72,6 +72,8 @@ mod tests {
             }
             Ok("password".into())
         }));
+
+        bitbox02::securechip::fake_event_counter_reset();
         assert_eq!(
             block_on(process(
                 &mut mock_hal,
@@ -81,6 +83,7 @@ mod tests {
             )),
             Ok(Response::Success(pb::Success {}))
         );
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 19);
         drop(mock_hal); // to remove mutable borrow of counter
         assert_eq!(counter, 2);
         assert!(!keystore::is_locked());

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -205,10 +205,12 @@ mod tests {
             "",
         );
 
+        bitbox02::securechip::fake_event_counter_reset();
         assert_eq!(
             hex::encode(secp256k1_get_private_key(keypath).unwrap()),
             "4604b4b710fe91f584fff084e1a9159fe4f8408fff380596a604948474ce4fa3"
         );
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 1);
     }
 
     #[test]
@@ -222,10 +224,12 @@ mod tests {
             "",
         );
 
+        bitbox02::securechip::fake_event_counter_reset();
         assert_eq!(
             hex::encode(secp256k1_get_private_key_twice(keypath).unwrap()),
             "4604b4b710fe91f584fff084e1a9159fe4f8408fff380596a604948474ce4fa3"
         );
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
     }
 
     #[test]
@@ -252,6 +256,9 @@ mod tests {
             "sleep own lobster state clean thrive tail exist cactus bitter pass soccer clinic riot dream turkey before sport action praise tunnel hood donate man",
             "",
         );
+
+        bitbox02::securechip::fake_event_counter_reset();
+
         assert_eq!(
             get_xpub_twice(&[])
                 .unwrap()
@@ -259,6 +266,9 @@ mod tests {
                 .unwrap(),
             "xpub661MyMwAqRbcEhX8d9WJh78SZrxusAzWFoykz4n5CF75uYRzixw5FZPUSoWyhaaJ1bpiPFdzdHSQqJN38PcTkyrLmxT4J2JDYfoGJQ4ioE2",
         );
+
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
+
         assert_eq!(
             get_xpub_twice(keypath)
                 .unwrap()
@@ -310,7 +320,10 @@ mod tests {
             "purity concert above invest pigeon category peace tuition hazard vivid latin since legal speak nation session onion library travel spell region blast estate stay",
             "",
         );
+
+        bitbox02::securechip::fake_event_counter_reset();
         assert_eq!(root_fingerprint(), Ok(vec![0x02, 0x40, 0xe9, 0x2a]));
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
 
         mock_unlocked_using_mnemonic(
             "small agent wife animal marine cloth exit thank stool idea steel frame",
@@ -439,20 +452,37 @@ mod tests {
             mock_memory();
             keystore::lock();
             let seed = &seed[..test.seed_len];
+
             assert!(keystore::unlock_bip39(test.mnemonic_passphrase).is_err());
+
+            bitbox02::securechip::fake_event_counter_reset();
             assert!(keystore::encrypt_and_store_seed(seed, "foo").is_ok());
+            assert_eq!(bitbox02::securechip::fake_event_counter(), 11);
+
             assert!(keystore::unlock_bip39(test.mnemonic_passphrase).is_err());
             assert!(keystore::is_locked());
+
+            bitbox02::securechip::fake_event_counter_reset();
             assert!(keystore::unlock("foo").is_ok());
+            assert_eq!(bitbox02::securechip::fake_event_counter(), 6);
+
             assert!(keystore::is_locked());
+
+            bitbox02::securechip::fake_event_counter_reset();
             assert!(keystore::unlock_bip39(test.mnemonic_passphrase).is_ok());
+            assert_eq!(bitbox02::securechip::fake_event_counter(), 2);
+
             assert!(!keystore::is_locked());
             assert_eq!(
                 get_bip39_mnemonic().unwrap().as_str(),
                 test.expected_mnemonic,
             );
             let keypath = &[44 + HARDENED, 0 + HARDENED, 0 + HARDENED];
+
+            bitbox02::securechip::fake_event_counter_reset();
             let xpub = get_xpub_once(keypath).unwrap();
+            assert_eq!(bitbox02::securechip::fake_event_counter(), 1);
+
             assert_eq!(
                 xpub.serialize_str(crate::bip32::XPubType::Xpub).unwrap(),
                 test.expected_xpub,
@@ -482,7 +512,11 @@ mod tests {
 
         // Test without tweak
         bitbox02::random::fake_reset();
+
+        bitbox02::securechip::fake_event_counter_reset();
         let sig = secp256k1_schnorr_sign(&keypath, &msg, None).unwrap();
+        assert_eq!(bitbox02::securechip::fake_event_counter(), 1);
+
         assert!(
             SECP256K1
                 .verify_schnorr(

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -144,6 +144,8 @@ const ALLOWLIST_FNS: &[&str] = &[
     "securechip_model",
     "securechip_monotonic_increments_remaining",
     "securechip_u2f_counter_set",
+    "fake_securechip_event_counter",
+    "fake_securechip_event_counter_reset",
     "smarteeprom_is_enabled",
     "smarteeprom_disable",
     "smarteeprom_bb02_config",

--- a/src/rust/bitbox02/src/keystore.rs
+++ b/src/rust/bitbox02/src/keystore.rs
@@ -422,9 +422,16 @@ mod tests {
         crate::memory::set_salt_root(mock_salt_root.as_slice().try_into().unwrap()).unwrap();
 
         assert!(encrypt_and_store_seed(&seed, "password").is_ok());
+
         // Loop to check that unlocking works while unlocked.
         for _ in 0..3 {
+            // First call: unlock Further calls perform a password check. The first onedoes a seed
+            // rentention (1 securechip event). The password check does not do the rentention but a
+            // copy_seed() instead to check the seed, so they end up hacing the same number of
+            // events.crate::securechip::fake_event_counter_reset();
+            crate::securechip::fake_event_counter_reset();
             assert!(unlock("password").is_ok());
+            assert_eq!(crate::securechip::fake_event_counter(), 6);
         }
 
         // Also check that the retained seed was encrypted with the expected encryption key.

--- a/src/rust/bitbox02/src/securechip.rs
+++ b/src/rust/bitbox02/src/securechip.rs
@@ -46,6 +46,16 @@ pub fn u2f_counter_set(_counter: u32) -> Result<(), ()> {
     Ok(())
 }
 
+#[cfg(feature = "testing")]
+pub fn fake_event_counter() -> u32 {
+    unsafe { bitbox02_sys::fake_securechip_event_counter() }
+}
+
+#[cfg(feature = "testing")]
+pub fn fake_event_counter_reset() {
+    unsafe { bitbox02_sys::fake_securechip_event_counter_reset() }
+}
+
 pub fn model() -> Result<Model, ()> {
     let mut ver = core::mem::MaybeUninit::uninit();
     match unsafe { bitbox02_sys::securechip_model(ver.as_mut_ptr()) } {

--- a/src/securechip/securechip.h
+++ b/src/securechip/securechip.h
@@ -177,4 +177,11 @@ typedef enum {
  */
 USE_RESULT bool securechip_model(securechip_model_t* model_out);
 
+#ifdef TESTING
+// Resets the event counter.
+void fake_securechip_event_counter_reset(void);
+// Retrieves the event counter.
+uint32_t fake_securechip_event_counter(void);
+#endif
+
 #endif

--- a/test/hardware-fakes/src/fake_securechip.c
+++ b/test/hardware-fakes/src/fake_securechip.c
@@ -20,51 +20,53 @@
 
 static uint32_t _u2f_counter;
 
-// Mocked contents of the secure chip rollkey slot.
-static const uint8_t _rollkey[32] =
-    "\x9d\xd1\x34\x1f\x6b\x4b\x26\xb1\x72\x89\xa1\xa3\x92\x71\x5c\xf0\xd0\x57\x8c\x84\xdb\x9a\x51"
-    "\xeb\xde\x14\x24\x06\x69\xd1\xd0\x5e";
-
 // Mocked contents of the securechip kdf slot.
 static const uint8_t _kdfkey[32] =
     "\xd2\xe1\xe6\xb1\x8b\x6c\x6b\x08\x43\x3e\xdb\xc1\xd1\x68\xc1\xa0\x04\x37\x74\xa4\x22\x18\x77"
     "\xe7\x9e\xd5\x66\x84\xbe\x5a\xc0\x1b";
 
+// Count how man seceurity events happen. The numbers were obtained by reading the security event
+// counter slot (0xE0C5) on a real device. We can use this to assert how many events were used in
+// unit tests. The number is relevant due to Optiga's throttling mechanism.
+static uint32_t _event_counter = 0;
+
 int securechip_kdf(const uint8_t* msg, size_t len, uint8_t* kdf_out)
 {
+    _event_counter += 1;
     rust_hmac_sha256(_kdfkey, 32, msg, len, kdf_out);
     return 0;
 }
-int securechip_kdf_rollkey(const uint8_t* msg, size_t len, uint8_t* kdf_out)
-{
-    rust_hmac_sha256(_rollkey, 32, msg, len, kdf_out);
-    return 0;
-}
+
 int securechip_init_new_password(const char* password)
 {
+    _event_counter += 1;
     (void)password;
     return 0;
 }
 int securechip_stretch_password(const char* password, uint8_t* stretched_out)
 {
+    _event_counter += 5;
     uint8_t key[9] = "unit-test";
     rust_hmac_sha256(key, sizeof(key), (const uint8_t*)password, strlen(password), stretched_out);
     return 0;
 }
 bool securechip_u2f_counter_set(uint32_t counter)
 {
+    _event_counter += 0;
     _u2f_counter = counter;
     return true;
 }
 
 bool securechip_u2f_counter_inc(uint32_t* counter)
 {
+    _event_counter += 0;
     *counter = _u2f_counter++;
     return true;
 }
 
 bool securechip_attestation_sign(const uint8_t* msg, uint8_t* signature_out)
 {
+    _event_counter += 1;
     return false;
 }
 
@@ -78,4 +80,14 @@ bool securechip_model(securechip_model_t* model_out)
 {
     *model_out = ATECC_ATECC608B;
     return true;
+}
+
+void fake_securechip_event_counter_reset(void)
+{
+    _event_counter = 0;
+}
+
+uint32_t fake_securechip_event_counter(void)
+{
+    return _event_counter;
 }


### PR DESCRIPTION
We count the number of security events the securechip functions take, and then assert in the keystore unit tests how many events the functions take there.

This is a basis for trying to reduce the count, so we can measure the changes properly. Too many events induce throttling.