### PR TITLE
sd-card: Increase usb processing timeout if sd card presence is checked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 - simulator: simulate a Nova device
 - Add API call to fetch multiple xpubs at once
 - Add the option for the simulator to write its memory to file.
+- Attempt to fix "backup creation failed" while backup creation actually succeeded
 
 ### 9.23.2
 - Improve touch sensor reliability when the sdcard is inserted

--- a/src/sd.c
+++ b/src/sd.c
@@ -29,6 +29,7 @@
 #include "screen.h"
 #include "sd.h"
 #include "util.h"
+#include <usb/usb_processing.h>
 
 #include <ff.h>
 
@@ -311,14 +312,17 @@ void sd_free_list(sd_list_t* list)
 
 bool sd_card_inserted(void)
 {
+    // The sd card is allowed up to 1s to initialize, therefore the usb processing timeout must also
+    // be increased by about 1s.
+    usb_processing_timeout_reset(-10);
 #ifdef TESTING
     return true;
 #else
     sd_mmc_err_t err = sd_mmc_check(0);
     /* If initialization is ongoing, wait up to 1 second for it to initialize */
     if (err == SD_MMC_INIT_ONGOING) {
-        for (int i = 0; i < 10; ++i) {
-            delay_ms(100);
+        for (int i = 0; i < 100; ++i) {
+            delay_ms(10);
             err = sd_mmc_check(0);
             if (err != SD_MMC_INIT_ONGOING) {
                 break;


### PR DESCRIPTION
Some users experienced a bug where they got "backup creation failed" even though the backup was successfully created.

This issue could be reproduced by forcing `sd_card_inserted` to always take 1s. The logs showed that the usb processing incorrectly timed out. The processing timeout is therefore reset to about 1s more than the default.

For good measure the loop checking the sd card presence is also changed to iterate more times and wait shorter times. One common case is that it runs a single iteration of the loop, and that is now much quicker.