### PR TITLE
workflows: use HAL for showing mnemonic and mnemonic quiz

### DIFF
--- a/src/rust/bitbox02-rust/src/workflow.rs
+++ b/src/rust/bitbox02-rust/src/workflow.rs
@@ -68,6 +68,17 @@ pub trait Workflows {
         label_middle: Option<&str>,
         label_right: Option<&str>,
     ) -> trinary_choice::TrinaryChoice;
+
+    /// Display the BIP39 mnemonic to the user.
+    async fn show_mnemonic(&mut self, words: &[&str]) -> Result<(), cancel::Error>;
+
+    /// Display these BIP39 mnemonic word choices to the user as part of the quiz to confirm the
+    /// user backuped up the mnemonic correctly.
+    async fn quiz_mnemonic_word(
+        &mut self,
+        choices: &[&str],
+        title: &str,
+    ) -> Result<u8, cancel::Error>;
 }
 
 pub struct RealWorkflows;
@@ -131,5 +142,17 @@ impl Workflows for RealWorkflows {
         label_right: Option<&str>,
     ) -> trinary_choice::TrinaryChoice {
         trinary_choice::choose(message, label_left, label_middle, label_right).await
+    }
+
+    async fn show_mnemonic(&mut self, words: &[&str]) -> Result<(), cancel::Error> {
+        mnemonic::show_mnemonic(words).await
+    }
+
+    async fn quiz_mnemonic_word(
+        &mut self,
+        choices: &[&str],
+        title: &str,
+    ) -> Result<u8, cancel::Error> {
+        mnemonic::confirm_word(choices, title).await
     }
 }

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic.rs
@@ -77,7 +77,7 @@ fn create_random_unique_words(word: &str, length: u8) -> (u8, Vec<zeroize::Zeroi
 }
 
 /// Displays all mnemonic words in a scroll-through screen.
-async fn show_mnemonic(words: &[&str]) -> Result<(), CancelError> {
+pub async fn show_mnemonic(words: &[&str]) -> Result<(), CancelError> {
     let result = RefCell::new(None);
     let mut component = bitbox02::ui::menu_create(bitbox02::ui::MenuParams {
         words,
@@ -94,7 +94,7 @@ async fn show_mnemonic(words: &[&str]) -> Result<(), CancelError> {
 }
 
 /// Displays the `choices` to the user, returning the index of the selected choice.
-async fn confirm_word(choices: &[&str], title: &str) -> Result<u8, CancelError> {
+pub async fn confirm_word(choices: &[&str], title: &str) -> Result<u8, CancelError> {
     let result = RefCell::new(None);
     let mut component = bitbox02::ui::menu_create(bitbox02::ui::MenuParams {
         words: choices,
@@ -125,7 +125,7 @@ pub async fn show_and_confirm_mnemonic(
         .map_err(|_| CancelError::Cancelled)?;
 
     // Part 1) Scroll through words
-    show_mnemonic(words).await?;
+    hal.ui().show_mnemonic(words).await?;
 
     // Can only succeed due to `accept_only`.
     let _ = hal
@@ -147,9 +147,9 @@ pub async fn show_and_confirm_mnemonic(
         choices.push("Back to\nrecovery words");
         let back_idx = (choices.len() - 1) as u8;
         loop {
-            match confirm_word(&choices, &title).await? {
+            match hal.ui().quiz_mnemonic_word(&choices, &title).await? {
                 selected_idx if selected_idx == correct_idx => break,
-                selected_idx if selected_idx == back_idx => show_mnemonic(words).await?,
+                selected_idx if selected_idx == back_idx => hal.ui().show_mnemonic(words).await?,
                 _ => hal.ui().status("Incorrect word\nTry again", false).await,
             }
         }

--- a/src/rust/bitbox02-rust/src/workflow/mnemonic_c_unit_tests.rs
+++ b/src/rust/bitbox02-rust/src/workflow/mnemonic_c_unit_tests.rs
@@ -17,6 +17,14 @@ pub use super::cancel::Error as CancelError;
 use alloc::string::String;
 use alloc::string::ToString;
 
+pub async fn show_mnemonic(_words: &[&str]) -> Result<(), CancelError> {
+    panic!("unused")
+}
+
+pub async fn confirm_word(_choices: &[&str], _title: &str) -> Result<u8, CancelError> {
+    panic!("unused")
+}
+
 pub async fn show_and_confirm_mnemonic(
     _hal: &mut impl crate::hal::Hal,
     words: &[&str],

--- a/src/rust/bitbox02-rust/src/workflow/testing.rs
+++ b/src/rust/bitbox02-rust/src/workflow/testing.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{Workflows, confirm, menu, sdcard, transaction, trinary_choice, trinary_input_string};
+use super::{
+    Workflows, cancel, confirm, menu, sdcard, transaction, trinary_choice, trinary_input_string,
+};
 
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -153,6 +155,18 @@ impl Workflows for TestingWorkflows<'_> {
         _label_middle: Option<&str>,
         _label_right: Option<&str>,
     ) -> trinary_choice::TrinaryChoice {
+        todo!("not used in unit tests yet");
+    }
+
+    async fn show_mnemonic(&mut self, _words: &[&str]) -> Result<(), cancel::Error> {
+        todo!("not used in unit tests yet");
+    }
+
+    async fn quiz_mnemonic_word(
+        &mut self,
+        _choices: &[&str],
+        _title: &str,
+    ) -> Result<u8, cancel::Error> {
         todo!("not used in unit tests yet");
     }
 }


### PR DESCRIPTION
`show_and_confirm_mnemonic(hal: ...)` did not use the HAL for all UI: show_mnemonic and confirm_mnemonic directly used the BitBox02 menu workflow without going through HAL. Can't use `hal().ui().menu(...)`, becaus:

- these functions bolt a cancel prompt on top
- show_mnemonic is not a normal menu where one can pick an entry, it's just a scroll-through for displaying the mnemonic

This should make it possible to mock/fake/test the mnemonic workflow functions, and provide different implementations for them in future BitBox hardware.