### PR TITLE
test: add option for the simulator to write to file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - simulator: enable Test Merchant for payment requests
 - simulator: simulate a Nova device
 - Add API call to fetch multiple xpubs at once
+- Add the option for the simulator to write its memory to file.
 
 ### 9.23.1
 - EVM: add HyperEVM (HYPE) and SONIC (S) to known networks


### PR DESCRIPTION
Disclaimer: This is a mixture of educated guesses, AI, and the little C I remember writing 15 years ago... so please keep that in mind while reviewing :D Anyway I tested it manually and it seems to work fine. 

If the env variable FAKE_MEMORY_FILEPATH is provided, the simulator will
write to file using three different files:

- ${FAKE_MEMORY_FILEPATH}_shared
- ${FAKE_MEMORY_FILEPATH}_app
- ${FAKE_MEMORY_FILEPATH}_smarteeprom

mimicking the behaviour used when reading/writing to memory.
