### PR TITLE
Add shared Bitcoin transaction vectors

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -250,6 +250,20 @@ name = "bitbox-securechip-sys"
 version = "0.1.0"
 
 [[package]]
+name = "bitbox-test-vectors"
+version = "0.1.0"
+dependencies = [
+ "bitbox-secp256k1",
+ "bitcoin",
+ "hex",
+ "miniscript",
+ "semver 1.0.20",
+ "serde",
+ "serde_json",
+ "sha3",
+]
+
+[[package]]
 name = "bitbox-u2fhid"
 version = "0.1.0"
 dependencies = [
@@ -306,6 +320,7 @@ dependencies = [
  "bitbox-platform-host",
  "bitbox-proto",
  "bitbox-secp256k1",
+ "bitbox-test-vectors",
  "bitbox-u2fhid",
  "bitbox-usb-report-queue",
  "bitbox02",
@@ -328,6 +343,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "prost",
+ "semver 1.0.20",
  "serde",
  "serde_json",
  "sha2",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "bitbox-executor",
     "bitbox03",
     "bitbox-lvgl",
+    "bitbox-test-vectors",
 ]
 
 resolver = "2"

--- a/src/rust/bitbox-test-vectors/Cargo.toml
+++ b/src/rust/bitbox-test-vectors/Cargo.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "bitbox-test-vectors"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+bitcoin = { workspace = true, features = ["std"] }
+bitbox-secp256k1 = { path = "../bitbox-secp256k1" }
+hex = { workspace = true, features = ["std"] }
+miniscript = "13.0.0"
+semver = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha3 = { workspace = true }
+
+[[bin]]
+name = "generate-btc-test-vectors"
+path = "src/main.rs"

--- a/src/rust/bitbox-test-vectors/README.md
+++ b/src/rust/bitbox-test-vectors/README.md
@@ -1,0 +1,53 @@
+# BitBox test vectors
+
+## Bitcoin transactions
+
+The Bitcoin transaction vector schema and generator are namespaced under `src/btc_transaction/`,
+leaving room for sibling vector families. Its readable Rust constructors in
+`src/btc_transaction/cases/` are the source of truth. Each scenario is authored once as a PSBT.
+Client libraries consume that PSBT through their public signing API, which converts it to the
+firmware protocol request. The firmware tests derive the same request directly from the PSBT and
+its options. A consumer should explicitly document and skip only the options its public API cannot
+express.
+
+Version expectations and the previous-transaction requirement live on the vector.
+
+Explicit derivation paths use canonical `m/...` strings rather than protocol-level integer arrays.
+Confirm and transaction-fee screens include their `longtouch` requirement. Client simulators whose
+stdout protocol omits that flag compare the remaining observable screen fields.
+`expected_signatures` describes the signature slots newly inserted by the signer, not the complete
+post-signing signature set. It records the input, key, optional Taproot leaf and sighash semantics
+without pinning nondeterministic signature bytes. Pre-existing cosigner signatures may remain in a
+PSBT, but an expected insertion slot must not already be populated.
+Consumers may separately pin a small set of deterministic signatures for implementation-specific
+regression coverage.
+
+Generate the canonical JSON explicitly from the firmware repository root:
+
+```sh
+cargo run --manifest-path src/rust/Cargo.toml \
+  -p bitbox-test-vectors --bin generate-btc-test-vectors
+```
+
+This is intentionally not a `build.rs`: ordinary builds must not rewrite committed fixtures. To
+verify that the checked-in artifact matches the constructors without writing anything, run:
+
+```sh
+cargo run --manifest-path src/rust/Cargo.toml \
+  -p bitbox-test-vectors --bin generate-btc-test-vectors -- --check
+```
+
+Passing one output path instead writes the generated JSON there. This is useful for inspecting a
+candidate artifact without changing the canonical file:
+
+```sh
+cargo run --manifest-path src/rust/Cargo.toml \
+  -p bitbox-test-vectors --bin generate-btc-test-vectors -- /tmp/btc-vectors.json
+```
+
+The canonical artifact is `testdata/btc-transaction-test-vectors.json`. Copy it byte-for-byte to:
+
+- `bitbox02-api-go/api/firmware/testdata/btc-transaction-test-vectors.json`
+- `bitbox-api-rs/tests/data/btc-transaction-test-vectors.json`
+
+Do not regenerate or edit either client copy independently.

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/additional_psbt.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/additional_psbt.rs
@@ -1,0 +1,661 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Additional portable scenarios migrated from the firmware transaction-signing tests.
+
+use super::common::{
+    ecdsa_signature, secp, simulator_xprv, simulator_xpub_at, taproot_key_signature,
+    transaction_vector,
+};
+use super::metadata_psbt::{coin_purchase_payment_request, payment_request_signature};
+use super::screens;
+use crate::btc_transaction::{
+    Coin, ExpectedSignature, FormatUnit, PaymentRequest, PaymentRequestMemo, PsbtOutputOptions,
+    PsbtSignOptions, Screen, SimpleType, TestVector,
+};
+use bitcoin::bip32::DerivationPath;
+use bitcoin::blockdata::script::Builder;
+use bitcoin::hashes::Hash;
+use bitcoin::opcodes::all::OP_RETURN;
+use bitcoin::{
+    Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness, transaction,
+};
+use std::collections::BTreeMap;
+
+const TBTC_EXTERNAL_XONLY: &str =
+    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576";
+const BTC_EXTERNAL_XONLY: &str = "a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c";
+const SILENT_PAYMENT_ADDRESS: &str = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv";
+
+struct SimpleSpend {
+    psbt: bitcoin::psbt::Psbt,
+    expected_signature: ExpectedSignature,
+}
+
+fn path(value: &str) -> DerivationPath {
+    value.parse().unwrap()
+}
+
+fn simple_script(
+    secp: &bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>,
+    script_type: SimpleType,
+    xpub: &bitcoin::bip32::Xpub,
+) -> (ScriptBuf, Option<ScriptBuf>) {
+    match script_type {
+        SimpleType::P2wpkh => (ScriptBuf::new_p2wpkh(&xpub.to_pub().wpubkey_hash()), None),
+        SimpleType::P2wpkhP2sh => {
+            let redeem_script = ScriptBuf::new_p2wpkh(&xpub.to_pub().wpubkey_hash());
+            (
+                ScriptBuf::new_p2sh(&redeem_script.script_hash()),
+                Some(redeem_script),
+            )
+        }
+        SimpleType::P2tr => (ScriptBuf::new_p2tr(secp, xpub.to_x_only_pub(), None), None),
+    }
+}
+
+fn simple_spend(
+    script_type: SimpleType,
+    account: &str,
+    input_index: u32,
+    sequence: u32,
+    locktime: u32,
+    external_script: ScriptBuf,
+) -> SimpleSpend {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let input_path = path(&format!("{account}/0/{input_index}"));
+    let change_path = path(&format!("{account}/1/0"));
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+    let (input_script, input_redeem_script) = simple_script(&secp, script_type, &input_xpub);
+    let (change_script, change_redeem_script) = simple_script(&secp, script_type, &change_xpub);
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_script,
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::from_consensus(locktime),
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(sequence),
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_script,
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: external_script,
+            },
+        ],
+    };
+    let mut psbt = bitcoin::psbt::Psbt::from_unsigned_tx(tx).unwrap();
+    // Keep the full previous transaction available even when this particular form only needs the
+    // witness UTXO. The derived firmware request may need it because of a non-Taproot owned output
+    // config.
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].redeem_script = input_redeem_script;
+    psbt.outputs[0].redeem_script = change_redeem_script;
+
+    let expected_signature = match script_type {
+        SimpleType::P2tr => {
+            psbt.inputs[0].tap_internal_key = Some(input_xpub.to_x_only_pub());
+            psbt.inputs[0].tap_key_origins.insert(
+                input_xpub.to_x_only_pub(),
+                (vec![], (fingerprint, input_path)),
+            );
+            psbt.outputs[0].tap_internal_key = Some(change_xpub.to_x_only_pub());
+            psbt.outputs[0].tap_key_origins.insert(
+                change_xpub.to_x_only_pub(),
+                (vec![], (fingerprint, change_path)),
+            );
+            taproot_key_signature(0, input_xpub.to_x_only_pub())
+        }
+        SimpleType::P2wpkh | SimpleType::P2wpkhP2sh => {
+            psbt.inputs[0]
+                .bip32_derivation
+                .insert(input_xpub.public_key, (fingerprint, input_path));
+            psbt.outputs[0]
+                .bip32_derivation
+                .insert(change_xpub.public_key, (fingerprint, change_path));
+            ecdsa_signature(0, input_xpub.public_key)
+        }
+    };
+
+    SimpleSpend {
+        psbt,
+        expected_signature,
+    }
+}
+
+fn p2tr_script(xonly: &str) -> ScriptBuf {
+    ScriptBuf::new_p2tr(&secp(), xonly.parse().unwrap(), None)
+}
+
+fn ltc_external_script() -> ScriptBuf {
+    let pubkey: bitcoin::PublicKey =
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            .parse()
+            .unwrap();
+    ScriptBuf::new_p2wpkh(&pubkey.wpubkey_hash().unwrap())
+}
+
+fn op_return_spend(payload: &[u8], value: u64) -> SimpleSpend {
+    let mut spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    let script = Builder::new()
+        .push_opcode(OP_RETURN)
+        .push_slice(bitcoin::script::PushBytesBuf::try_from(payload.to_vec()).unwrap())
+        .into_script();
+    spend.psbt.unsigned_tx.output.insert(
+        0,
+        TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: script,
+        },
+    );
+    spend.psbt.outputs.insert(0, Default::default());
+    spend
+}
+
+fn op_return_nonascii() -> TestVector {
+    let spend = op_return_spend(&[1, 2, 3, 4, 5], 0);
+    transaction_vector(
+        "op-return-nonascii",
+        "Displays a non-ASCII OP_RETURN payload as hexadecimal and signs the transaction.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::op_return_nonascii(),
+    )
+}
+
+fn op_return_nonzero_value() -> TestVector {
+    let spend = op_return_spend(b"hello world", 100);
+    transaction_vector(
+        "op-return-nonzero-value",
+        "Rejects a nonzero-value OP_RETURN output.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![],
+        screens::unsupported_then_invalid_input("9.24.0"),
+    )
+}
+
+fn op_return_silent_payment() -> TestVector {
+    let spend = op_return_spend(b"hello world", 0);
+    transaction_vector(
+        "op-return-silent-payment",
+        "Rejects silent-payment metadata on an OP_RETURN output.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions {
+            outputs: BTreeMap::from([(
+                0,
+                PsbtOutputOptions {
+                    silent_payment_address: Some(SILENT_PAYMENT_ADDRESS.into()),
+                    payment_request_index: None,
+                },
+            )]),
+            ..Default::default()
+        },
+        vec![],
+        screens::unsupported_then_invalid_input("9.24.0"),
+    )
+}
+
+fn op_return_payment_request() -> TestVector {
+    let spend = op_return_spend(b"hello world", 0);
+    let signed_address = "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d";
+    transaction_vector(
+        "op-return-payment-request",
+        "Rejects payment-request metadata on an OP_RETURN output.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions {
+            outputs: BTreeMap::from([(
+                0,
+                PsbtOutputOptions {
+                    silent_payment_address: None,
+                    payment_request_index: Some(0),
+                },
+            )]),
+            payment_requests: vec![PaymentRequest {
+                recipient_name: "Test Merchant".into(),
+                total_amount: 1,
+                nonce: String::new(),
+                memos: vec![PaymentRequestMemo::Text {
+                    note: "TextMemo line1\nTextMemo line2".into(),
+                }],
+                signature: hex::encode(payment_request_signature(1, signed_address)),
+            }],
+            ..Default::default()
+        },
+        vec![],
+        screens::unsupported_then_invalid_input("9.24.0"),
+    )
+}
+
+fn multiple_output_types(
+    coin: Coin,
+    format_unit: FormatUnit,
+    high_fee_warning: bool,
+) -> TestVector {
+    assert!(!high_fee_warning || coin == Coin::Btc && format_unit == FormatUnit::Default);
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let coin_type = match coin {
+        Coin::Btc => 0,
+        Coin::Ltc => 2,
+        Coin::Tbtc => panic!("multiple-output fixture has no TBTC address set"),
+    };
+    let account = format!("m/84'/{coin_type}'/10'");
+    let input_path = path(&format!("{account}/0/5"));
+    let change0_path = path(&format!("{account}/1/3"));
+    let change1_path = path(&format!("{account}/1/30"));
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change0_xpub = simulator_xpub_at(&secp, &change0_path);
+    let change1_xpub = simulator_xpub_at(&secp, &change1_path);
+    let prev_tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(2_030_000_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(&input_xpub.to_pub().wpubkey_hash()),
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2pkh(&bitcoin::PubkeyHash::from_byte_array(
+                    [0x11; 20],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(if high_fee_warning {
+                    1_034_567_890
+                } else {
+                    1_234_567_890
+                }),
+                script_pubkey: ScriptBuf::new_p2sh(&bitcoin::ScriptHash::from_byte_array(
+                    [0x22; 20],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(6_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array(
+                    [0x33; 20],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(7_000),
+                script_pubkey: ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array(
+                    [0x44; 32],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(690_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&change0_xpub.to_pub().wpubkey_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(100),
+                script_pubkey: ScriptBuf::new_p2wpkh(&change1_xpub.to_pub().wpubkey_hash()),
+            },
+        ],
+    };
+    let mut psbt = bitcoin::psbt::Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0]
+        .bip32_derivation
+        .insert(input_xpub.public_key, (fingerprint, input_path));
+    psbt.outputs[4]
+        .bip32_derivation
+        .insert(change0_xpub.public_key, (fingerprint, change0_path));
+    psbt.outputs[5]
+        .bip32_derivation
+        .insert(change1_xpub.public_key, (fingerprint, change1_path));
+
+    let unit_name = match format_unit {
+        FormatUnit::Default => "coin",
+        FormatUnit::Sat => "satoshi",
+    };
+    let id = if high_fee_warning {
+        "high-fee-rounding".into()
+    } else {
+        format!(
+            "multiple-output-types-{}-{unit_name}",
+            match coin {
+                Coin::Btc => "bitcoin",
+                Coin::Ltc => "litecoin",
+                Coin::Tbtc => unreachable!(),
+            }
+        )
+    };
+    transaction_vector(
+        &id,
+        if high_fee_warning {
+            "Displays the 18.1% high-fee warning and requires the final longtouch on the warning instead of the fee screen."
+        } else {
+            "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction."
+        },
+        coin,
+        psbt,
+        PsbtSignOptions {
+            format_unit,
+            ..Default::default()
+        },
+        vec![ecdsa_signature(0, input_xpub.public_key)],
+        screens::multiple_output_types(coin, format_unit == FormatUnit::Sat, high_fee_warning),
+    )
+}
+
+fn swap_payment_request(unsupported_source: bool) -> TestVector {
+    let (coin, account, external_xonly, source_address, source_coin_type) = if unsupported_source {
+        (
+            Coin::Tbtc,
+            "m/84'/1'/0'",
+            TBTC_EXTERNAL_XONLY,
+            "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d",
+            1,
+        )
+    } else {
+        (
+            Coin::Btc,
+            "m/84'/0'/0'",
+            BTC_EXTERNAL_XONLY,
+            "bc1pmg5dhafms6h9nts4dtehgkanym6yeccfmk5hx3ts3jxnm4zh2knqv80ha5",
+            0,
+        )
+    };
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        account,
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(external_xonly),
+    );
+    let options = PsbtSignOptions {
+        outputs: BTreeMap::from([(
+            1,
+            PsbtOutputOptions {
+                silent_payment_address: None,
+                payment_request_index: Some(0),
+            },
+        )]),
+        payment_requests: vec![coin_purchase_payment_request(
+            source_coin_type,
+            20_000_000,
+            source_address,
+        )],
+        ..Default::default()
+    };
+    transaction_vector(
+        if unsupported_source {
+            "swap-payment-request-unsupported-source"
+        } else {
+            "swap-payment-request"
+        },
+        if unsupported_source {
+            "Rejects a coin-purchase payment request whose source account is Bitcoin testnet."
+        } else {
+            "Displays and signs a Bitcoin-to-Ethereum coin-purchase payment request."
+        },
+        coin,
+        spend.psbt,
+        options,
+        (!unsupported_source)
+            .then_some(spend.expected_signature)
+            .into_iter()
+            .collect(),
+        if unsupported_source {
+            screens::swap_payment_request_unsupported_source()
+        } else {
+            screens::swap_payment_request()
+        },
+    )
+}
+
+fn p2wpkh_p2sh() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkhP2sh,
+        "m/49'/1'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "p2wpkh-p2sh",
+        "Signs a nested SegWit input and recognizes nested SegWit change.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[]),
+    )
+}
+
+fn high_address_index() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        100_000,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "high-input-address-index",
+        "Spends an owned input at address index 100000 without treating the high spend path as a receive-address verification request.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[]),
+    )
+}
+
+fn locktime(block: u32, sequence: u32, rbf: bool) -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        0,
+        sequence,
+        block,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    let qualifier = if rbf { "rbf" } else { "non-rbf" };
+    let locktime_screen = Screen::Confirm {
+        title: String::new(),
+        body: format!(
+            "Locktime on block:\n{block}\nTransaction is {}RBF",
+            if rbf { "" } else { "not " }
+        ),
+        longtouch: false,
+    };
+    transaction_vector(
+        &format!("locktime-{qualifier}"),
+        &format!("Displays block locktime {block} and its {qualifier} sequence semantics."),
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[locktime_screen]),
+    )
+}
+
+fn zero_locktime() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        0,
+        Sequence::MAX.0 - 2,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "locktime-zero",
+        "Suppresses the locktime confirmation when locktime is zero even if the sequence signals RBF.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[]),
+    )
+}
+
+fn p2tr_output_btc() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/0'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(BTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "p2tr-output-mainnet",
+        "Displays and signs a mainnet P2TR recipient output from a native SegWit account.",
+        Coin::Btc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::p2tr_output_btc(),
+    )
+}
+
+fn silent_payment_rejects_owned_output() -> TestVector {
+    let mut spend = simple_spend(
+        SimpleType::P2tr,
+        "m/86'/0'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(BTC_EXTERNAL_XONLY),
+    );
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let receive_path = path("m/84'/0'/0'/0/0");
+    let receive_xpub = simulator_xpub_at(&secp, &receive_path);
+    spend.psbt.unsigned_tx.output[1].script_pubkey =
+        ScriptBuf::new_p2wpkh(&receive_xpub.to_pub().wpubkey_hash());
+    spend.psbt.outputs[1]
+        .bip32_derivation
+        .insert(receive_xpub.public_key, (fingerprint, receive_path));
+
+    let options = PsbtSignOptions {
+        outputs: BTreeMap::from([(
+            1,
+            PsbtOutputOptions {
+                silent_payment_address: Some(SILENT_PAYMENT_ADDRESS.into()),
+                payment_request_index: None,
+            },
+        )]),
+        ..Default::default()
+    };
+    transaction_vector(
+        "silent-payment-owned-output",
+        "Covers version-specific handling of silent-payment metadata attached to an output owned by this device, rejected since v9.26.3.",
+        Coin::Btc,
+        spend.psbt,
+        options,
+        vec![spend.expected_signature],
+        screens::silent_payment_owned_output(),
+    )
+}
+
+fn ltc_locktime(sequence: u32, qualifier: &str) -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/2'/0'",
+        0,
+        sequence,
+        10,
+        ltc_external_script(),
+    );
+    let locktime_screen = Screen::Confirm {
+        title: String::new(),
+        body: "Locktime on block:\n10\n".into(),
+        longtouch: false,
+    };
+    transaction_vector(
+        &format!("locktime-litecoin-{qualifier}"),
+        "Displays a Litecoin block locktime without Bitcoin-specific RBF wording.",
+        Coin::Ltc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_ltc(&[locktime_screen]),
+    )
+}
+
+pub fn all() -> Vec<TestVector> {
+    vec![
+        multiple_output_types(Coin::Btc, FormatUnit::Default, false),
+        multiple_output_types(Coin::Btc, FormatUnit::Sat, false),
+        multiple_output_types(Coin::Ltc, FormatUnit::Default, false),
+        multiple_output_types(Coin::Btc, FormatUnit::Default, true),
+        swap_payment_request(false),
+        swap_payment_request(true),
+        p2wpkh_p2sh(),
+        high_address_index(),
+        zero_locktime(),
+        locktime(10, Sequence::MAX.0 - 1, false),
+        locktime(10, Sequence::MAX.0 - 2, true),
+        ltc_locktime(Sequence::MAX.0 - 1, "non-rbf-sequence"),
+        ltc_locktime(Sequence::MAX.0 - 2, "rbf-sequence"),
+        p2tr_output_btc(),
+        silent_payment_rejects_owned_output(),
+        op_return_nonascii(),
+        op_return_nonzero_value(),
+        op_return_silent_payment(),
+        op_return_payment_request(),
+    ]
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/additional_psbt.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/additional_psbt.rs
@@ -1,0 +1,723 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Additional portable scenarios migrated from the firmware transaction-signing tests.
+
+use super::common::{
+    ecdsa_signature, secp, simulator_xprv, simulator_xpub_at, taproot_key_signature,
+    transaction_vector,
+};
+use super::metadata_psbt::{coin_purchase_payment_request, payment_request_signature};
+use super::screens;
+use crate::btc_transaction::{
+    Coin, ExpectedSignature, FormatUnit, PaymentRequest, PaymentRequestMemo, PsbtOutputOptions,
+    PsbtSignOptions, Screen, SimpleType, TestVector,
+};
+use bitcoin::bip32::DerivationPath;
+use bitcoin::blockdata::script::Builder;
+use bitcoin::hashes::Hash;
+use bitcoin::opcodes::all::OP_RETURN;
+use bitcoin::{
+    Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness, transaction,
+};
+use std::collections::BTreeMap;
+
+const TBTC_EXTERNAL_XONLY: &str =
+    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576";
+const BTC_EXTERNAL_XONLY: &str = "a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c";
+const SILENT_PAYMENT_ADDRESS: &str = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv";
+
+struct SimpleSpend {
+    psbt: bitcoin::psbt::Psbt,
+    expected_signature: ExpectedSignature,
+}
+
+fn path(value: &str) -> DerivationPath {
+    value.parse().unwrap()
+}
+
+fn simple_script(
+    secp: &bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>,
+    script_type: SimpleType,
+    xpub: &bitcoin::bip32::Xpub,
+) -> (ScriptBuf, Option<ScriptBuf>) {
+    match script_type {
+        SimpleType::P2wpkh => (ScriptBuf::new_p2wpkh(&xpub.to_pub().wpubkey_hash()), None),
+        SimpleType::P2wpkhP2sh => {
+            let redeem_script = ScriptBuf::new_p2wpkh(&xpub.to_pub().wpubkey_hash());
+            (
+                ScriptBuf::new_p2sh(&redeem_script.script_hash()),
+                Some(redeem_script),
+            )
+        }
+        SimpleType::P2tr => (ScriptBuf::new_p2tr(secp, xpub.to_x_only_pub(), None), None),
+    }
+}
+
+fn simple_spend(
+    script_type: SimpleType,
+    account: &str,
+    input_index: u32,
+    sequence: u32,
+    locktime: u32,
+    external_script: ScriptBuf,
+) -> SimpleSpend {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let input_path = path(&format!("{account}/0/{input_index}"));
+    let change_path = path(&format!("{account}/1/0"));
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+    let (input_script, input_redeem_script) = simple_script(&secp, script_type, &input_xpub);
+    let (change_script, change_redeem_script) = simple_script(&secp, script_type, &change_xpub);
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_script,
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::from_consensus(locktime),
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(sequence),
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_script,
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: external_script,
+            },
+        ],
+    };
+    let mut psbt = bitcoin::psbt::Psbt::from_unsigned_tx(tx).unwrap();
+    // Keep the full previous transaction available even when this particular form only needs the
+    // witness UTXO. The derived firmware request may need it because of a non-Taproot owned output
+    // config.
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].redeem_script = input_redeem_script;
+    psbt.outputs[0].redeem_script = change_redeem_script;
+
+    let expected_signature = match script_type {
+        SimpleType::P2tr => {
+            psbt.inputs[0].tap_internal_key = Some(input_xpub.to_x_only_pub());
+            psbt.inputs[0].tap_key_origins.insert(
+                input_xpub.to_x_only_pub(),
+                (vec![], (fingerprint, input_path)),
+            );
+            psbt.outputs[0].tap_internal_key = Some(change_xpub.to_x_only_pub());
+            psbt.outputs[0].tap_key_origins.insert(
+                change_xpub.to_x_only_pub(),
+                (vec![], (fingerprint, change_path)),
+            );
+            taproot_key_signature(0, input_xpub.to_x_only_pub())
+        }
+        SimpleType::P2wpkh | SimpleType::P2wpkhP2sh => {
+            psbt.inputs[0]
+                .bip32_derivation
+                .insert(input_xpub.public_key, (fingerprint, input_path));
+            psbt.outputs[0]
+                .bip32_derivation
+                .insert(change_xpub.public_key, (fingerprint, change_path));
+            ecdsa_signature(0, input_xpub.public_key)
+        }
+    };
+
+    SimpleSpend {
+        psbt,
+        expected_signature,
+    }
+}
+
+fn p2tr_script(xonly: &str) -> ScriptBuf {
+    ScriptBuf::new_p2tr(&secp(), xonly.parse().unwrap(), None)
+}
+
+fn ltc_external_script() -> ScriptBuf {
+    let pubkey: bitcoin::PublicKey =
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            .parse()
+            .unwrap();
+    ScriptBuf::new_p2wpkh(&pubkey.wpubkey_hash().unwrap())
+}
+
+fn op_return_script(payload: &[u8]) -> ScriptBuf {
+    Builder::new()
+        .push_opcode(OP_RETURN)
+        .push_slice(bitcoin::script::PushBytesBuf::try_from(payload.to_vec()).unwrap())
+        .into_script()
+}
+
+fn op_return_spend(payload: &[u8], value: u64) -> SimpleSpend {
+    let mut spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    spend.psbt.unsigned_tx.output.insert(
+        0,
+        TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: op_return_script(payload),
+        },
+    );
+    spend.psbt.outputs.insert(0, Default::default());
+    spend
+}
+
+fn op_return_nonascii() -> TestVector {
+    let spend = op_return_spend(&[1, 2, 3, 4, 5], 0);
+    transaction_vector(
+        "op-return-nonascii",
+        "Displays a non-ASCII OP_RETURN payload as hexadecimal and signs the transaction.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::op_return_nonascii(),
+    )
+}
+
+fn op_return_nonzero_value() -> TestVector {
+    let spend = op_return_spend(b"hello world", 100);
+    transaction_vector(
+        "op-return-nonzero-value",
+        "Rejects a nonzero-value OP_RETURN output.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![],
+        screens::unsupported_then_invalid_input("9.24.0"),
+    )
+}
+
+fn op_return_silent_payment() -> TestVector {
+    let spend = op_return_spend(b"hello world", 0);
+    transaction_vector(
+        "op-return-silent-payment",
+        "Rejects silent-payment metadata on an OP_RETURN output.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions {
+            outputs: BTreeMap::from([(
+                0,
+                PsbtOutputOptions {
+                    silent_payment_address: Some(SILENT_PAYMENT_ADDRESS.into()),
+                    payment_request_index: None,
+                },
+            )]),
+            ..Default::default()
+        },
+        vec![],
+        screens::unsupported_then_invalid_input("9.24.0"),
+    )
+}
+
+fn op_return_payment_request() -> TestVector {
+    let spend = op_return_spend(b"hello world", 0);
+    let signed_address = "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d";
+    transaction_vector(
+        "op-return-payment-request",
+        "Rejects payment-request metadata on an OP_RETURN output.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions {
+            outputs: BTreeMap::from([(
+                0,
+                PsbtOutputOptions {
+                    silent_payment_address: None,
+                    payment_request_index: Some(0),
+                },
+            )]),
+            payment_requests: vec![PaymentRequest {
+                recipient_name: "Test Merchant".into(),
+                total_amount: 1,
+                nonce: String::new(),
+                memos: vec![PaymentRequestMemo::Text {
+                    note: "TextMemo line1\nTextMemo line2".into(),
+                }],
+                signature: hex::encode(payment_request_signature(1, signed_address)),
+            }],
+            ..Default::default()
+        },
+        vec![],
+        screens::unsupported_then_invalid_input("9.24.0"),
+    )
+}
+
+fn all_change_spend(change_value: u64, with_op_return: bool) -> SimpleSpend {
+    let mut spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/0'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(BTC_EXTERNAL_XONLY),
+    );
+    spend.psbt.unsigned_tx.output.truncate(1);
+    spend.psbt.outputs.truncate(1);
+    spend.psbt.unsigned_tx.output[0].value = Amount::from_sat(change_value);
+    if with_op_return {
+        spend.psbt.unsigned_tx.output.push(TxOut {
+            value: Amount::ZERO,
+            script_pubkey: op_return_script(b"metadata"),
+        });
+        spend.psbt.outputs.push(Default::default());
+    }
+    spend
+}
+
+fn all_change_high_fee(with_op_return: bool) -> TestVector {
+    let spend = all_change_spend(30_000_000, with_op_return);
+    transaction_vector(
+        if with_op_return {
+            "all-change-high-fee-op-return"
+        } else {
+            "all-change-high-fee"
+        },
+        if with_op_return {
+            "Uses the verified input total for a high-fee warning when all spendable outputs are change and an OP_RETURN output is present."
+        } else {
+            "Uses the verified input total for a high-fee warning when every output is change."
+        },
+        Coin::Btc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::all_change_high_fee(with_op_return),
+    )
+}
+
+fn all_change_fee_below_threshold() -> TestVector {
+    let spend = all_change_spend(95_000_000, false);
+    transaction_vector(
+        "all-change-fee-below-threshold",
+        "Does not warn when the fee of an all-change transaction is below 10% of the verified input total.",
+        Coin::Btc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::all_change_fee_below_threshold(),
+    )
+}
+
+fn multiple_output_types(
+    coin: Coin,
+    format_unit: FormatUnit,
+    high_fee_warning: bool,
+) -> TestVector {
+    assert!(!high_fee_warning || coin == Coin::Btc && format_unit == FormatUnit::Default);
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let coin_type = match coin {
+        Coin::Btc => 0,
+        Coin::Ltc => 2,
+        Coin::Tbtc => panic!("multiple-output fixture has no TBTC address set"),
+    };
+    let account = format!("m/84'/{coin_type}'/10'");
+    let input_path = path(&format!("{account}/0/5"));
+    let change0_path = path(&format!("{account}/1/3"));
+    let change1_path = path(&format!("{account}/1/30"));
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change0_xpub = simulator_xpub_at(&secp, &change0_path);
+    let change1_xpub = simulator_xpub_at(&secp, &change1_path);
+    let prev_tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(2_030_000_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(&input_xpub.to_pub().wpubkey_hash()),
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2pkh(&bitcoin::PubkeyHash::from_byte_array(
+                    [0x11; 20],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(if high_fee_warning {
+                    1_034_567_890
+                } else {
+                    1_234_567_890
+                }),
+                script_pubkey: ScriptBuf::new_p2sh(&bitcoin::ScriptHash::from_byte_array(
+                    [0x22; 20],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(6_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array(
+                    [0x33; 20],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(7_000),
+                script_pubkey: ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array(
+                    [0x44; 32],
+                )),
+            },
+            TxOut {
+                value: Amount::from_sat(690_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&change0_xpub.to_pub().wpubkey_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(100),
+                script_pubkey: ScriptBuf::new_p2wpkh(&change1_xpub.to_pub().wpubkey_hash()),
+            },
+        ],
+    };
+    let mut psbt = bitcoin::psbt::Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0]
+        .bip32_derivation
+        .insert(input_xpub.public_key, (fingerprint, input_path));
+    psbt.outputs[4]
+        .bip32_derivation
+        .insert(change0_xpub.public_key, (fingerprint, change0_path));
+    psbt.outputs[5]
+        .bip32_derivation
+        .insert(change1_xpub.public_key, (fingerprint, change1_path));
+
+    let unit_name = match format_unit {
+        FormatUnit::Default => "coin",
+        FormatUnit::Sat => "satoshi",
+    };
+    let id = if high_fee_warning {
+        "high-fee-rounding".into()
+    } else {
+        format!(
+            "multiple-output-types-{}-{unit_name}",
+            match coin {
+                Coin::Btc => "bitcoin",
+                Coin::Ltc => "litecoin",
+                Coin::Tbtc => unreachable!(),
+            }
+        )
+    };
+    transaction_vector(
+        &id,
+        if high_fee_warning {
+            "Displays the 18.1% high-fee warning and requires the final longtouch on the warning instead of the fee screen."
+        } else {
+            "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction."
+        },
+        coin,
+        psbt,
+        PsbtSignOptions {
+            format_unit,
+            ..Default::default()
+        },
+        vec![ecdsa_signature(0, input_xpub.public_key)],
+        screens::multiple_output_types(coin, format_unit == FormatUnit::Sat, high_fee_warning),
+    )
+}
+
+fn swap_payment_request(unsupported_source: bool) -> TestVector {
+    let (coin, account, external_xonly, source_address, source_coin_type) = if unsupported_source {
+        (
+            Coin::Tbtc,
+            "m/84'/1'/0'",
+            TBTC_EXTERNAL_XONLY,
+            "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d",
+            1,
+        )
+    } else {
+        (
+            Coin::Btc,
+            "m/84'/0'/0'",
+            BTC_EXTERNAL_XONLY,
+            "bc1pmg5dhafms6h9nts4dtehgkanym6yeccfmk5hx3ts3jxnm4zh2knqv80ha5",
+            0,
+        )
+    };
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        account,
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(external_xonly),
+    );
+    let options = PsbtSignOptions {
+        outputs: BTreeMap::from([(
+            1,
+            PsbtOutputOptions {
+                silent_payment_address: None,
+                payment_request_index: Some(0),
+            },
+        )]),
+        payment_requests: vec![coin_purchase_payment_request(
+            source_coin_type,
+            20_000_000,
+            source_address,
+        )],
+        ..Default::default()
+    };
+    transaction_vector(
+        if unsupported_source {
+            "swap-payment-request-unsupported-source"
+        } else {
+            "swap-payment-request"
+        },
+        if unsupported_source {
+            "Rejects a coin-purchase payment request whose source account is Bitcoin testnet."
+        } else {
+            "Displays and signs a Bitcoin-to-Ethereum coin-purchase payment request."
+        },
+        coin,
+        spend.psbt,
+        options,
+        (!unsupported_source)
+            .then_some(spend.expected_signature)
+            .into_iter()
+            .collect(),
+        if unsupported_source {
+            screens::swap_payment_request_unsupported_source()
+        } else {
+            screens::swap_payment_request()
+        },
+    )
+}
+
+fn p2wpkh_p2sh() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkhP2sh,
+        "m/49'/1'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "p2wpkh-p2sh",
+        "Signs a nested SegWit input and recognizes nested SegWit change.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[]),
+    )
+}
+
+fn high_address_index() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        100_000,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "high-input-address-index",
+        "Spends an owned input at address index 100000 without treating the high spend path as a receive-address verification request.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[]),
+    )
+}
+
+fn locktime(block: u32, sequence: u32, rbf: bool) -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        0,
+        sequence,
+        block,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    let qualifier = if rbf { "rbf" } else { "non-rbf" };
+    let locktime_screen = Screen::Confirm {
+        title: String::new(),
+        body: format!(
+            "Locktime on block:\n{block}\nTransaction is {}RBF",
+            if rbf { "" } else { "not " }
+        ),
+        longtouch: false,
+    };
+    transaction_vector(
+        &format!("locktime-{qualifier}"),
+        &format!("Displays block locktime {block} and its {qualifier} sequence semantics."),
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[locktime_screen]),
+    )
+}
+
+fn zero_locktime() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/1'/0'",
+        0,
+        Sequence::MAX.0 - 2,
+        0,
+        p2tr_script(TBTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "locktime-zero",
+        "Suppresses the locktime confirmation when locktime is zero even if the sequence signals RBF.",
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_tbtc(&[]),
+    )
+}
+
+fn p2tr_output_btc() -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/0'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(BTC_EXTERNAL_XONLY),
+    );
+    transaction_vector(
+        "p2tr-output-mainnet",
+        "Displays and signs a mainnet P2TR recipient output from a native SegWit account.",
+        Coin::Btc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::p2tr_output_btc(),
+    )
+}
+
+fn silent_payment_rejects_owned_output() -> TestVector {
+    let mut spend = simple_spend(
+        SimpleType::P2tr,
+        "m/86'/0'/0'",
+        0,
+        Sequence::MAX.0,
+        0,
+        p2tr_script(BTC_EXTERNAL_XONLY),
+    );
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let receive_path = path("m/84'/0'/0'/0/0");
+    let receive_xpub = simulator_xpub_at(&secp, &receive_path);
+    spend.psbt.unsigned_tx.output[1].script_pubkey =
+        ScriptBuf::new_p2wpkh(&receive_xpub.to_pub().wpubkey_hash());
+    spend.psbt.outputs[1]
+        .bip32_derivation
+        .insert(receive_xpub.public_key, (fingerprint, receive_path));
+
+    let options = PsbtSignOptions {
+        outputs: BTreeMap::from([(
+            1,
+            PsbtOutputOptions {
+                silent_payment_address: Some(SILENT_PAYMENT_ADDRESS.into()),
+                payment_request_index: None,
+            },
+        )]),
+        ..Default::default()
+    };
+    transaction_vector(
+        "silent-payment-owned-output",
+        "Covers version-specific handling of silent-payment metadata attached to an output owned by this device, rejected since v9.26.3.",
+        Coin::Btc,
+        spend.psbt,
+        options,
+        vec![spend.expected_signature],
+        screens::silent_payment_owned_output(),
+    )
+}
+
+fn ltc_locktime(sequence: u32, qualifier: &str) -> TestVector {
+    let spend = simple_spend(
+        SimpleType::P2wpkh,
+        "m/84'/2'/0'",
+        0,
+        sequence,
+        10,
+        ltc_external_script(),
+    );
+    let locktime_screen = Screen::Confirm {
+        title: String::new(),
+        body: "Locktime on block:\n10\n".into(),
+        longtouch: false,
+    };
+    transaction_vector(
+        &format!("locktime-litecoin-{qualifier}"),
+        "Displays a Litecoin block locktime without Bitcoin-specific RBF wording.",
+        Coin::Ltc,
+        spend.psbt,
+        PsbtSignOptions::default(),
+        vec![spend.expected_signature],
+        screens::simple_ltc(&[locktime_screen]),
+    )
+}
+
+pub fn all() -> Vec<TestVector> {
+    vec![
+        multiple_output_types(Coin::Btc, FormatUnit::Default, false),
+        multiple_output_types(Coin::Btc, FormatUnit::Sat, false),
+        multiple_output_types(Coin::Ltc, FormatUnit::Default, false),
+        multiple_output_types(Coin::Btc, FormatUnit::Default, true),
+        swap_payment_request(false),
+        swap_payment_request(true),
+        p2wpkh_p2sh(),
+        high_address_index(),
+        zero_locktime(),
+        locktime(10, Sequence::MAX.0 - 1, false),
+        locktime(10, Sequence::MAX.0 - 2, true),
+        ltc_locktime(Sequence::MAX.0 - 1, "non-rbf-sequence"),
+        ltc_locktime(Sequence::MAX.0 - 2, "rbf-sequence"),
+        p2tr_output_btc(),
+        silent_payment_rejects_owned_output(),
+        op_return_nonascii(),
+        op_return_nonzero_value(),
+        op_return_silent_payment(),
+        op_return_payment_request(),
+        all_change_high_fee(false),
+        all_change_high_fee(true),
+        all_change_fee_below_threshold(),
+    ]
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/common.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/common.rs
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::btc_transaction::{
+    Coin, ExpectedSignature, FirmwareInput, FirmwareOutput, FirmwareSignRequest, OutputType,
+    PsbtForm, PsbtSignOptions, ScriptConfig, ScriptConfigWithKeypath, Sighash, SignatureKind,
+    SimpleType, TestVector, VersionExpectation,
+};
+use bitcoin::bip32::{DerivationPath, Xpriv, Xpub};
+use bitcoin::key::TapTweak;
+use bitcoin::script::Instruction;
+use bitcoin::secp256k1::{self, Secp256k1};
+use bitcoin::{ScriptBuf, TxOut};
+
+use std::collections::BTreeMap;
+
+pub const SOME_XPUB: &str = "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk";
+
+pub fn secp() -> Secp256k1<secp256k1::All> {
+    Secp256k1::new()
+}
+
+pub fn simulator_xprv() -> Xpriv {
+    crate::btc_transaction::SIMULATOR_BIP32_XPRV
+        .parse()
+        .unwrap()
+}
+
+pub fn simulator_xpub_at<C: secp256k1::Signing>(
+    secp: &Secp256k1<C>,
+    path: &DerivationPath,
+) -> Xpub {
+    Xpub::from_priv(secp, &simulator_xprv().derive_priv(secp, path).unwrap())
+}
+
+pub fn keypath(path: &DerivationPath) -> String {
+    format!("m/{path}")
+}
+
+pub fn transaction_vector(
+    id: &str,
+    description: &str,
+    coin: Coin,
+    psbt: bitcoin::psbt::Psbt,
+    psbt_options: PsbtSignOptions,
+    expected_signatures: Vec<ExpectedSignature>,
+    expectations: Vec<VersionExpectation>,
+) -> TestVector {
+    let expected_needs_prevtxs = firmware_request_from_psbt(&psbt, &psbt_options)
+        .unwrap()
+        .needs_prevtxs();
+    TestVector {
+        id: id.into(),
+        description: description.into(),
+        coin,
+        psbt: PsbtForm {
+            transaction: hex::encode(psbt.serialize()),
+            options: psbt_options,
+        },
+        expected_needs_prevtxs,
+        expectations,
+        registrations: vec![],
+        expected_signatures,
+        expected_generated_outputs: BTreeMap::new(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum OurKey {
+    Segwit(bitcoin::secp256k1::PublicKey),
+    Taproot(bitcoin::secp256k1::XOnlyPublicKey),
+}
+
+impl OurKey {
+    fn bip352_pubkey(self, secp: &Secp256k1<secp256k1::All>) -> Vec<u8> {
+        match self {
+            Self::Segwit(pubkey) => pubkey.serialize().to_vec(),
+            // Taproot silent-payment inputs use the tweaked key-spend private key.
+            Self::Taproot(pubkey) => pubkey.tap_tweak(secp, None).0.serialize().to_vec(),
+        }
+    }
+}
+
+fn input_our_key(
+    input: &bitcoin::psbt::Input,
+    fingerprint: bitcoin::bip32::Fingerprint,
+) -> Option<(OurKey, DerivationPath)> {
+    input
+        .tap_key_origins
+        .iter()
+        .find_map(|(pubkey, (_, (candidate, keypath)))| {
+            (*candidate == fingerprint).then(|| (OurKey::Taproot(*pubkey), keypath.clone()))
+        })
+        .or_else(|| {
+            input
+                .bip32_derivation
+                .iter()
+                .find_map(|(pubkey, (candidate, keypath))| {
+                    (*candidate == fingerprint).then(|| (OurKey::Segwit(*pubkey), keypath.clone()))
+                })
+        })
+}
+
+fn output_our_key(
+    output: &bitcoin::psbt::Output,
+    fingerprint: bitcoin::bip32::Fingerprint,
+) -> Option<(OurKey, DerivationPath)> {
+    output
+        .tap_key_origins
+        .iter()
+        .find_map(|(pubkey, (_, (candidate, keypath)))| {
+            (*candidate == fingerprint).then(|| (OurKey::Taproot(*pubkey), keypath.clone()))
+        })
+        .or_else(|| {
+            output
+                .bip32_derivation
+                .iter()
+                .find_map(|(pubkey, (candidate, keypath))| {
+                    (*candidate == fingerprint).then(|| (OurKey::Segwit(*pubkey), keypath.clone()))
+                })
+        })
+}
+
+fn account_keypath(path: &DerivationPath) -> Result<String, String> {
+    let components = path.as_ref();
+    if components.len() < 3 {
+        return Err(format!("keypath m/{path} has no account prefix"));
+    }
+    Ok(keypath(&DerivationPath::from(components[..3].to_vec())))
+}
+
+fn script_config_from_utxo(
+    output: &TxOut,
+    keypath: &DerivationPath,
+    redeem_script: Option<&ScriptBuf>,
+) -> Result<ScriptConfigWithKeypath, String> {
+    let script_type = if output.script_pubkey.is_p2wpkh() {
+        SimpleType::P2wpkh
+    } else if output.script_pubkey.is_p2sh()
+        && redeem_script.is_some_and(|script| script.is_p2wpkh())
+    {
+        SimpleType::P2wpkhP2sh
+    } else if output.script_pubkey.is_p2tr() {
+        SimpleType::P2tr
+    } else {
+        return Err(format!(
+            "cannot infer a simple script config for {}",
+            output.script_pubkey
+        ));
+    };
+    Ok(ScriptConfigWithKeypath {
+        script_config: ScriptConfig::Simple { script_type },
+        keypath: account_keypath(keypath)?,
+    })
+}
+
+fn find_or_add_config(
+    configs: &mut Vec<ScriptConfigWithKeypath>,
+    config: ScriptConfigWithKeypath,
+) -> usize {
+    if let Some(index) = configs.iter().position(|candidate| candidate == &config) {
+        index
+    } else {
+        configs.push(config);
+        configs.len() - 1
+    }
+}
+
+fn same_account(
+    input_configs: &[ScriptConfigWithKeypath],
+    output_config: &ScriptConfigWithKeypath,
+) -> Result<bool, String> {
+    for input_config in input_configs {
+        if matches!(input_config.script_config, ScriptConfig::Simple { .. }) {
+            let input_path = input_config
+                .keypath
+                .parse::<DerivationPath>()
+                .map_err(|err| err.to_string())?;
+            let output_path = output_config
+                .keypath
+                .parse::<DerivationPath>()
+                .map_err(|err| err.to_string())?;
+            if input_path.as_ref().get(2) != output_path.as_ref().get(2) {
+                return Ok(false);
+            }
+        } else if input_config != output_config {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn external_output(output: &TxOut) -> Result<(OutputType, Vec<u8>), String> {
+    let script = output.script_pubkey.as_bytes();
+    if output.script_pubkey.is_p2pkh() {
+        Ok((OutputType::P2pkh, script[3..23].to_vec()))
+    } else if output.script_pubkey.is_p2sh() {
+        Ok((OutputType::P2sh, script[2..22].to_vec()))
+    } else if output.script_pubkey.is_p2wpkh() {
+        Ok((OutputType::P2wpkh, script[2..].to_vec()))
+    } else if output.script_pubkey.is_p2wsh() {
+        Ok((OutputType::P2wsh, script[2..].to_vec()))
+    } else if output.script_pubkey.is_p2tr() {
+        Ok((OutputType::P2tr, script[2..].to_vec()))
+    } else if output.script_pubkey.is_op_return() {
+        let mut instructions = output.script_pubkey.instructions_minimal();
+        match (
+            instructions.next(),
+            instructions.next(),
+            instructions.next(),
+        ) {
+            (Some(Ok(Instruction::Op(op))), Some(Ok(Instruction::PushBytes(payload))), None)
+                if op == bitcoin::opcodes::all::OP_RETURN =>
+            {
+                Ok((OutputType::OpReturn, payload.as_bytes().to_vec()))
+            }
+            _ => Err("unsupported OP_RETURN script".into()),
+        }
+    } else {
+        Err(format!(
+            "unsupported output script {}",
+            output.script_pubkey
+        ))
+    }
+}
+
+pub(in crate::btc_transaction) fn firmware_request_from_psbt(
+    psbt: &bitcoin::psbt::Psbt,
+    options: &PsbtSignOptions,
+) -> Result<FirmwareSignRequest, String> {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let contains_silent_payment = options
+        .outputs
+        .values()
+        .any(|output| output.silent_payment_address.is_some());
+    let mut script_configs = options
+        .force_script_config
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    let forced_config = options.force_script_config.is_some();
+    let mut input_prev_txs = Vec::with_capacity(psbt.inputs.len());
+    let mut inputs = Vec::with_capacity(psbt.inputs.len());
+
+    for (index, (tx_input, psbt_input)) in
+        psbt.unsigned_tx.input.iter().zip(&psbt.inputs).enumerate()
+    {
+        let prev_tx = psbt_input.non_witness_utxo.as_ref();
+        let utxo = psbt_input.witness_utxo.as_ref().or_else(|| {
+            prev_tx.and_then(|tx| tx.output.get(tx_input.previous_output.vout as usize))
+        });
+        let utxo = utxo.ok_or_else(|| format!("PSBT input {index} has no spend UTXO"))?;
+        let (our_key, input_keypath) = input_our_key(psbt_input, fingerprint)
+            .ok_or_else(|| format!("PSBT input {index} has no simulator key"))?;
+        let script_config_index = if forced_config {
+            0
+        } else {
+            let config =
+                script_config_from_utxo(utxo, &input_keypath, psbt_input.redeem_script.as_ref())?;
+            find_or_add_config(&mut script_configs, config)
+        };
+        input_prev_txs.push(prev_tx);
+        inputs.push(FirmwareInput {
+            prev_out_hash: tx_input.previous_output.txid,
+            prev_out_index: tx_input.previous_output.vout,
+            prev_out_value: utxo.value.to_sat(),
+            sequence: tx_input.sequence.to_consensus_u32(),
+            keypath: input_keypath,
+            script_config_index: script_config_index as u32,
+            prev_tx: None,
+            bip352_pubkey: contains_silent_payment.then(|| our_key.bip352_pubkey(&secp)),
+        });
+    }
+
+    let mut output_script_configs = Vec::new();
+    let mut outputs = Vec::with_capacity(psbt.outputs.len());
+    for (index, (tx_output, psbt_output)) in psbt
+        .unsigned_tx
+        .output
+        .iter()
+        .zip(&psbt.outputs)
+        .enumerate()
+    {
+        let output_options = options.outputs.get(&index);
+        let silent_payment_address =
+            output_options.and_then(|output| output.silent_payment_address.clone());
+        let payment_request_index = output_options.and_then(|output| output.payment_request_index);
+        if let Some((_, output_keypath)) = output_our_key(psbt_output, fingerprint) {
+            let config = if let Some(config) = &options.force_script_config {
+                config.clone()
+            } else {
+                script_config_from_utxo(
+                    tx_output,
+                    &output_keypath,
+                    psbt_output.redeem_script.as_ref(),
+                )?
+            };
+            let (script_config_index, output_script_config_index) =
+                if same_account(&script_configs, &config)? {
+                    (find_or_add_config(&mut script_configs, config) as u32, None)
+                } else {
+                    let index = find_or_add_config(&mut output_script_configs, config);
+                    (0, Some(index as u32))
+                };
+            outputs.push(FirmwareOutput {
+                ours: true,
+                value: tx_output.value.to_sat(),
+                output_type: OutputType::Unknown,
+                payload: Vec::new(),
+                keypath: Some(output_keypath),
+                script_config_index,
+                output_script_config_index,
+                silent_payment_address,
+                payment_request_index,
+            });
+        } else {
+            let (output_type, payload) =
+                if silent_payment_address.is_some() && !tx_output.script_pubkey.is_op_return() {
+                    (OutputType::Unknown, Vec::new())
+                } else {
+                    external_output(tx_output)?
+                };
+            outputs.push(FirmwareOutput {
+                ours: false,
+                value: tx_output.value.to_sat(),
+                output_type,
+                payload,
+                keypath: None,
+                script_config_index: 0,
+                output_script_config_index: None,
+                silent_payment_address,
+                payment_request_index,
+            });
+        }
+    }
+
+    let needs_prevtxs = script_configs
+        .iter()
+        .any(|config| !config.script_config.is_taproot());
+    if needs_prevtxs {
+        for (index, prev_tx) in input_prev_txs.into_iter().enumerate() {
+            inputs[index].prev_tx = Some(
+                prev_tx
+                    .ok_or_else(|| format!("PSBT input {index} needs a non-witness UTXO"))?
+                    .clone(),
+            );
+        }
+    }
+
+    Ok(FirmwareSignRequest {
+        script_configs,
+        output_script_configs,
+        version: psbt.unsigned_tx.version.0 as u32,
+        inputs,
+        outputs,
+        locktime: psbt.unsigned_tx.lock_time.to_consensus_u32(),
+        payment_requests: options.payment_requests.clone(),
+        format_unit: options.format_unit,
+    })
+}
+
+pub fn ecdsa_signature(
+    input_index: usize,
+    pubkey: bitcoin::secp256k1::PublicKey,
+) -> ExpectedSignature {
+    ExpectedSignature {
+        input_index,
+        kind: SignatureKind::Ecdsa,
+        pubkey: Some(pubkey.to_string()),
+        leaf_hash: None,
+        sighash: Sighash::All,
+    }
+}
+
+pub fn taproot_key_signature(
+    input_index: usize,
+    pubkey: bitcoin::secp256k1::XOnlyPublicKey,
+) -> ExpectedSignature {
+    ExpectedSignature {
+        input_index,
+        kind: SignatureKind::TaprootKey,
+        pubkey: Some(pubkey.to_string()),
+        leaf_hash: None,
+        sighash: Sighash::Default,
+    }
+}
+
+pub fn taproot_script_signature(
+    input_index: usize,
+    pubkey: bitcoin::secp256k1::XOnlyPublicKey,
+    leaf_hash: bitcoin::TapLeafHash,
+) -> ExpectedSignature {
+    ExpectedSignature {
+        input_index,
+        kind: SignatureKind::TaprootScript,
+        pubkey: Some(pubkey.to_string()),
+        leaf_hash: Some(leaf_hash.to_string()),
+        sighash: Sighash::Default,
+    }
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/descriptor_psbt.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/descriptor_psbt.rs
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Portable multisig and policy scenarios backed by descriptors.
+
+use super::common::{
+    ecdsa_signature, keypath, secp, simulator_xprv, simulator_xpub_at, taproot_key_signature,
+    taproot_script_signature, transaction_vector,
+};
+use super::screens;
+use crate::btc_transaction::{
+    Coin, KeyOriginInfo, MultisigScriptType, PsbtSignOptions, Registration, ScriptConfig,
+    ScriptConfigWithKeypath, TestVector,
+};
+use bitcoin::bip32::{ChainCode, ChildNumber, DerivationPath, Fingerprint, KeySource, Xpriv, Xpub};
+use bitcoin::hashes::{Hash, sha256};
+use bitcoin::psbt::Psbt;
+use bitcoin::secp256k1::{PublicKey, XOnlyPublicKey};
+use bitcoin::taproot::TapLeafHash;
+use bitcoin::{
+    Amount, Network, NetworkKind, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    transaction,
+};
+use miniscript::psbt::PsbtExt;
+use std::collections::BTreeMap;
+
+const EXTERNAL_XONLY: &str = "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576";
+const POLICY_ACCOUNT: &str = "m/48'/1'/0'/3'";
+
+struct MultisigSpend {
+    psbt: Psbt,
+    config: ScriptConfig,
+    account: DerivationPath,
+    input_pubkey: PublicKey,
+}
+
+struct PolicySpend {
+    psbt: Psbt,
+    config: ScriptConfig,
+    account: DerivationPath,
+    input_pubkey: PublicKey,
+    display_keys: Vec<String>,
+}
+
+fn path(value: &str) -> DerivationPath {
+    value.parse().unwrap()
+}
+
+fn seeded_xpriv(index: u8) -> Xpriv {
+    let mut seed = [0u8; 32];
+    seed[0] = index;
+    Xpriv::new_master(Network::Testnet, &seed).unwrap()
+}
+
+fn account_xpub(root: &Xpriv, account: &DerivationPath) -> Xpub {
+    Xpub::from_priv(&secp(), &root.derive_priv(&secp(), account).unwrap())
+}
+
+fn descriptor_key(root: &Xpriv, account: &DerivationPath, xpub: Xpub, branches: &str) -> String {
+    format!(
+        "[{}/{}]{xpub}/{branches}/*",
+        root.fingerprint(&secp()),
+        account
+    )
+}
+
+fn descriptor_psbt(descriptor: &str, change_index: u32) -> Psbt {
+    let descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> =
+        descriptor.parse().unwrap();
+    assert!(descriptor.sanity_check().is_ok());
+    let [receive, change] = descriptor
+        .into_single_descriptors()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let input_descriptor = receive.at_derivation_index(0).unwrap();
+    let change_descriptor = change.at_derivation_index(change_index).unwrap();
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_descriptor.script_pubkey(),
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_descriptor.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp(), EXTERNAL_XONLY.parse().unwrap(), None),
+            },
+        ],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    if !input_descriptor.script_pubkey().is_p2tr() {
+        psbt.inputs[0].non_witness_utxo = Some(prev_tx);
+    }
+    psbt.update_input_with_descriptor(0, &input_descriptor)
+        .unwrap();
+    psbt.update_output_with_descriptor(0, &change_descriptor)
+        .unwrap();
+    psbt
+}
+
+fn add_cosigner_signature(psbt: &mut Psbt, root: &Xpriv) {
+    let ecdsa_before = psbt.inputs[0].partial_sigs.len();
+    let taproot_before = psbt.inputs[0].tap_script_sigs.len();
+    psbt.sign(root, &secp()).unwrap();
+    assert_eq!(
+        psbt.inputs[0].partial_sigs.len() + psbt.inputs[0].tap_script_sigs.len(),
+        ecdsa_before + taproot_before + 1
+    );
+}
+
+fn multisig_spend(
+    threshold: u32,
+    xpub_count: usize,
+    script_type: MultisigScriptType,
+    cosigner_signatures: usize,
+) -> MultisigSpend {
+    assert!(threshold as usize <= xpub_count);
+    assert!(cosigner_signatures < threshold as usize);
+
+    let secp = secp();
+    let account = match script_type {
+        MultisigScriptType::P2wsh => path("m/48'/1'/0'/2'"),
+        MultisigScriptType::P2wshP2sh => path("m/48'/1'/0'/1'"),
+    };
+    let our_xpub = simulator_xpub_at(&secp, &account);
+    let cosigner_roots = (1..xpub_count)
+        .map(|index| seeded_xpriv(u8::try_from(index).unwrap()))
+        .collect::<Vec<_>>();
+    let cosigner_xpubs = cosigner_roots
+        .iter()
+        .map(|root| account_xpub(root, &account))
+        .collect::<Vec<_>>();
+
+    let mut descriptor_keys = vec![format!(
+        "[{}/{}]{our_xpub}/<0;1>/*",
+        simulator_xprv().fingerprint(&secp),
+        account
+    )];
+    descriptor_keys.extend(
+        cosigner_roots
+            .iter()
+            .zip(&cosigner_xpubs)
+            .map(|(root, xpub)| descriptor_key(root, &account, *xpub, "<0;1>")),
+    );
+    let sortedmulti = format!("sortedmulti({threshold},{})", descriptor_keys.join(","));
+    let descriptor = match script_type {
+        MultisigScriptType::P2wsh => format!("wsh({sortedmulti})"),
+        MultisigScriptType::P2wshP2sh => format!("sh(wsh({sortedmulti}))"),
+    };
+    let mut psbt = descriptor_psbt(&descriptor, 0);
+    for root in cosigner_roots.iter().take(cosigner_signatures) {
+        add_cosigner_signature(&mut psbt, root);
+    }
+
+    let config = ScriptConfig::Multisig {
+        threshold,
+        xpubs: std::iter::once(our_xpub.to_string())
+            .chain(cosigner_xpubs.iter().map(ToString::to_string))
+            .collect(),
+        our_xpub_index: 0,
+        script_type,
+    };
+    let input_path = path(&format!("{account}/0/0"));
+    MultisigSpend {
+        psbt,
+        config,
+        account,
+        input_pubkey: simulator_xpub_at(&secp, &input_path).public_key,
+    }
+}
+
+fn multisig_vector(
+    id: &str,
+    description: &str,
+    threshold: u32,
+    xpub_count: usize,
+    script_type: MultisigScriptType,
+    cosigner_signatures: usize,
+    name: Option<&str>,
+) -> TestVector {
+    let spend = multisig_spend(threshold, xpub_count, script_type, cosigner_signatures);
+    let success = name.is_some();
+    let mut vector = transaction_vector(
+        id,
+        description,
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: spend.config.clone(),
+                keypath: keypath(&spend.account),
+            }),
+            ..Default::default()
+        },
+        success
+            .then(|| ecdsa_signature(0, spend.input_pubkey))
+            .into_iter()
+            .collect(),
+        match name {
+            Some(name) => screens::multisig(threshold, xpub_count, name),
+            None => screens::always_invalid_input(),
+        },
+    );
+    if let Some(name) = name {
+        vector.registrations.push(Registration {
+            script_config: spend.config,
+            keypath: Some(keypath(&spend.account)),
+            name: name.into(),
+        });
+    }
+    vector
+}
+
+fn policy_spend(policy: &str, change_index: u32, sign_cosigner: bool) -> PolicySpend {
+    let secp = secp();
+    let account = path(POLICY_ACCOUNT);
+    let our_xpub = simulator_xpub_at(&secp, &account);
+    let cosigner_root = seeded_xpriv(100);
+    let cosigner_xpub = account_xpub(&cosigner_root, &account);
+    let descriptor = policy
+        .replace("/**", "/<0;1>/*")
+        .replace(
+            "@0",
+            &format!(
+                "[{}/{}]{our_xpub}",
+                simulator_xprv().fingerprint(&secp),
+                account
+            ),
+        )
+        .replace(
+            "@1",
+            &format!(
+                "[{}/{}]{cosigner_xpub}",
+                cosigner_root.fingerprint(&secp),
+                account
+            ),
+        );
+    let mut psbt = descriptor_psbt(&descriptor, change_index);
+    if sign_cosigner {
+        add_cosigner_signature(&mut psbt, &cosigner_root);
+    }
+    let config = ScriptConfig::Policy {
+        policy: policy.into(),
+        keys: vec![
+            KeyOriginInfo {
+                root_fingerprint: Some(simulator_xprv().fingerprint(&secp).to_string()),
+                keypath: Some(keypath(&account)),
+                xpub: our_xpub.to_string(),
+            },
+            KeyOriginInfo {
+                root_fingerprint: None,
+                keypath: None,
+                xpub: cosigner_xpub.to_string(),
+            },
+        ],
+    };
+    let input_branch = if policy.contains("<10;11>") { 10 } else { 0 };
+    let input_path = path(&format!("{account}/{input_branch}/0"));
+    PolicySpend {
+        psbt,
+        config,
+        account,
+        input_pubkey: simulator_xpub_at(&secp, &input_path).public_key,
+        display_keys: vec![
+            format!("This device: {}", screens::DEVICE_POLICY_XPUB),
+            cosigner_xpub.to_string(),
+        ],
+    }
+}
+
+fn policy_vector(
+    id: &str,
+    description: &str,
+    policy: &str,
+    name: &str,
+    spend: PolicySpend,
+    account_override: Option<DerivationPath>,
+    success: bool,
+) -> TestVector {
+    let config_account = account_override.as_ref().unwrap_or(&spend.account);
+    let prefix = screens::policy_prefix(policy, name, &spend.display_keys);
+    let mut vector = transaction_vector(
+        id,
+        description,
+        Coin::Tbtc,
+        spend.psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: spend.config.clone(),
+                keypath: keypath(config_account),
+            }),
+            ..Default::default()
+        },
+        success
+            .then(|| ecdsa_signature(0, spend.input_pubkey))
+            .into_iter()
+            .collect(),
+        if success {
+            screens::policy(policy, name, &spend.display_keys, false)
+        } else {
+            screens::always_invalid_input_with_screens(prefix)
+        },
+    );
+    vector.registrations.push(Registration {
+        script_config: spend.config,
+        keypath: None,
+        name: name.into(),
+    });
+    vector
+}
+
+fn unspendable_xpub(cosigner: Xpub, ours: Xpub, script_key_pair_repetitions: usize) -> Xpub {
+    let mut keys = Vec::with_capacity(66 * script_key_pair_repetitions);
+    for _ in 0..script_key_pair_repetitions {
+        keys.extend_from_slice(&cosigner.public_key.serialize());
+        keys.extend_from_slice(&ours.public_key.serialize());
+    }
+    Xpub {
+        network: NetworkKind::Test,
+        depth: 0,
+        parent_fingerprint: Default::default(),
+        child_number: ChildNumber::from_normal_idx(0).unwrap(),
+        public_key: "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+            .parse()
+            .unwrap(),
+        chain_code: ChainCode::from(sha256::Hash::hash(&keys).to_byte_array()),
+    }
+}
+
+fn policy_tr_keyspend_with_script_tree() -> TestVector {
+    let policy = "tr(@0/**,pk(@1/**))";
+    let name = "test tr tweaked keyspend";
+    let PolicySpend {
+        psbt,
+        config,
+        account,
+        input_pubkey,
+        display_keys,
+    } = policy_spend(policy, 0, false);
+    let mut vector = transaction_vector(
+        "policy-tr-keyspend-with-script-tree",
+        "Signs a Taproot policy key path whose tweak commits to a script tree.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: config.clone(),
+                keypath: keypath(&account),
+            }),
+            ..Default::default()
+        },
+        vec![taproot_key_signature(0, input_pubkey.x_only_public_key().0)],
+        screens::policy(policy, name, &display_keys, true),
+    );
+    vector.registrations.push(Registration {
+        script_config: config,
+        keypath: None,
+        name: name.into(),
+    });
+    vector
+}
+
+fn taproot_script_key(
+    origins: &BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
+    fingerprint: Fingerprint,
+    keypath: &DerivationPath,
+) -> (XOnlyPublicKey, TapLeafHash) {
+    let (pubkey, (leaf_hashes, _)) = origins
+        .iter()
+        .find(|(_, (_, (candidate_fingerprint, candidate_keypath)))| {
+            *candidate_fingerprint == fingerprint && candidate_keypath == keypath
+        })
+        .unwrap();
+    assert_eq!(leaf_hashes.len(), 1);
+    (*pubkey, leaf_hashes[0])
+}
+
+struct UnspendablePolicy<'a> {
+    id: &'a str,
+    description: &'a str,
+    policy: &'a str,
+    name: &'a str,
+    cosigner_seed: u8,
+    cosigner_account: &'a str,
+    display_cosigner_origin: bool,
+    script_key_pair_repetitions: usize,
+}
+
+fn unspendable_policy_vector(spec: UnspendablePolicy<'_>) -> TestVector {
+    let secp = secp();
+    let account = path(POLICY_ACCOUNT);
+    let cosigner_account = path(spec.cosigner_account);
+    let our_xpub = simulator_xpub_at(&secp, &account);
+    let cosigner_root = seeded_xpriv(spec.cosigner_seed);
+    let cosigner_xpub = account_xpub(&cosigner_root, &cosigner_account);
+    let nums_xpub = unspendable_xpub(cosigner_xpub, our_xpub, spec.script_key_pair_repetitions);
+    let descriptor = spec
+        .policy
+        .replace("@0", &nums_xpub.to_string())
+        .replace(
+            "@1",
+            &format!(
+                "[{}/{}]{cosigner_xpub}",
+                cosigner_root.fingerprint(&secp),
+                cosigner_account
+            ),
+        )
+        .replace(
+            "@2",
+            &format!(
+                "[{}/{}]{our_xpub}",
+                simulator_xprv().fingerprint(&secp),
+                account
+            ),
+        );
+    let mut psbt = descriptor_psbt(&descriptor, 0);
+
+    let input_path = path(&format!("{account}/0/0"));
+    let cosigner_input_path = path(&format!("{cosigner_account}/0/0"));
+    let our_fingerprint = simulator_xprv().fingerprint(&secp);
+    let cosigner_fingerprint = cosigner_root.fingerprint(&secp);
+    let (input_pubkey, leaf_hash) = taproot_script_key(
+        &psbt.inputs[0].tap_key_origins,
+        our_fingerprint,
+        &input_path,
+    );
+    let (cosigner_input_pubkey, cosigner_leaf_hash) = taproot_script_key(
+        &psbt.inputs[0].tap_key_origins,
+        cosigner_fingerprint,
+        &cosigner_input_path,
+    );
+    assert_eq!(leaf_hash, cosigner_leaf_hash);
+
+    psbt.sign(&cosigner_root, &secp).unwrap();
+    assert!(
+        psbt.inputs[0]
+            .tap_script_sigs
+            .contains_key(&(cosigner_input_pubkey, leaf_hash))
+    );
+    psbt.inputs[0]
+        .tap_script_sigs
+        .retain(|key, _| key == &(cosigner_input_pubkey, leaf_hash));
+
+    let output_path = path(&format!("{account}/1/0"));
+    let cosigner_output_path = path(&format!("{cosigner_account}/1/0"));
+    for (origins, our_path, cosigner_path) in [
+        (
+            &mut psbt.inputs[0].tap_key_origins,
+            &input_path,
+            &cosigner_input_path,
+        ),
+        (
+            &mut psbt.outputs[0].tap_key_origins,
+            &output_path,
+            &cosigner_output_path,
+        ),
+    ] {
+        origins.retain(|_, (_, (fingerprint, keypath))| {
+            (*fingerprint != our_fingerprint || keypath == our_path)
+                && (*fingerprint != cosigner_fingerprint || keypath == cosigner_path)
+        });
+    }
+
+    let cosigner_origin = format!("[{cosigner_fingerprint}/{cosigner_account}]{cosigner_xpub}");
+    let config = ScriptConfig::Policy {
+        policy: spec.policy.into(),
+        keys: vec![
+            KeyOriginInfo {
+                root_fingerprint: None,
+                keypath: None,
+                xpub: nums_xpub.to_string(),
+            },
+            KeyOriginInfo {
+                root_fingerprint: spec
+                    .display_cosigner_origin
+                    .then(|| cosigner_fingerprint.to_string()),
+                keypath: spec
+                    .display_cosigner_origin
+                    .then(|| keypath(&cosigner_account)),
+                xpub: cosigner_xpub.to_string(),
+            },
+            KeyOriginInfo {
+                root_fingerprint: Some(our_fingerprint.to_string()),
+                keypath: Some(keypath(&account)),
+                xpub: our_xpub.to_string(),
+            },
+        ],
+    };
+    let display_keys = vec![
+        format!("Provably unspendable: {nums_xpub}"),
+        if spec.display_cosigner_origin {
+            cosigner_origin
+        } else {
+            cosigner_xpub.to_string()
+        },
+        format!("This device: {}", screens::DEVICE_POLICY_XPUB),
+    ];
+    let mut vector = transaction_vector(
+        spec.id,
+        spec.description,
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: config.clone(),
+                keypath: keypath(&account),
+            }),
+            ..Default::default()
+        },
+        vec![taproot_script_signature(0, input_pubkey, leaf_hash)],
+        screens::policy(spec.policy, spec.name, &display_keys, true),
+    );
+    vector.registrations.push(Registration {
+        script_config: config,
+        keypath: None,
+        name: spec.name.into(),
+    });
+    vector
+}
+
+fn policy_tr_unspendable_internal_key() -> TestVector {
+    unspendable_policy_vector(UnspendablePolicy {
+        id: "policy-tr-unspendable-internal-key",
+        description: "Signs a Taproot script path with a provably unspendable internal key and displays that property in the policy review.",
+        policy: "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+        name: "test unspendable policy",
+        cosigner_seed: 101,
+        cosigner_account: POLICY_ACCOUNT,
+        display_cosigner_origin: false,
+        script_key_pair_repetitions: 1,
+    })
+}
+
+fn policy_tr_unspendable_internal_key_complex() -> TestVector {
+    unspendable_policy_vector(UnspendablePolicy {
+        id: "policy-tr-unspendable-internal-key-complex",
+        description: "Signs the satisfiable branch of a multi-leaf Taproot policy with a provably unspendable internal key, distinct multipaths and a relative-timelock sibling branch.",
+        policy: "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+        name: "test complex unspendable",
+        cosigner_seed: 102,
+        cosigner_account: "m/48'/1'/0'/2'",
+        display_cosigner_origin: true,
+        script_key_pair_repetitions: 2,
+    })
+}
+
+pub fn all() -> Vec<TestVector> {
+    let multipath_policy = "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))";
+    let standard_policy = "wsh(multi(2,@0/**,@1/**))";
+    vec![
+        multisig_vector(
+            "multisig-not-registered",
+            "Rejects a valid 1-of-2 P2WSH multisig transaction when its account has not been registered.",
+            1,
+            2,
+            MultisigScriptType::P2wsh,
+            0,
+            None,
+        ),
+        multisig_vector(
+            "multisig-p2wsh-p2sh",
+            "Signs and finalizes a registered 1-of-2 nested P2SH-P2WSH multisig transaction.",
+            1,
+            2,
+            MultisigScriptType::P2wshP2sh,
+            0,
+            Some("test sh-wsh multisig"),
+        ),
+        multisig_vector(
+            "multisig-large",
+            "Adds the seventh signature to a registered 7-of-15 P2WSH multisig transaction whose PSBT already contains six cosigner signatures.",
+            7,
+            15,
+            MultisigScriptType::P2wsh,
+            6,
+            Some("test large multisig"),
+        ),
+        policy_tr_keyspend_with_script_tree(),
+        policy_tr_unspendable_internal_key(),
+        policy_tr_unspendable_internal_key_complex(),
+        policy_vector(
+            "policy-different-multipath-derivations",
+            "Signs and finalizes a registered WSH policy whose two keys use different receive and change branches.",
+            multipath_policy,
+            "test multipath policy",
+            policy_spend(multipath_policy, 0, true),
+            None,
+            true,
+        ),
+        policy_vector(
+            "policy-wrong-account-keypath",
+            "Rejects a registered policy when the signing account keypath does not match the device key in the policy.",
+            standard_policy,
+            "test policy account",
+            policy_spend(standard_policy, 0, false),
+            Some(path("m/48'/1'/0'/4'")),
+            false,
+        ),
+        policy_vector(
+            "policy-change-index-too-high",
+            "Rejects a registered policy change output at address index 10000.",
+            standard_policy,
+            "test policy account",
+            policy_spend(standard_policy, 10_000, false),
+            None,
+            false,
+        ),
+    ]
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/metadata_psbt.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/metadata_psbt.rs
@@ -1,0 +1,579 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! PSBT scenarios covering output metadata and compatibility behavior.
+
+use super::common::{
+    ecdsa_signature, keypath, secp, simulator_xprv, simulator_xpub_at, taproot_key_signature,
+    transaction_vector,
+};
+use super::screens;
+use crate::btc_transaction::{
+    Coin, PaymentRequest, PaymentRequestMemo, PsbtOutputOptions, PsbtSignOptions, TestVector,
+};
+use bitcoin::bip32::DerivationPath;
+use bitcoin::consensus::encode::VarInt;
+use bitcoin::hashes::{Hash, HashEngine, sha256};
+use bitcoin::psbt::Psbt;
+use bitcoin::secp256k1::{Message, SecretKey};
+use bitcoin::{
+    Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness, transaction,
+};
+use sha3::Digest;
+use std::collections::BTreeMap;
+
+const SILENT_PAYMENT_ADDRESS: &str = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv";
+
+pub fn all() -> Vec<TestVector> {
+    vec![
+        taproot_spends_to_non_taproot(),
+        silent_payment(),
+        send_self(false),
+        send_self(true),
+        payment_request(),
+        payment_request_rejects_owned_output(),
+    ]
+}
+
+fn path(value: &str) -> DerivationPath {
+    value.parse().unwrap()
+}
+
+fn dummy_input() -> TxIn {
+    TxIn {
+        previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+            .parse()
+            .unwrap(),
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::MAX,
+        witness: Witness::default(),
+    }
+}
+
+fn unsigned_input(prev_tx: &Transaction, vout: u32) -> TxIn {
+    TxIn {
+        previous_output: OutPoint {
+            txid: prev_tx.compute_txid(),
+            vout,
+        },
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::MAX,
+        witness: Witness::default(),
+    }
+}
+
+// All inputs are Taproot, but the change output is not Taproot. Some firmware versions
+// conservatively request the previous transactions in this case.
+fn taproot_spends_to_non_taproot() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let input0_path = path("m/86'/1'/0'/0/0");
+    let input1_path = path("m/86'/1'/0'/0/1");
+    let change_path = path("m/84'/1'/0'/1/0");
+    let input0_xpub = simulator_xpub_at(&secp, &input0_path);
+    let input1_xpub = simulator_xpub_at(&secp, &input1_path);
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![dummy_input()],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, input0_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, input1_xpub.to_x_only_pub(), None),
+            },
+        ],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![unsigned_input(&prev_tx, 0), unsigned_input(&prev_tx, 1)],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&change_xpub.to_pub().wpubkey_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+    for (index, (xpub, input_path)) in [(input0_xpub, input0_path), (input1_xpub, input1_path)]
+        .into_iter()
+        .enumerate()
+    {
+        psbt.inputs[index].witness_utxo = Some(prev_tx.output[index].clone());
+        psbt.inputs[index].non_witness_utxo = Some(prev_tx.clone());
+        psbt.inputs[index].tap_internal_key = Some(xpub.to_x_only_pub());
+        psbt.inputs[index]
+            .tap_key_origins
+            .insert(xpub.to_x_only_pub(), (vec![], (fingerprint, input_path)));
+    }
+    psbt.outputs[0]
+        .bip32_derivation
+        .insert(change_xpub.to_pub().0, (fingerprint, change_path));
+
+    transaction_vector(
+        "taproot-to-non-taproot-change",
+        "Signs all-Taproot inputs with P2WPKH change, requiring previous transactions for the added non-Taproot output config.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions::default(),
+        vec![
+            taproot_key_signature(0, input0_xpub.to_x_only_pub()),
+            taproot_key_signature(1, input1_xpub.to_x_only_pub()),
+        ],
+        screens::taproot_to_non_taproot_change(),
+    )
+}
+
+// Test that a mixed-input PSBT can ask the device to generate a BIP352 output.
+fn silent_payment() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let change_path = path("m/86'/0'/0'/1/0");
+    let input0_path = path("m/86'/0'/0'/0/0"); // P2TR
+    let input1_path = path("m/84'/0'/0'/0/0"); // P2WPKH
+    let input2_path = path("m/49'/0'/0'/0/0"); // P2SH-P2WPKH
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+    let input0_xpub = simulator_xpub_at(&secp, &input0_path);
+    let input1_xpub = simulator_xpub_at(&secp, &input1_path);
+    let input2_xpub = simulator_xpub_at(&secp, &input2_path);
+    let input2_redeem = ScriptBuf::new_p2wpkh(&input2_xpub.to_pub().wpubkey_hash());
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![dummy_input()],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, input0_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&input1_xpub.to_pub().wpubkey_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2sh(&input2_redeem.script_hash()),
+            },
+        ],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: (0..3).map(|vout| unsigned_input(&prev_tx, vout)).collect(),
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, change_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                // The device fills this script from the silent-payment address.
+                script_pubkey: ScriptBuf::new(),
+            },
+        ],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].tap_internal_key = Some(input0_xpub.to_x_only_pub());
+    psbt.inputs[0].tap_key_origins.insert(
+        input0_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input0_path)),
+    );
+    psbt.inputs[1].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[1].witness_utxo = Some(prev_tx.output[1].clone());
+    psbt.inputs[1]
+        .bip32_derivation
+        .insert(input1_xpub.to_pub().0, (fingerprint, input1_path));
+    psbt.inputs[2].non_witness_utxo = Some(prev_tx);
+    psbt.inputs[2].witness_utxo = psbt.inputs[2]
+        .non_witness_utxo
+        .as_ref()
+        .map(|tx| tx.output[2].clone());
+    psbt.inputs[2].redeem_script = Some(input2_redeem);
+    psbt.inputs[2]
+        .bip32_derivation
+        .insert(input2_xpub.to_pub().0, (fingerprint, input2_path));
+    psbt.outputs[0].tap_internal_key = Some(change_xpub.to_x_only_pub());
+    psbt.outputs[0].tap_key_origins.insert(
+        change_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, change_path)),
+    );
+
+    let mut outputs = BTreeMap::new();
+    outputs.insert(
+        1,
+        PsbtOutputOptions {
+            silent_payment_address: Some(SILENT_PAYMENT_ADDRESS.into()),
+            payment_request_index: None,
+        },
+    );
+    let mut result = transaction_vector(
+        "silent-payment",
+        "Signs mixed inputs with BIP352 metadata and a device-generated silent-payment output.",
+        Coin::Btc,
+        psbt,
+        PsbtSignOptions {
+            outputs,
+            ..Default::default()
+        },
+        vec![
+            taproot_key_signature(0, input0_xpub.to_x_only_pub()),
+            ecdsa_signature(1, input1_xpub.to_pub().0),
+            ecdsa_signature(2, input2_xpub.to_pub().0),
+        ],
+        screens::silent_payment(),
+    );
+    result.expected_generated_outputs.insert(
+        1,
+        "5120d826829cb603fc008e5ef99d0818f2126d3569c3ab8a6cd069f07a20e892bd59".into(),
+    );
+    result
+}
+
+// Tests that the output is recognized as the same account or another account on this device.
+fn send_self(different_account: bool) -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let input_path = path("m/86'/1'/0'/0/0");
+    let change_path = path("m/49'/1'/0'/1/0");
+    let send_self_path = if different_account {
+        path("m/84'/1'/1'/0/0")
+    } else {
+        path("m/84'/1'/0'/0/0")
+    };
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+    let send_self_xpub = simulator_xpub_at(&secp, &send_self_path);
+    let change_redeem = ScriptBuf::new_p2wpkh(&change_xpub.to_pub().wpubkey_hash());
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![dummy_input()],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: ScriptBuf::new_p2tr(&secp, input_xpub.to_x_only_pub(), None),
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![unsigned_input(&prev_tx, 0)],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(50_000_000),
+                script_pubkey: ScriptBuf::new_p2sh(&change_redeem.script_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&send_self_xpub.to_pub().wpubkey_hash()),
+            },
+        ],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].tap_internal_key = Some(input_xpub.to_x_only_pub());
+    psbt.inputs[0].tap_key_origins.insert(
+        input_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input_path)),
+    );
+    psbt.outputs[0].redeem_script = Some(change_redeem);
+    psbt.outputs[0]
+        .bip32_derivation
+        .insert(change_xpub.to_pub().0, (fingerprint, change_path));
+    psbt.outputs[1]
+        .bip32_derivation
+        .insert(send_self_xpub.to_pub().0, (fingerprint, send_self_path));
+
+    transaction_vector(
+        if different_account {
+            "send-self-different-account"
+        } else {
+            "send-self-same-account"
+        },
+        if different_account {
+            "Covers ownership detection for another account and version-specific account labels."
+        } else {
+            "Covers ownership detection for the input account, suppression of change confirmation and version-specific account labels."
+        },
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions::default(),
+        vec![taproot_key_signature(0, input_xpub.to_x_only_pub())],
+        if different_account {
+            screens::send_self_different_account()
+        } else {
+            screens::send_self_same_account()
+        },
+    )
+}
+
+fn hash_len_prefixed(engine: &mut sha256::HashEngine, value: &[u8]) {
+    engine.input(&bitcoin::consensus::serialize(&VarInt(value.len() as u64)));
+    engine.input(value);
+}
+
+pub(super) fn payment_request_signature(value: u64, address: &str) -> Vec<u8> {
+    let mut sighash = sha256::Hash::engine();
+    sighash.input(b"SL\x00\x24");
+    hash_len_prefixed(&mut sighash, b"");
+    hash_len_prefixed(&mut sighash, b"Test Merchant");
+    sighash.input(&bitcoin::consensus::serialize(&VarInt(1)));
+    sighash.input(&1u32.to_le_bytes());
+    hash_len_prefixed(&mut sighash, b"TextMemo line1\nTextMemo line2");
+    sighash.input(&1u32.to_le_bytes());
+
+    let mut output_hash = sha256::Hash::engine();
+    output_hash.input(&value.to_le_bytes());
+    hash_len_prefixed(&mut output_hash, address.as_bytes());
+    sighash.input(sha256::Hash::from_engine(output_hash).as_byte_array());
+
+    let digest = sha256::Hash::from_engine(sighash).to_byte_array();
+    let secret_key = SecretKey::from_slice(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+    secp()
+        .sign_ecdsa(&Message::from_digest(digest), &secret_key)
+        .serialize_compact()
+        .to_vec()
+}
+
+fn checksummed_eth_address(pubkey: &bitcoin::secp256k1::PublicKey) -> String {
+    let hash = sha3::Keccak256::digest(&pubkey.serialize_uncompressed()[1..]);
+    let mut address = hex::encode(&hash[hash.len() - 20..]).into_bytes();
+    let checksum = sha3::Keccak256::digest(&address);
+    for (index, byte) in address.iter_mut().enumerate() {
+        let nibble = if index % 2 == 0 {
+            checksum[index / 2] >> 4
+        } else {
+            checksum[index / 2] & 0x0f
+        };
+        if *byte > b'9' && nibble > 7 {
+            *byte -= 32;
+        }
+    }
+    format!("0x{}", String::from_utf8(address).unwrap())
+}
+
+pub(super) fn coin_purchase_payment_request(
+    source_coin_type: u32,
+    value: u64,
+    source_address: &str,
+) -> PaymentRequest {
+    let address_keypath = path("m/44'/60'/0'/0/0");
+    let private_key = simulator_xprv()
+        .derive_priv(&secp(), &address_keypath)
+        .unwrap()
+        .private_key;
+    let destination_address = checksummed_eth_address(
+        &bitcoin::secp256k1::PublicKey::from_secret_key(&secp(), &private_key),
+    );
+    let destination_amount = "0.25 ETH";
+
+    let mut sighash = sha256::Hash::engine();
+    sighash.input(b"SL\x00\x24");
+    hash_len_prefixed(&mut sighash, b"");
+    hash_len_prefixed(&mut sighash, b"Test Merchant");
+    sighash.input(&bitcoin::consensus::serialize(&VarInt(1)));
+    sighash.input(&3u32.to_le_bytes());
+    sighash.input(&60u32.to_le_bytes());
+    hash_len_prefixed(&mut sighash, destination_amount.as_bytes());
+    hash_len_prefixed(&mut sighash, destination_address.as_bytes());
+    sighash.input(&source_coin_type.to_le_bytes());
+
+    let mut output_hash = sha256::Hash::engine();
+    output_hash.input(&value.to_le_bytes());
+    hash_len_prefixed(&mut output_hash, source_address.as_bytes());
+    sighash.input(sha256::Hash::from_engine(output_hash).as_byte_array());
+
+    let digest = sha256::Hash::from_engine(sighash).to_byte_array();
+    let secret_key = SecretKey::from_slice(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+    let signature = secp()
+        .sign_ecdsa(&Message::from_digest(digest), &secret_key)
+        .serialize_compact();
+    PaymentRequest {
+        recipient_name: "Test Merchant".into(),
+        total_amount: value,
+        nonce: String::new(),
+        memos: vec![PaymentRequestMemo::CoinPurchase {
+            coin_type: 60,
+            amount: destination_amount.into(),
+            address: destination_address,
+            address_keypath: keypath(&address_keypath),
+        }],
+        signature: hex::encode(signature),
+    }
+}
+
+fn payment_request_options(output_index: usize, value: u64, address: &str) -> PsbtSignOptions {
+    PsbtSignOptions {
+        outputs: BTreeMap::from([(
+            output_index,
+            PsbtOutputOptions {
+                silent_payment_address: None,
+                payment_request_index: Some(0),
+            },
+        )]),
+        payment_requests: vec![PaymentRequest {
+            recipient_name: "Test Merchant".into(),
+            total_amount: value,
+            nonce: String::new(),
+            memos: vec![PaymentRequestMemo::Text {
+                note: "TextMemo line1\nTextMemo line2".into(),
+            }],
+            signature: hex::encode(payment_request_signature(value, address)),
+        }],
+        ..Default::default()
+    }
+}
+
+fn payment_request() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let input_path = path("m/86'/1'/0'/0/0");
+    let change_path = path("m/49'/1'/0'/1/0");
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+    let change_redeem = ScriptBuf::new_p2wpkh(&change_xpub.to_pub().wpubkey_hash());
+    let address = "tb1q9kvhpyd32aqhpsc8yrdm48gx5dnadq63lservm";
+    let recipient_script = address
+        .parse::<bitcoin::Address<_>>()
+        .unwrap()
+        .assume_checked()
+        .script_pubkey();
+    let value = 20_000_000;
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![dummy_input()],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: ScriptBuf::new_p2tr(&secp, input_xpub.to_x_only_pub(), None),
+        }],
+    };
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![unsigned_input(&prev_tx, 0)],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(50_000_000),
+                script_pubkey: ScriptBuf::new_p2sh(&change_redeem.script_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey: recipient_script,
+            },
+        ],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].tap_internal_key = Some(input_xpub.to_x_only_pub());
+    psbt.inputs[0].tap_key_origins.insert(
+        input_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input_path)),
+    );
+    psbt.outputs[0].redeem_script = Some(change_redeem);
+    psbt.outputs[0]
+        .bip32_derivation
+        .insert(change_xpub.to_pub().0, (fingerprint, change_path));
+
+    transaction_vector(
+        "payment-request",
+        "Covers signed SLIP-24 payment-request metadata, merchant and multiline memo screens, address suppression and the pre-v9.24 simulator merchant limitation.",
+        Coin::Tbtc,
+        psbt,
+        payment_request_options(1, value, address),
+        vec![taproot_key_signature(0, input_xpub.to_x_only_pub())],
+        screens::payment_request(),
+    )
+}
+
+fn payment_request_rejects_owned_output() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+    let input_path = path("m/86'/1'/0'/0/0");
+    let change_path = path("m/86'/1'/0'/1/0");
+    let receive_path = path("m/84'/1'/0'/0/0");
+    let input_xpub = simulator_xpub_at(&secp, &input_path);
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+    let receive_xpub = simulator_xpub_at(&secp, &receive_path);
+    let receive_address = bitcoin::Address::p2wpkh(
+        &bitcoin::CompressedPublicKey(receive_xpub.public_key),
+        bitcoin::Network::Testnet,
+    )
+    .to_string();
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![dummy_input()],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: ScriptBuf::new_p2tr(&secp, input_xpub.to_x_only_pub(), None),
+        }],
+    };
+    let value = 20_000_000;
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![unsigned_input(&prev_tx, 0)],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, change_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey: ScriptBuf::new_p2wpkh(&receive_xpub.to_pub().wpubkey_hash()),
+            },
+        ],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].tap_internal_key = Some(input_xpub.to_x_only_pub());
+    psbt.inputs[0].tap_key_origins.insert(
+        input_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input_path)),
+    );
+    psbt.outputs[0].tap_internal_key = Some(change_xpub.to_x_only_pub());
+    psbt.outputs[0].tap_key_origins.insert(
+        change_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, change_path)),
+    );
+    psbt.outputs[1]
+        .bip32_derivation
+        .insert(receive_xpub.public_key, (fingerprint, receive_path));
+
+    transaction_vector(
+        "payment-request-owned-output",
+        "Covers version-specific handling of payment-request metadata attached to an output owned by this device, rejected since v9.26.3.",
+        Coin::Tbtc,
+        psbt,
+        payment_request_options(1, value, &receive_address),
+        vec![taproot_key_signature(0, input_xpub.to_x_only_pub())],
+        screens::payment_request_owned_output(),
+    )
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/mod.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/mod.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::btc_transaction::TestVector;
+
+mod additional_psbt;
+mod common;
+mod descriptor_psbt;
+mod metadata_psbt;
+mod screens;
+mod standard_psbt;
+
+pub(super) use common::firmware_request_from_psbt;
+
+pub fn all() -> Vec<TestVector> {
+    let mut vectors = standard_psbt::all();
+    vectors.extend(metadata_psbt::all());
+    vectors.extend(additional_psbt::all());
+    vectors.extend(descriptor_psbt::all());
+    vectors
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/screens.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/screens.rs
@@ -1,0 +1,768 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::common::SOME_XPUB;
+use crate::btc_transaction::{Coin, Outcome, Screen, VersionExpectation};
+
+const TBTC_EXTERNAL_ADDRESS: &str =
+    "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d";
+const TBTC_EXTERNAL_ADDRESS_GROUPED: &str =
+    "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d";
+const BTC_P2TR_ADDRESS: &str = "bc1pmg5dhafms6h9nts4dtehgkanym6yeccfmk5hx3ts3jxnm4zh2knqv80ha5";
+const BTC_P2TR_ADDRESS_GROUPED: &str =
+    "bc1p mg5d hafm s6h9 nts4 dteh gkan ym6y eccf mk5h x3ts 3jxn m4zh 2knq v80h a5";
+const LTC_EXTERNAL_ADDRESS: &str = "ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9";
+const LTC_EXTERNAL_ADDRESS_GROUPED: &str = "ltc1 qw50 8d6q ejxt dg4y 5r3z arva ry0c 5xw7 kgmn 4n9";
+const SILENT_PAYMENT_ADDRESS: &str = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv";
+const SILENT_PAYMENT_ADDRESS_GROUPED: &str = "sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv";
+const PSBT_SAME_ACCOUNT_ADDRESS: &str = "tb1ql34ny8mcpgjqr0ngsnjmlpzjpgncyz2ygh2gye";
+const PSBT_SAME_ACCOUNT_ADDRESS_GROUPED: &str =
+    "tb1q l34n y8mc pgjq r0ng snjm lpzj pgnc yz2y gh2g ye";
+const PSBT_OTHER_ACCOUNT_ADDRESS: &str = "tb1qvrcm2akp30d7ecnqdjk8qdu09962ak005rcp6j";
+const PSBT_OTHER_ACCOUNT_ADDRESS_GROUPED: &str =
+    "tb1q vrcm 2akp 30d7 ecnq djk8 qdu0 9962 ak00 5rcp 6j";
+pub const DEVICE_POLICY_XPUB: &str = "[4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv";
+
+fn success(
+    min_version: Option<&str>,
+    max_version_exclusive: Option<&str>,
+    screens: Vec<Screen>,
+) -> VersionExpectation {
+    VersionExpectation {
+        min_version: min_version.map(Into::into),
+        max_version_exclusive: max_version_exclusive.map(Into::into),
+        outcome: Outcome::Success,
+        unsupported_version: None,
+        screens,
+    }
+}
+
+fn unsupported_before(version: &str) -> VersionExpectation {
+    VersionExpectation {
+        min_version: None,
+        max_version_exclusive: Some(version.into()),
+        outcome: Outcome::Unsupported,
+        unsupported_version: Some(version.into()),
+        screens: vec![],
+    }
+}
+
+fn invalid_input_before(version: &str) -> VersionExpectation {
+    invalid_input(None, Some(version))
+}
+
+fn invalid_input(
+    min_version: Option<&str>,
+    max_version_exclusive: Option<&str>,
+) -> VersionExpectation {
+    invalid_input_with_screens(min_version, max_version_exclusive, vec![])
+}
+
+fn invalid_input_with_screens(
+    min_version: Option<&str>,
+    max_version_exclusive: Option<&str>,
+    screens: Vec<Screen>,
+) -> VersionExpectation {
+    VersionExpectation {
+        min_version: min_version.map(Into::into),
+        max_version_exclusive: max_version_exclusive.map(Into::into),
+        outcome: Outcome::InvalidInput,
+        unsupported_version: None,
+        screens,
+    }
+}
+
+fn status() -> Screen {
+    Screen::Status {
+        title: "Transaction".into(),
+        body: "confirmed".into(),
+    }
+}
+
+fn address(amount: &str, address: &str) -> Screen {
+    Screen::TransactionAddress {
+        amount: amount.into(),
+        address: address.into(),
+    }
+}
+
+fn final_fee(amount: &str, fee: &str) -> Screen {
+    Screen::TransactionFee {
+        amount: amount.into(),
+        fee: fee.into(),
+        longtouch: true,
+    }
+}
+
+fn warning_fee(amount: &str, fee: &str) -> Screen {
+    Screen::TransactionFee {
+        amount: amount.into(),
+        fee: fee.into(),
+        longtouch: false,
+    }
+}
+
+fn high_fee(percent: u32) -> Screen {
+    high_fee_decimal(&format!("{percent}.0"))
+}
+
+fn high_fee_decimal(percent: &str) -> Screen {
+    Screen::Confirm {
+        title: "High fee".into(),
+        body: format!("The fee is {percent}%\nthe send amount.\nProceed?"),
+        longtouch: true,
+    }
+}
+
+fn confirmed_screens(high_fee_percent: &str) -> Vec<Screen> {
+    vec![high_fee_decimal(high_fee_percent), status()]
+}
+
+fn transaction_screens(
+    amount: &str,
+    output_address: &str,
+    total: &str,
+    transaction_fee: &str,
+    high_fee_percent: &str,
+) -> Vec<Screen> {
+    vec![
+        address(amount, output_address),
+        warning_fee(total, transaction_fee),
+        high_fee_decimal(high_fee_percent),
+        status(),
+    ]
+}
+
+fn standard_expectations(
+    prefix: Vec<Screen>,
+    total: &str,
+    transaction_fee: &str,
+    high_fee_percent: u32,
+) -> Vec<VersionExpectation> {
+    let suffix_before_920 = vec![high_fee(high_fee_percent), status()];
+    let suffix_920 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS),
+        warning_fee(total, transaction_fee),
+        high_fee(high_fee_percent),
+        status(),
+    ];
+    let suffix_926 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS_GROUPED),
+        warning_fee(total, transaction_fee),
+        high_fee(high_fee_percent),
+        status(),
+    ];
+
+    vec![
+        success(
+            None,
+            Some("9.20.0"),
+            with_suffix(&prefix, suffix_before_920),
+        ),
+        success(
+            Some("9.20.0"),
+            Some("9.26.0"),
+            with_suffix(&prefix, suffix_920),
+        ),
+        success(Some("9.26.0"), None, with_suffix(&prefix, suffix_926)),
+    ]
+}
+
+fn simple_expectations(
+    middle: &[Screen],
+    external_address: &str,
+    grouped_external_address: &str,
+    unit: &str,
+) -> Vec<VersionExpectation> {
+    let amount = format!("0.20000000 {unit}");
+    let total = format!("0.30000000 {unit}");
+    let fee_amount = format!("0.10000000 {unit}");
+    let suffix = |address_value: &str| {
+        let mut screens = vec![address(&amount, address_value)];
+        screens.extend_from_slice(middle);
+        screens.extend([warning_fee(&total, &fee_amount), high_fee(50), status()]);
+        screens
+    };
+    let mut legacy = middle.to_vec();
+    legacy.extend([high_fee(50), status()]);
+
+    vec![
+        success(None, Some("9.20.0"), legacy),
+        success(Some("9.20.0"), Some("9.26.0"), suffix(external_address)),
+        success(Some("9.26.0"), None, suffix(grouped_external_address)),
+    ]
+}
+
+fn taproot_policy_expectations(prefix: Vec<Screen>) -> Vec<VersionExpectation> {
+    let suffix_920 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS),
+        warning_fee("0.30000000 TBTC", "0.10000000 TBTC"),
+        high_fee(50),
+        status(),
+    ];
+    let suffix_926 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS_GROUPED),
+        warning_fee("0.30000000 TBTC", "0.10000000 TBTC"),
+        high_fee(50),
+        status(),
+    ];
+
+    vec![
+        unsupported_before("9.21.0"),
+        success(
+            Some("9.21.0"),
+            Some("9.26.0"),
+            with_suffix(&prefix, suffix_920),
+        ),
+        success(Some("9.26.0"), None, with_suffix(&prefix, suffix_926)),
+    ]
+}
+
+fn with_suffix(prefix: &[Screen], suffix: Vec<Screen>) -> Vec<Screen> {
+    prefix.iter().cloned().chain(suffix).collect()
+}
+
+pub fn taproot_key_spend() -> Vec<VersionExpectation> {
+    standard_expectations(vec![], "1.00000000 TBTC", "0.80000000 TBTC", 400)
+}
+
+pub fn simple_tbtc(middle: &[Screen]) -> Vec<VersionExpectation> {
+    simple_expectations(
+        middle,
+        TBTC_EXTERNAL_ADDRESS,
+        TBTC_EXTERNAL_ADDRESS_GROUPED,
+        "TBTC",
+    )
+}
+
+pub fn simple_ltc(middle: &[Screen]) -> Vec<VersionExpectation> {
+    simple_expectations(
+        middle,
+        LTC_EXTERNAL_ADDRESS,
+        LTC_EXTERNAL_ADDRESS_GROUPED,
+        "LTC",
+    )
+}
+
+pub fn multiple_output_types(
+    coin: Coin,
+    sat: bool,
+    high_fee_warning: bool,
+) -> Vec<VersionExpectation> {
+    assert!(!high_fee_warning || coin == Coin::Btc && !sat);
+    let (unit, addresses, grouped_addresses) = match coin {
+        Coin::Btc => (
+            "BTC",
+            [
+                "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH",
+                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
+                "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8",
+                "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4",
+            ],
+            [
+                "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH",
+                "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ",
+                "bc1q xven xven xven xven xven xven xven xven 2ymj t8",
+                "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4",
+            ],
+        ),
+        Coin::Ltc => (
+            "LTC",
+            [
+                "LLnCCHbSzfwWquEdaS5TF2Yt7uz5Qb1SZ1",
+                "MB1e6aUeL3Zj4s4H2ZqFBHaaHd7kvvzTco",
+                "ltc1qxvenxvenxvenxvenxvenxvenxvenxvenwcpknh",
+                "ltc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqwr7k5s",
+            ],
+            [
+                "LLnC CHbS zfwW quEd aS5T F2Yt 7uz5 Qb1S Z1",
+                "MB1e 6aUe L3Zj 4s4H 2ZqF BHaa Hd7k vvzT co",
+                "ltc1 qxve nxve nxve nxve nxve nxve nxve nxve nwcp knh",
+                "ltc1 qg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z qwr7 k5s",
+            ],
+        ),
+        Coin::Tbtc => panic!("multiple-output fixture has no TBTC address set"),
+    };
+    let amounts = if sat {
+        [
+            "100000000 sat".into(),
+            "1234567890 sat".into(),
+            "6000 sat".into(),
+            "7000 sat".into(),
+        ]
+    } else {
+        [
+            format!("1.00000000 {unit}"),
+            format!(
+                "{} {unit}",
+                if high_fee_warning {
+                    "10.34567890"
+                } else {
+                    "12.34567890"
+                }
+            ),
+            format!("0.00006000 {unit}"),
+            format!("0.00007000 {unit}"),
+        ]
+    };
+    let change_warning = || Screen::Confirm {
+        title: "Warning".into(),
+        body: "There are 2\nchange outputs.\nProceed?".into(),
+        longtouch: false,
+    };
+    let final_screens = |addresses: [&str; 4]| {
+        let mut result = addresses
+            .into_iter()
+            .zip(&amounts)
+            .map(|(output_address, amount)| address(amount, output_address))
+            .collect::<Vec<_>>();
+        result.push(change_warning());
+        result.push(if sat {
+            final_fee("1339999900 sat", "5419010 sat")
+        } else if high_fee_warning {
+            warning_fee("13.39999900 BTC", "2.05419010 BTC")
+        } else {
+            final_fee(
+                &format!("13.39999900 {unit}"),
+                &format!("0.05419010 {unit}"),
+            )
+        });
+        if high_fee_warning {
+            result.push(high_fee_decimal("18.1"));
+        }
+        result.push(status());
+        result
+    };
+    let mut legacy_screens = vec![change_warning()];
+    if high_fee_warning {
+        legacy_screens.push(high_fee_decimal("18.1"));
+    }
+    legacy_screens.push(status());
+    vec![
+        success(None, Some("9.20.0"), legacy_screens),
+        success(Some("9.20.0"), Some("9.26.0"), final_screens(addresses)),
+        success(Some("9.26.0"), None, final_screens(grouped_addresses)),
+    ]
+}
+
+pub fn p2tr_output_btc() -> Vec<VersionExpectation> {
+    simple_expectations(&[], BTC_P2TR_ADDRESS, BTC_P2TR_ADDRESS_GROUPED, "BTC")
+}
+
+pub fn always_invalid_input() -> Vec<VersionExpectation> {
+    vec![invalid_input(None, None)]
+}
+
+pub fn always_invalid_input_with_screens(screens: Vec<Screen>) -> Vec<VersionExpectation> {
+    vec![invalid_input_with_screens(None, None, screens)]
+}
+
+pub fn unsupported_then_invalid_input(version: &str) -> Vec<VersionExpectation> {
+    vec![
+        unsupported_before(version),
+        invalid_input(Some(version), None),
+    ]
+}
+
+pub fn swap_payment_request() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input(None, Some("9.24.0")),
+        invalid_input_with_screens(
+            Some("9.24.0"),
+            Some("9.26.0"),
+            vec![address("0.20000000 BTC", "Test Merchant")],
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            vec![
+                address("0.20000000 BTC", "Test Merchant"),
+                Screen::Swap {
+                    title: "Swap".into(),
+                    from: "0.20000000 BTC".into(),
+                    to: "0.25 ETH".into(),
+                },
+                warning_fee("0.30000000 BTC", "0.10000000 BTC"),
+                high_fee(50),
+                status(),
+            ],
+        ),
+    ]
+}
+
+pub fn swap_payment_request_unsupported_source() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input(None, Some("9.24.0")),
+        invalid_input_with_screens(
+            Some("9.24.0"),
+            Some("9.26.0"),
+            vec![address("0.20000000 TBTC", "Test Merchant")],
+        ),
+        invalid_input(Some("9.26.0"), None),
+    ]
+}
+
+pub fn mixed_spend() -> Vec<VersionExpectation> {
+    standard_expectations(vec![], "2.00000000 TBTC", "1.80000000 TBTC", 900)
+}
+
+pub fn op_return() -> Vec<VersionExpectation> {
+    vec![
+        unsupported_before("9.24.0"),
+        success(
+            Some("9.24.0"),
+            None,
+            vec![
+                Screen::Confirm {
+                    title: "OP_RETURN".into(),
+                    body: "hello world".into(),
+                    longtouch: false,
+                },
+                final_fee("0.01000000 TBTC", "0.01000000 TBTC"),
+                status(),
+            ],
+        ),
+    ]
+}
+
+pub fn op_return_nonascii() -> Vec<VersionExpectation> {
+    let screens = |external_address: &str| {
+        vec![
+            Screen::Confirm {
+                title: "OP_RETURN\ndata (hex)".into(),
+                body: "0102030405".into(),
+                longtouch: false,
+            },
+            address("0.20000000 TBTC", external_address),
+            warning_fee("0.30000000 TBTC", "0.10000000 TBTC"),
+            high_fee(50),
+            status(),
+        ]
+    };
+    vec![
+        unsupported_before("9.24.0"),
+        success(
+            Some("9.24.0"),
+            Some("9.26.0"),
+            screens(TBTC_EXTERNAL_ADDRESS),
+        ),
+        success(Some("9.26.0"), None, screens(TBTC_EXTERNAL_ADDRESS_GROUPED)),
+    ]
+}
+
+pub fn multisig(threshold: u32, xpub_count: usize, name: &str) -> Vec<VersionExpectation> {
+    standard_expectations(
+        vec![
+            Screen::Confirm {
+                title: "Spend from".into(),
+                body: format!("{threshold}-of-{xpub_count}\nBTC Testnet multisig"),
+                longtouch: false,
+            },
+            Screen::Confirm {
+                title: "Spend from".into(),
+                body: name.into(),
+                longtouch: false,
+            },
+        ],
+        "0.30000000 TBTC",
+        "0.10000000 TBTC",
+        50,
+    )
+}
+
+pub fn multisig_p2wsh() -> Vec<VersionExpectation> {
+    multisig(1, 2, "test wsh multisig")
+}
+
+pub fn policy_prefix(policy: &str, name: &str, keys: &[String]) -> Vec<Screen> {
+    let mut result = vec![
+        Screen::Confirm {
+            title: "Spend from".into(),
+            body: format!("BTC Testnet\npolicy with\n{} keys", keys.len()),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Name".into(),
+            body: name.into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "".into(),
+            body: "Show policy\ndetails?".into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Policy".into(),
+            body: policy.into(),
+            longtouch: false,
+        },
+    ];
+    result.extend(keys.iter().enumerate().map(|(index, key)| Screen::Confirm {
+        title: format!("Key {}/{}", index + 1, keys.len()),
+        body: key.clone(),
+        longtouch: false,
+    }));
+    result
+}
+
+pub fn policy(policy: &str, name: &str, keys: &[String], taproot: bool) -> Vec<VersionExpectation> {
+    let prefix = policy_prefix(policy, name, keys);
+    if taproot {
+        taproot_policy_expectations(prefix)
+    } else {
+        standard_expectations(prefix, "0.30000000 TBTC", "0.10000000 TBTC", 50)
+    }
+}
+
+pub fn policy_wsh() -> Vec<VersionExpectation> {
+    policy(
+        "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+        "test wsh policy",
+        &[
+            format!("This device: {DEVICE_POLICY_XPUB}"),
+            SOME_XPUB.into(),
+        ],
+        false,
+    )
+}
+
+pub fn policy_tr_keyspend() -> Vec<VersionExpectation> {
+    policy(
+        "tr(@0/<0;1>/*)",
+        "test tr keyspend policy",
+        &[format!("This device: {DEVICE_POLICY_XPUB}")],
+        true,
+    )
+}
+
+pub fn policy_tr_scriptspend() -> Vec<VersionExpectation> {
+    policy(
+        "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+        "test tr scriptspend policy",
+        &[
+            SOME_XPUB.into(),
+            format!("This device: {DEVICE_POLICY_XPUB}"),
+        ],
+        true,
+    )
+}
+
+pub fn taproot_to_non_taproot_change() -> Vec<VersionExpectation> {
+    standard_expectations(vec![], "1.00000000 TBTC", "0.80000000 TBTC", 400)
+}
+
+pub fn silent_payment() -> Vec<VersionExpectation> {
+    vec![
+        unsupported_before("9.21.0"),
+        success(
+            Some("9.21.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 BTC",
+                SILENT_PAYMENT_ADDRESS,
+                "2.00000000 BTC",
+                "1.80000000 BTC",
+                "900.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            transaction_screens(
+                "0.20000000 BTC",
+                SILENT_PAYMENT_ADDRESS_GROUPED,
+                "2.00000000 BTC",
+                "1.80000000 BTC",
+                "900.0",
+            ),
+        ),
+    ]
+}
+
+pub fn send_self_same_account() -> Vec<VersionExpectation> {
+    let old_address = format!("This BitBox02: {PSBT_SAME_ACCOUNT_ADDRESS}");
+    let address = format!("This BitBox (same account): {PSBT_SAME_ACCOUNT_ADDRESS}");
+    let grouped_address =
+        format!("This BitBox (same account): {PSBT_SAME_ACCOUNT_ADDRESS_GROUPED}");
+
+    vec![
+        success(None, Some("9.20.0"), confirmed_screens("150.0")),
+        success(
+            Some("9.20.0"),
+            Some("9.22.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                &old_address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+        success(
+            Some("9.22.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                &address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            transaction_screens(
+                "0.20000000 TBTC",
+                &grouped_address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+    ]
+}
+
+pub fn silent_payment_owned_output() -> Vec<VersionExpectation> {
+    let old_address = format!("This BitBox02: {SILENT_PAYMENT_ADDRESS}");
+    let address = format!("This BitBox (same account): {SILENT_PAYMENT_ADDRESS}");
+    let grouped_address = format!("This BitBox (same account): {SILENT_PAYMENT_ADDRESS_GROUPED}");
+
+    vec![
+        unsupported_before("9.21.0"),
+        success(
+            Some("9.21.0"),
+            Some("9.22.0"),
+            transaction_screens(
+                "0.20000000 BTC",
+                &old_address,
+                "0.30000000 BTC",
+                "0.10000000 BTC",
+                "50.0",
+            ),
+        ),
+        success(
+            Some("9.22.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 BTC",
+                &address,
+                "0.30000000 BTC",
+                "0.10000000 BTC",
+                "50.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            Some("9.26.3"),
+            transaction_screens(
+                "0.20000000 BTC",
+                &grouped_address,
+                "0.30000000 BTC",
+                "0.10000000 BTC",
+                "50.0",
+            ),
+        ),
+        invalid_input(Some("9.26.3"), None),
+    ]
+}
+
+pub fn payment_request_owned_output() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input(None, Some("9.24.0")),
+        success(
+            Some("9.24.0"),
+            Some("9.26.3"),
+            payment_request_screens("0.30000000 TBTC", "0.10000000 TBTC", 50),
+        ),
+        invalid_input(Some("9.26.3"), None),
+    ]
+}
+
+fn send_self_different_account_modern() -> Vec<VersionExpectation> {
+    let address = format!("This BitBox (account #2): {PSBT_OTHER_ACCOUNT_ADDRESS}");
+    let grouped_address = format!("This BitBox (account #2): {PSBT_OTHER_ACCOUNT_ADDRESS_GROUPED}");
+
+    vec![
+        success(
+            Some("9.22.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                &address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            transaction_screens(
+                "0.20000000 TBTC",
+                &grouped_address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+    ]
+}
+
+pub fn send_self_different_account() -> Vec<VersionExpectation> {
+    vec![
+        success(None, Some("9.20.0"), confirmed_screens("150.0")),
+        success(
+            Some("9.20.0"),
+            Some("9.22.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                PSBT_OTHER_ACCOUNT_ADDRESS,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+    ]
+    .into_iter()
+    .chain(send_self_different_account_modern())
+    .collect()
+}
+
+fn payment_request_screens(
+    total: &str,
+    transaction_fee: &str,
+    high_fee_percent: u32,
+) -> Vec<Screen> {
+    vec![
+        address("0.20000000 TBTC", "Test Merchant"),
+        Screen::Confirm {
+            title: "".into(),
+            body: "Memo from\n\nTest Merchant".into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Memo 1/2".into(),
+            body: "TextMemo line1".into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Memo 2/2".into(),
+            body: "TextMemo line2".into(),
+            longtouch: false,
+        },
+        warning_fee(total, transaction_fee),
+        high_fee(high_fee_percent),
+        status(),
+    ]
+}
+
+pub fn payment_request() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input_before("9.24.0"),
+        success(
+            Some("9.24.0"),
+            None,
+            payment_request_screens("0.50000000 TBTC", "0.30000000 TBTC", 150),
+        ),
+    ]
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/screens.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/screens.rs
@@ -1,0 +1,817 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::common::SOME_XPUB;
+use crate::btc_transaction::{Coin, Outcome, Screen, VersionExpectation};
+
+const TBTC_EXTERNAL_ADDRESS: &str =
+    "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d";
+const TBTC_EXTERNAL_ADDRESS_GROUPED: &str =
+    "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d";
+const BTC_P2TR_ADDRESS: &str = "bc1pmg5dhafms6h9nts4dtehgkanym6yeccfmk5hx3ts3jxnm4zh2knqv80ha5";
+const BTC_P2TR_ADDRESS_GROUPED: &str =
+    "bc1p mg5d hafm s6h9 nts4 dteh gkan ym6y eccf mk5h x3ts 3jxn m4zh 2knq v80h a5";
+const LTC_EXTERNAL_ADDRESS: &str = "ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9";
+const LTC_EXTERNAL_ADDRESS_GROUPED: &str = "ltc1 qw50 8d6q ejxt dg4y 5r3z arva ry0c 5xw7 kgmn 4n9";
+const SILENT_PAYMENT_ADDRESS: &str = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv";
+const SILENT_PAYMENT_ADDRESS_GROUPED: &str = "sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv";
+const PSBT_SAME_ACCOUNT_ADDRESS: &str = "tb1ql34ny8mcpgjqr0ngsnjmlpzjpgncyz2ygh2gye";
+const PSBT_SAME_ACCOUNT_ADDRESS_GROUPED: &str =
+    "tb1q l34n y8mc pgjq r0ng snjm lpzj pgnc yz2y gh2g ye";
+const PSBT_OTHER_ACCOUNT_ADDRESS: &str = "tb1qvrcm2akp30d7ecnqdjk8qdu09962ak005rcp6j";
+const PSBT_OTHER_ACCOUNT_ADDRESS_GROUPED: &str =
+    "tb1q vrcm 2akp 30d7 ecnq djk8 qdu0 9962 ak00 5rcp 6j";
+// Simulator builds before v9.20 did not report transaction address or fee screens. Vectors whose
+// only earlier difference would be such an incomplete capture start at v9.20, so their screen lists
+// cannot be mistaken for the screens shown by the device.
+const COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION: &str = "9.20.0";
+pub const DEVICE_POLICY_XPUB: &str = "[4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv";
+
+fn success(
+    min_version: Option<&str>,
+    max_version_exclusive: Option<&str>,
+    screens: Vec<Screen>,
+) -> VersionExpectation {
+    VersionExpectation {
+        min_version: min_version.map(Into::into),
+        max_version_exclusive: max_version_exclusive.map(Into::into),
+        outcome: Outcome::Success,
+        unsupported_version: None,
+        screens,
+    }
+}
+
+fn unsupported_before(version: &str) -> VersionExpectation {
+    VersionExpectation {
+        min_version: None,
+        max_version_exclusive: Some(version.into()),
+        outcome: Outcome::Unsupported,
+        unsupported_version: Some(version.into()),
+        screens: vec![],
+    }
+}
+
+fn invalid_input_before(version: &str) -> VersionExpectation {
+    invalid_input(None, Some(version))
+}
+
+fn invalid_input(
+    min_version: Option<&str>,
+    max_version_exclusive: Option<&str>,
+) -> VersionExpectation {
+    invalid_input_with_screens(min_version, max_version_exclusive, vec![])
+}
+
+fn invalid_input_with_screens(
+    min_version: Option<&str>,
+    max_version_exclusive: Option<&str>,
+    screens: Vec<Screen>,
+) -> VersionExpectation {
+    VersionExpectation {
+        min_version: min_version.map(Into::into),
+        max_version_exclusive: max_version_exclusive.map(Into::into),
+        outcome: Outcome::InvalidInput,
+        unsupported_version: None,
+        screens,
+    }
+}
+
+fn status() -> Screen {
+    Screen::Status {
+        title: "Transaction".into(),
+        body: "confirmed".into(),
+    }
+}
+
+fn address(amount: &str, address: &str) -> Screen {
+    Screen::TransactionAddress {
+        amount: amount.into(),
+        address: address.into(),
+    }
+}
+
+fn final_fee(amount: &str, fee: &str) -> Screen {
+    Screen::TransactionFee {
+        amount: amount.into(),
+        fee: fee.into(),
+        longtouch: true,
+    }
+}
+
+fn warning_fee(amount: &str, fee: &str) -> Screen {
+    Screen::TransactionFee {
+        amount: amount.into(),
+        fee: fee.into(),
+        longtouch: false,
+    }
+}
+
+fn high_fee(percent: u32) -> Screen {
+    high_fee_decimal(&format!("{percent}.0"))
+}
+
+fn high_fee_decimal(percent: &str) -> Screen {
+    Screen::Confirm {
+        title: "High fee".into(),
+        body: format!("The fee is {percent}%\nthe send amount.\nProceed?"),
+        longtouch: true,
+    }
+}
+
+fn high_fee_total_inputs(percent: u32) -> Screen {
+    Screen::Confirm {
+        title: "High fee".into(),
+        body: format!("The fee is {percent}.0%\nof all inputs.\nProceed?"),
+        longtouch: true,
+    }
+}
+
+fn transaction_screens(
+    amount: &str,
+    output_address: &str,
+    total: &str,
+    transaction_fee: &str,
+    high_fee_percent: &str,
+) -> Vec<Screen> {
+    vec![
+        address(amount, output_address),
+        warning_fee(total, transaction_fee),
+        high_fee_decimal(high_fee_percent),
+        status(),
+    ]
+}
+
+fn standard_expectations(
+    prefix: Vec<Screen>,
+    total: &str,
+    transaction_fee: &str,
+    high_fee_percent: u32,
+) -> Vec<VersionExpectation> {
+    let suffix_920 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS),
+        warning_fee(total, transaction_fee),
+        high_fee(high_fee_percent),
+        status(),
+    ];
+    let suffix_926 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS_GROUPED),
+        warning_fee(total, transaction_fee),
+        high_fee(high_fee_percent),
+        status(),
+    ];
+
+    vec![
+        success(
+            Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+            Some("9.26.0"),
+            with_suffix(&prefix, suffix_920),
+        ),
+        success(Some("9.26.0"), None, with_suffix(&prefix, suffix_926)),
+    ]
+}
+
+fn simple_expectations(
+    middle: &[Screen],
+    external_address: &str,
+    grouped_external_address: &str,
+    unit: &str,
+) -> Vec<VersionExpectation> {
+    let amount = format!("0.20000000 {unit}");
+    let total = format!("0.30000000 {unit}");
+    let fee_amount = format!("0.10000000 {unit}");
+    let suffix = |address_value: &str| {
+        let mut screens = vec![address(&amount, address_value)];
+        screens.extend_from_slice(middle);
+        screens.extend([warning_fee(&total, &fee_amount), high_fee(50), status()]);
+        screens
+    };
+
+    vec![
+        success(
+            Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+            Some("9.26.0"),
+            suffix(external_address),
+        ),
+        success(Some("9.26.0"), None, suffix(grouped_external_address)),
+    ]
+}
+
+fn taproot_policy_expectations(prefix: Vec<Screen>) -> Vec<VersionExpectation> {
+    let suffix_920 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS),
+        warning_fee("0.30000000 TBTC", "0.10000000 TBTC"),
+        high_fee(50),
+        status(),
+    ];
+    let suffix_926 = vec![
+        address("0.20000000 TBTC", TBTC_EXTERNAL_ADDRESS_GROUPED),
+        warning_fee("0.30000000 TBTC", "0.10000000 TBTC"),
+        high_fee(50),
+        status(),
+    ];
+
+    vec![
+        unsupported_before("9.21.0"),
+        success(
+            Some("9.21.0"),
+            Some("9.26.0"),
+            with_suffix(&prefix, suffix_920),
+        ),
+        success(Some("9.26.0"), None, with_suffix(&prefix, suffix_926)),
+    ]
+}
+
+fn with_suffix(prefix: &[Screen], suffix: Vec<Screen>) -> Vec<Screen> {
+    prefix.iter().cloned().chain(suffix).collect()
+}
+
+pub fn taproot_key_spend() -> Vec<VersionExpectation> {
+    standard_expectations(vec![], "1.00000000 TBTC", "0.80000000 TBTC", 400)
+}
+
+pub fn simple_tbtc(middle: &[Screen]) -> Vec<VersionExpectation> {
+    simple_expectations(
+        middle,
+        TBTC_EXTERNAL_ADDRESS,
+        TBTC_EXTERNAL_ADDRESS_GROUPED,
+        "TBTC",
+    )
+}
+
+pub fn simple_ltc(middle: &[Screen]) -> Vec<VersionExpectation> {
+    simple_expectations(
+        middle,
+        LTC_EXTERNAL_ADDRESS,
+        LTC_EXTERNAL_ADDRESS_GROUPED,
+        "LTC",
+    )
+}
+
+pub fn multiple_output_types(
+    coin: Coin,
+    sat: bool,
+    high_fee_warning: bool,
+) -> Vec<VersionExpectation> {
+    assert!(!high_fee_warning || coin == Coin::Btc && !sat);
+    let (unit, addresses, grouped_addresses) = match coin {
+        Coin::Btc => (
+            "BTC",
+            [
+                "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH",
+                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
+                "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8",
+                "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4",
+            ],
+            [
+                "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH",
+                "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ",
+                "bc1q xven xven xven xven xven xven xven xven 2ymj t8",
+                "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4",
+            ],
+        ),
+        Coin::Ltc => (
+            "LTC",
+            [
+                "LLnCCHbSzfwWquEdaS5TF2Yt7uz5Qb1SZ1",
+                "MB1e6aUeL3Zj4s4H2ZqFBHaaHd7kvvzTco",
+                "ltc1qxvenxvenxvenxvenxvenxvenxvenxvenwcpknh",
+                "ltc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqwr7k5s",
+            ],
+            [
+                "LLnC CHbS zfwW quEd aS5T F2Yt 7uz5 Qb1S Z1",
+                "MB1e 6aUe L3Zj 4s4H 2ZqF BHaa Hd7k vvzT co",
+                "ltc1 qxve nxve nxve nxve nxve nxve nxve nxve nwcp knh",
+                "ltc1 qg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z qwr7 k5s",
+            ],
+        ),
+        Coin::Tbtc => panic!("multiple-output fixture has no TBTC address set"),
+    };
+    let amounts = if sat {
+        [
+            "100000000 sat".into(),
+            "1234567890 sat".into(),
+            "6000 sat".into(),
+            "7000 sat".into(),
+        ]
+    } else {
+        [
+            format!("1.00000000 {unit}"),
+            format!(
+                "{} {unit}",
+                if high_fee_warning {
+                    "10.34567890"
+                } else {
+                    "12.34567890"
+                }
+            ),
+            format!("0.00006000 {unit}"),
+            format!("0.00007000 {unit}"),
+        ]
+    };
+    let change_warning = || Screen::Confirm {
+        title: "Warning".into(),
+        body: "There are 2\nchange outputs.\nProceed?".into(),
+        longtouch: false,
+    };
+    let final_screens = |addresses: [&str; 4]| {
+        let mut result = addresses
+            .into_iter()
+            .zip(&amounts)
+            .map(|(output_address, amount)| address(amount, output_address))
+            .collect::<Vec<_>>();
+        result.push(change_warning());
+        result.push(if sat {
+            final_fee("1339999900 sat", "5419010 sat")
+        } else if high_fee_warning {
+            warning_fee("13.39999900 BTC", "2.05419010 BTC")
+        } else {
+            final_fee(
+                &format!("13.39999900 {unit}"),
+                &format!("0.05419010 {unit}"),
+            )
+        });
+        if high_fee_warning {
+            result.push(high_fee_decimal("18.1"));
+        }
+        result.push(status());
+        result
+    };
+    vec![
+        success(
+            Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+            Some("9.26.0"),
+            final_screens(addresses),
+        ),
+        success(Some("9.26.0"), None, final_screens(grouped_addresses)),
+    ]
+}
+
+pub fn p2tr_output_btc() -> Vec<VersionExpectation> {
+    simple_expectations(&[], BTC_P2TR_ADDRESS, BTC_P2TR_ADDRESS_GROUPED, "BTC")
+}
+
+pub fn always_invalid_input() -> Vec<VersionExpectation> {
+    vec![invalid_input(None, None)]
+}
+
+pub fn always_invalid_input_with_screens(screens: Vec<Screen>) -> Vec<VersionExpectation> {
+    vec![invalid_input_with_screens(None, None, screens)]
+}
+
+pub fn unsupported_then_invalid_input(version: &str) -> Vec<VersionExpectation> {
+    vec![
+        unsupported_before(version),
+        invalid_input(Some(version), None),
+    ]
+}
+
+pub fn swap_payment_request() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input(None, Some("9.24.0")),
+        invalid_input_with_screens(
+            Some("9.24.0"),
+            Some("9.26.0"),
+            vec![address("0.20000000 BTC", "Test Merchant")],
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            vec![
+                address("0.20000000 BTC", "Test Merchant"),
+                Screen::Swap {
+                    title: "Swap".into(),
+                    from: "0.20000000 BTC".into(),
+                    to: "0.25 ETH".into(),
+                },
+                warning_fee("0.30000000 BTC", "0.10000000 BTC"),
+                high_fee(50),
+                status(),
+            ],
+        ),
+    ]
+}
+
+pub fn swap_payment_request_unsupported_source() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input(None, Some("9.24.0")),
+        invalid_input_with_screens(
+            Some("9.24.0"),
+            Some("9.26.0"),
+            vec![address("0.20000000 TBTC", "Test Merchant")],
+        ),
+        invalid_input(Some("9.26.0"), None),
+    ]
+}
+
+pub fn mixed_spend() -> Vec<VersionExpectation> {
+    standard_expectations(vec![], "2.00000000 TBTC", "1.80000000 TBTC", 900)
+}
+
+pub fn op_return() -> Vec<VersionExpectation> {
+    vec![
+        unsupported_before("9.24.0"),
+        success(
+            Some("9.24.0"),
+            None,
+            vec![
+                Screen::Confirm {
+                    title: "OP_RETURN".into(),
+                    body: "hello world".into(),
+                    longtouch: false,
+                },
+                final_fee("0.01000000 TBTC", "0.01000000 TBTC"),
+                status(),
+            ],
+        ),
+    ]
+}
+
+pub fn op_return_nonascii() -> Vec<VersionExpectation> {
+    let screens = |external_address: &str| {
+        vec![
+            Screen::Confirm {
+                title: "OP_RETURN\ndata (hex)".into(),
+                body: "0102030405".into(),
+                longtouch: false,
+            },
+            address("0.20000000 TBTC", external_address),
+            warning_fee("0.30000000 TBTC", "0.10000000 TBTC"),
+            high_fee(50),
+            status(),
+        ]
+    };
+    vec![
+        unsupported_before("9.24.0"),
+        success(
+            Some("9.24.0"),
+            Some("9.26.0"),
+            screens(TBTC_EXTERNAL_ADDRESS),
+        ),
+        success(Some("9.26.0"), None, screens(TBTC_EXTERNAL_ADDRESS_GROUPED)),
+    ]
+}
+
+pub fn all_change_high_fee(with_op_return: bool) -> Vec<VersionExpectation> {
+    let prefix = || {
+        with_op_return
+            .then(|| Screen::Confirm {
+                title: "OP_RETURN".into(),
+                body: "metadata".into(),
+                longtouch: false,
+            })
+            .into_iter()
+            .collect::<Vec<_>>()
+    };
+    let previous_screens = || {
+        let mut screens = prefix();
+        screens.extend([final_fee("0.70000000 BTC", "0.70000000 BTC"), status()]);
+        screens
+    };
+    let current_screens = || {
+        let mut screens = prefix();
+        screens.extend([
+            warning_fee("0.70000000 BTC", "0.70000000 BTC"),
+            high_fee_total_inputs(70),
+            status(),
+        ]);
+        screens
+    };
+
+    if with_op_return {
+        vec![
+            unsupported_before("9.24.0"),
+            success(Some("9.24.0"), Some("9.27.0"), previous_screens()),
+            success(Some("9.27.0"), None, current_screens()),
+        ]
+    } else {
+        vec![
+            success(
+                Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+                Some("9.27.0"),
+                previous_screens(),
+            ),
+            success(Some("9.27.0"), None, current_screens()),
+        ]
+    }
+}
+
+pub fn all_change_fee_below_threshold() -> Vec<VersionExpectation> {
+    vec![success(
+        Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+        None,
+        vec![final_fee("0.05000000 BTC", "0.05000000 BTC"), status()],
+    )]
+}
+
+pub fn multisig(threshold: u32, xpub_count: usize, name: &str) -> Vec<VersionExpectation> {
+    standard_expectations(
+        vec![
+            Screen::Confirm {
+                title: "Spend from".into(),
+                body: format!("{threshold}-of-{xpub_count}\nBTC Testnet multisig"),
+                longtouch: false,
+            },
+            Screen::Confirm {
+                title: "Spend from".into(),
+                body: name.into(),
+                longtouch: false,
+            },
+        ],
+        "0.30000000 TBTC",
+        "0.10000000 TBTC",
+        50,
+    )
+}
+
+pub fn multisig_p2wsh() -> Vec<VersionExpectation> {
+    multisig(1, 2, "test wsh multisig")
+}
+
+pub fn policy_prefix(policy: &str, name: &str, keys: &[String]) -> Vec<Screen> {
+    let mut result = vec![
+        Screen::Confirm {
+            title: "Spend from".into(),
+            body: format!("BTC Testnet\npolicy with\n{} keys", keys.len()),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Name".into(),
+            body: name.into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "".into(),
+            body: "Show policy\ndetails?".into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Policy".into(),
+            body: policy.into(),
+            longtouch: false,
+        },
+    ];
+    result.extend(keys.iter().enumerate().map(|(index, key)| Screen::Confirm {
+        title: format!("Key {}/{}", index + 1, keys.len()),
+        body: key.clone(),
+        longtouch: false,
+    }));
+    result
+}
+
+pub fn policy(policy: &str, name: &str, keys: &[String], taproot: bool) -> Vec<VersionExpectation> {
+    let prefix = policy_prefix(policy, name, keys);
+    if taproot {
+        taproot_policy_expectations(prefix)
+    } else {
+        standard_expectations(prefix, "0.30000000 TBTC", "0.10000000 TBTC", 50)
+    }
+}
+
+pub fn policy_wsh() -> Vec<VersionExpectation> {
+    policy(
+        "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+        "test wsh policy",
+        &[
+            format!("This device: {DEVICE_POLICY_XPUB}"),
+            SOME_XPUB.into(),
+        ],
+        false,
+    )
+}
+
+pub fn policy_tr_keyspend() -> Vec<VersionExpectation> {
+    policy(
+        "tr(@0/<0;1>/*)",
+        "test tr keyspend policy",
+        &[format!("This device: {DEVICE_POLICY_XPUB}")],
+        true,
+    )
+}
+
+pub fn policy_tr_scriptspend() -> Vec<VersionExpectation> {
+    policy(
+        "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+        "test tr scriptspend policy",
+        &[
+            SOME_XPUB.into(),
+            format!("This device: {DEVICE_POLICY_XPUB}"),
+        ],
+        true,
+    )
+}
+
+pub fn taproot_to_non_taproot_change() -> Vec<VersionExpectation> {
+    standard_expectations(vec![], "1.00000000 TBTC", "0.80000000 TBTC", 400)
+}
+
+pub fn silent_payment() -> Vec<VersionExpectation> {
+    vec![
+        unsupported_before("9.21.0"),
+        success(
+            Some("9.21.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 BTC",
+                SILENT_PAYMENT_ADDRESS,
+                "2.00000000 BTC",
+                "1.80000000 BTC",
+                "900.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            transaction_screens(
+                "0.20000000 BTC",
+                SILENT_PAYMENT_ADDRESS_GROUPED,
+                "2.00000000 BTC",
+                "1.80000000 BTC",
+                "900.0",
+            ),
+        ),
+    ]
+}
+
+pub fn send_self_same_account() -> Vec<VersionExpectation> {
+    let old_address = format!("This BitBox02: {PSBT_SAME_ACCOUNT_ADDRESS}");
+    let address = format!("This BitBox (same account): {PSBT_SAME_ACCOUNT_ADDRESS}");
+    let grouped_address =
+        format!("This BitBox (same account): {PSBT_SAME_ACCOUNT_ADDRESS_GROUPED}");
+
+    vec![
+        success(
+            Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+            Some("9.22.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                &old_address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+        success(
+            Some("9.22.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                &address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            transaction_screens(
+                "0.20000000 TBTC",
+                &grouped_address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+    ]
+}
+
+pub fn silent_payment_owned_output() -> Vec<VersionExpectation> {
+    let old_address = format!("This BitBox02: {SILENT_PAYMENT_ADDRESS}");
+    let address = format!("This BitBox (same account): {SILENT_PAYMENT_ADDRESS}");
+    let grouped_address = format!("This BitBox (same account): {SILENT_PAYMENT_ADDRESS_GROUPED}");
+
+    vec![
+        unsupported_before("9.21.0"),
+        success(
+            Some("9.21.0"),
+            Some("9.22.0"),
+            transaction_screens(
+                "0.20000000 BTC",
+                &old_address,
+                "0.30000000 BTC",
+                "0.10000000 BTC",
+                "50.0",
+            ),
+        ),
+        success(
+            Some("9.22.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 BTC",
+                &address,
+                "0.30000000 BTC",
+                "0.10000000 BTC",
+                "50.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            Some("9.26.3"),
+            transaction_screens(
+                "0.20000000 BTC",
+                &grouped_address,
+                "0.30000000 BTC",
+                "0.10000000 BTC",
+                "50.0",
+            ),
+        ),
+        invalid_input(Some("9.26.3"), None),
+    ]
+}
+
+pub fn payment_request_owned_output() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input(None, Some("9.24.0")),
+        success(
+            Some("9.24.0"),
+            Some("9.26.3"),
+            payment_request_screens("0.30000000 TBTC", "0.10000000 TBTC", 50),
+        ),
+        invalid_input(Some("9.26.3"), None),
+    ]
+}
+
+fn send_self_different_account_modern() -> Vec<VersionExpectation> {
+    let address = format!("This BitBox (account #2): {PSBT_OTHER_ACCOUNT_ADDRESS}");
+    let grouped_address = format!("This BitBox (account #2): {PSBT_OTHER_ACCOUNT_ADDRESS_GROUPED}");
+
+    vec![
+        success(
+            Some("9.22.0"),
+            Some("9.26.0"),
+            transaction_screens(
+                "0.20000000 TBTC",
+                &address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+        success(
+            Some("9.26.0"),
+            None,
+            transaction_screens(
+                "0.20000000 TBTC",
+                &grouped_address,
+                "0.50000000 TBTC",
+                "0.30000000 TBTC",
+                "150.0",
+            ),
+        ),
+    ]
+}
+
+pub fn send_self_different_account() -> Vec<VersionExpectation> {
+    vec![success(
+        Some(COMPLETE_TRANSACTION_SCREEN_CAPTURE_VERSION),
+        Some("9.22.0"),
+        transaction_screens(
+            "0.20000000 TBTC",
+            PSBT_OTHER_ACCOUNT_ADDRESS,
+            "0.50000000 TBTC",
+            "0.30000000 TBTC",
+            "150.0",
+        ),
+    )]
+    .into_iter()
+    .chain(send_self_different_account_modern())
+    .collect()
+}
+
+fn payment_request_screens(
+    total: &str,
+    transaction_fee: &str,
+    high_fee_percent: u32,
+) -> Vec<Screen> {
+    vec![
+        address("0.20000000 TBTC", "Test Merchant"),
+        Screen::Confirm {
+            title: "".into(),
+            body: "Memo from\n\nTest Merchant".into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Memo 1/2".into(),
+            body: "TextMemo line1".into(),
+            longtouch: false,
+        },
+        Screen::Confirm {
+            title: "Memo 2/2".into(),
+            body: "TextMemo line2".into(),
+            longtouch: false,
+        },
+        warning_fee(total, transaction_fee),
+        high_fee(high_fee_percent),
+        status(),
+    ]
+}
+
+pub fn payment_request() -> Vec<VersionExpectation> {
+    vec![
+        invalid_input_before("9.24.0"),
+        success(
+            Some("9.24.0"),
+            None,
+            payment_request_screens("0.50000000 TBTC", "0.30000000 TBTC", 150),
+        ),
+    ]
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/cases/standard_psbt.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/cases/standard_psbt.rs
@@ -1,0 +1,873 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::common::{
+    SOME_XPUB, ecdsa_signature, keypath, secp, simulator_xprv, simulator_xpub_at,
+    taproot_key_signature, taproot_script_signature, transaction_vector,
+};
+use super::screens;
+use crate::btc_transaction::{
+    Coin, KeyOriginInfo, MultisigScriptType, PsbtSignOptions, Registration, ScriptConfig,
+    ScriptConfigWithKeypath, TestVector,
+};
+use bitcoin::bip32::{DerivationPath, Xpub};
+use bitcoin::opcodes::all;
+use bitcoin::psbt::Psbt;
+use bitcoin::{
+    Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    blockdata::script::Builder, transaction,
+};
+use miniscript::psbt::PsbtExt;
+
+pub fn all() -> Vec<TestVector> {
+    vec![
+        taproot_key_spend(),
+        mixed_spend(),
+        op_return(),
+        multisig_p2wsh(),
+        policy_wsh(),
+        policy_tr_keyspend(),
+        policy_tr_scriptspend(),
+    ]
+}
+
+/// Test signing where all inputs are BIP86 Taproot keyspends.
+fn taproot_key_spend() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+
+    let change_path: DerivationPath = "m/86'/1'/0'/1/0".parse().unwrap();
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+
+    let input0_path: DerivationPath = "m/86'/1'/0'/0/0".parse().unwrap();
+    let input0_xpub = simulator_xpub_at(&secp, &input0_path);
+
+    let input1_path: DerivationPath = "m/86'/1'/0'/0/1".parse().unwrap();
+    let input1_xpub = simulator_xpub_at(&secp, &input1_path);
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, input0_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, input1_xpub.to_x_only_pub(), None),
+            },
+        ],
+    };
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![
+            TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence(0xFFFFFFFF),
+                witness: Witness::default(),
+            },
+            TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout: 1,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence(0xFFFFFFFF),
+                witness: Witness::default(),
+            },
+        ],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, change_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    // Add input and change infos.
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0].tap_internal_key = Some(input0_xpub.to_x_only_pub());
+    psbt.inputs[0].tap_key_origins.insert(
+        input0_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input0_path.clone())),
+    );
+    psbt.inputs[1].witness_utxo = Some(prev_tx.output[1].clone());
+    psbt.inputs[1].tap_internal_key = Some(input1_xpub.to_x_only_pub());
+    psbt.inputs[1].tap_key_origins.insert(
+        input1_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input1_path.clone())),
+    );
+
+    psbt.outputs[0].tap_internal_key = Some(change_xpub.to_x_only_pub());
+    psbt.outputs[0].tap_key_origins.insert(
+        change_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, change_path)),
+    );
+
+    transaction_vector(
+        "taproot-key-spend",
+        "Signs two BIP86 Taproot key-spend inputs and recognizes a BIP86 change output.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions::default(),
+        vec![
+            taproot_key_signature(0, input0_xpub.to_x_only_pub()),
+            taproot_key_signature(1, input1_xpub.to_x_only_pub()),
+        ],
+        screens::taproot_key_spend(),
+    )
+}
+
+/// Test signing with mixed input types: P2TR, P2WPKH and P2SH-P2WPKH.
+fn mixed_spend() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+
+    let change_path: DerivationPath = "m/86'/1'/0'/1/0".parse().unwrap();
+    let change_xpub = simulator_xpub_at(&secp, &change_path);
+
+    let input0_path: DerivationPath = "m/86'/1'/0'/0/0".parse().unwrap();
+    let input0_xpub = simulator_xpub_at(&secp, &input0_path);
+
+    let input1_path: DerivationPath = "m/84'/1'/0'/0/0".parse().unwrap();
+    let input1_xpub = simulator_xpub_at(&secp, &input1_path);
+
+    let input2_path: DerivationPath = "m/49'/1'/0'/0/0".parse().unwrap();
+    let input2_xpub = simulator_xpub_at(&secp, &input2_path);
+
+    let input2_redeemscript = ScriptBuf::new_p2wpkh(&input2_xpub.to_pub().wpubkey_hash());
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, input0_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&input1_xpub.to_pub().wpubkey_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2sh(&input2_redeemscript.clone().into()),
+            },
+        ],
+    };
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: (0..3)
+            .map(|vout| TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence(0xFFFFFFFF),
+                witness: Witness::default(),
+            })
+            .collect(),
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(100_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(&secp, change_xpub.to_x_only_pub(), None),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    // Add input and change infos.
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].tap_internal_key = Some(input0_xpub.to_x_only_pub());
+    psbt.inputs[0].tap_key_origins.insert(
+        input0_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, input0_path)),
+    );
+
+    psbt.inputs[1].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[1]
+        .bip32_derivation
+        .insert(input1_xpub.to_pub().0, (fingerprint, input1_path));
+
+    psbt.inputs[2].non_witness_utxo = Some(prev_tx);
+    psbt.inputs[2].redeem_script = Some(input2_redeemscript);
+    psbt.inputs[2]
+        .bip32_derivation
+        .insert(input2_xpub.to_pub().0, (fingerprint, input2_path));
+
+    psbt.outputs[0].tap_internal_key = Some(change_xpub.to_x_only_pub());
+    psbt.outputs[0].tap_key_origins.insert(
+        change_xpub.to_x_only_pub(),
+        (vec![], (fingerprint, change_path)),
+    );
+
+    transaction_vector(
+        "mixed-spend",
+        "Signs P2TR, native P2WPKH and nested P2SH-P2WPKH inputs from one previous transaction and recognizes BIP86 change.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions::default(),
+        vec![
+            taproot_key_signature(0, input0_xpub.to_x_only_pub()),
+            ecdsa_signature(1, input1_xpub.to_pub().0),
+            ecdsa_signature(2, input2_xpub.to_pub().0),
+        ],
+        screens::mixed_spend(),
+    )
+}
+
+fn op_return() -> TestVector {
+    let secp = secp();
+    let fingerprint = simulator_xprv().fingerprint(&secp);
+
+    let input_path: DerivationPath = "m/84'/1'/0'/0/5".parse().unwrap();
+    let change_path: DerivationPath = "m/84'/1'/0'/1/0".parse().unwrap();
+
+    let input_pub = simulator_xpub_at(&secp, &input_path).to_pub();
+    let change_pub = simulator_xpub_at(&secp, &change_path).to_pub();
+
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(&input_pub.wpubkey_hash()),
+        }],
+    };
+
+    let op_return_data = b"hello world";
+    let op_return_script = Builder::new()
+        .push_opcode(all::OP_RETURN)
+        .push_slice(op_return_data)
+        .into_script();
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(49_000_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&change_pub.wpubkey_hash()),
+            },
+            TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: op_return_script,
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx.clone());
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    psbt.inputs[0]
+        .bip32_derivation
+        .insert(input_pub.0, (fingerprint, input_path));
+
+    psbt.outputs[0]
+        .bip32_derivation
+        .insert(change_pub.0, (fingerprint, change_path));
+
+    transaction_vector(
+        "op-return",
+        "Signs a P2WPKH spend with a zero-value OP_RETURN output containing one printable data push and a P2WPKH change output.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions::default(),
+        vec![ecdsa_signature(0, input_pub.0)],
+        screens::op_return(),
+    )
+}
+
+/// Test a registered 1-of-2 P2WSH multisig account. The historical test name says 1-of-3, but the
+/// client test has always used two xpubs; this vector retains the exact transaction construction.
+fn multisig_p2wsh() -> TestVector {
+    let secp = secp();
+    let our_root_fingerprint = simulator_xprv().fingerprint(&secp);
+
+    let threshold: u32 = 1;
+    let keypath_account: DerivationPath = "m/48'/1'/0'/2'".parse().unwrap();
+
+    let our_xpub: Xpub = simulator_xpub_at(&secp, &keypath_account);
+    let some_xpub: Xpub = SOME_XPUB.parse().unwrap();
+
+    // We use the miniscript library to build a multipath descriptor including key origin so we can
+    // easily derive the receive/change descriptor, pubkey scripts, populate the PSBT input key
+    // infos and convert the sigs to final witnesses.
+    let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = format!(
+        "wsh(sortedmulti({},[{}/48'/1'/0'/2']{}/<0;1>/*,{}/<0;1>/*))",
+        threshold, our_root_fingerprint, our_xpub, some_xpub
+    )
+    .parse()
+    .unwrap();
+    assert!(multi_descriptor.sanity_check().is_ok());
+
+    let [descriptor_receive, descriptor_change] = multi_descriptor
+        .into_single_descriptors()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    // Derive /0/0 (first receive) and /1/0 (first change) descriptors.
+    let input_descriptor = descriptor_receive.at_derivation_index(0).unwrap();
+    let change_descriptor = descriptor_change.at_derivation_index(0).unwrap();
+
+    let multisig_config = ScriptConfig::Multisig {
+        threshold,
+        xpubs: vec![our_xpub.to_string(), some_xpub.to_string()],
+        our_xpub_index: 0,
+        script_type: MultisigScriptType::P2wsh,
+    };
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_descriptor.script_pubkey(),
+        }],
+    };
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_descriptor.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    // Add input and change infos.
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx);
+    // These add the input/output bip32_derivation entries / key infos.
+    psbt.update_input_with_descriptor(0, &input_descriptor)
+        .unwrap();
+    psbt.update_output_with_descriptor(0, &change_descriptor)
+        .unwrap();
+
+    let input_path: DerivationPath = "m/48'/1'/0'/2'/0/0".parse().unwrap();
+    let input_pubkey = simulator_xpub_at(&secp, &input_path).public_key;
+    let mut vector = transaction_vector(
+        "multisig-p2wsh",
+        "Signs the device branch of a registered 1-of-2 sortedmulti P2WSH input, recognizes descriptor-derived change, and finalizes the witness.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: multisig_config.clone(),
+                keypath: keypath(&keypath_account),
+            }),
+            ..Default::default()
+        },
+        vec![ecdsa_signature(0, input_pubkey)],
+        screens::multisig_p2wsh(),
+    );
+    vector.registrations = vec![Registration {
+        script_config: multisig_config,
+        keypath: Some(keypath(&keypath_account)),
+        name: "test wsh multisig".into(),
+    }];
+    vector
+}
+
+fn policy_wsh() -> TestVector {
+    let secp = secp();
+    // Policy string following BIP-388 syntax, input to the BitBox.
+    let policy = "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))";
+
+    let our_root_fingerprint = simulator_xprv().fingerprint(&secp);
+    let keypath_account: DerivationPath = "m/48'/1'/0'/3'".parse().unwrap();
+    let our_xpub: Xpub = simulator_xpub_at(&secp, &keypath_account);
+    let some_xpub: Xpub = SOME_XPUB.parse().unwrap();
+
+    // We use the miniscript library to build a multipath descriptor including key origin so we can
+    // easily derive the receive/change descriptor, pubkey scripts, populate the PSBT input key
+    // infos and convert the sigs to final witnesses.
+    let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = policy
+        .replace(
+            "@0",
+            &format!("[{}/48'/1'/0'/3']{}", our_root_fingerprint, our_xpub),
+        )
+        .replace("@1", &some_xpub.to_string())
+        .parse()
+        .unwrap();
+    assert!(multi_descriptor.sanity_check().is_ok());
+
+    let [descriptor_receive, descriptor_change] = multi_descriptor
+        .into_single_descriptors()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    // Derive /0/0 (first receive) and /1/0 (first change) descriptors.
+    let input_descriptor = descriptor_receive.at_derivation_index(0).unwrap();
+    let change_descriptor = descriptor_change.at_derivation_index(0).unwrap();
+
+    let policy_config = ScriptConfig::Policy {
+        policy: policy.into(),
+        keys: vec![
+            // Our key: root fingerprint and keypath are required.
+            KeyOriginInfo {
+                root_fingerprint: Some(our_root_fingerprint.to_string()),
+                keypath: Some(keypath(&keypath_account)),
+                xpub: our_xpub.to_string(),
+            },
+            // Foreign key: root fingerprint and keypath are optional.
+            KeyOriginInfo {
+                root_fingerprint: None,
+                keypath: None,
+                xpub: some_xpub.to_string(),
+            },
+        ],
+    };
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_descriptor.script_pubkey(),
+        }],
+    };
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_descriptor.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    // Add input and change infos.
+    psbt.inputs[0].non_witness_utxo = Some(prev_tx);
+    // These add the input/output bip32_derivation entries / key infos.
+    psbt.update_input_with_descriptor(0, &input_descriptor)
+        .unwrap();
+    psbt.update_output_with_descriptor(0, &change_descriptor)
+        .unwrap();
+
+    let input_path: DerivationPath = "m/48'/1'/0'/3'/0/0".parse().unwrap();
+    let input_pubkey = simulator_xpub_at(&secp, &input_path).public_key;
+    let mut vector = transaction_vector(
+        "policy-wsh",
+        "Signs the device branch of a registered BIP388 WSH or-policy and recognizes descriptor-derived change.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: policy_config.clone(),
+                keypath: keypath(&keypath_account),
+            }),
+            ..Default::default()
+        },
+        vec![ecdsa_signature(0, input_pubkey)],
+        screens::policy_wsh(),
+    );
+    vector.registrations = vec![Registration {
+        script_config: policy_config,
+        keypath: None,
+        name: "test wsh policy".into(),
+    }];
+    vector
+}
+
+fn policy_tr_keyspend() -> TestVector {
+    let secp = secp();
+    // Policy string following BIP-388 syntax, input to the BitBox.
+    let policy = "tr(@0/<0;1>/*)";
+
+    let our_root_fingerprint = simulator_xprv().fingerprint(&secp);
+    let keypath_account: DerivationPath = "m/48'/1'/0'/3'".parse().unwrap();
+    let our_xpub: Xpub = simulator_xpub_at(&secp, &keypath_account);
+
+    // We use the miniscript library to build a multipath descriptor including key origin so we can
+    // easily derive the receive/change descriptor, pubkey scripts, populate the PSBT input key
+    // infos and convert the sigs to final witnesses.
+    let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = policy
+        .replace(
+            "@0",
+            &format!("[{}/48'/1'/0'/3']{}", our_root_fingerprint, our_xpub),
+        )
+        .parse()
+        .unwrap();
+    assert!(multi_descriptor.sanity_check().is_ok());
+
+    let [descriptor_receive, descriptor_change] = multi_descriptor
+        .into_single_descriptors()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    // Derive /0/0 (first receive) and /1/0 (first change) descriptors.
+    let input_descriptor = descriptor_receive.at_derivation_index(0).unwrap();
+    let change_descriptor = descriptor_change.at_derivation_index(0).unwrap();
+
+    let policy_config = ScriptConfig::Policy {
+        policy: policy.into(),
+        keys: vec![
+            // Our key: root fingerprint and keypath are required.
+            KeyOriginInfo {
+                root_fingerprint: Some(our_root_fingerprint.to_string()),
+                keypath: Some(keypath(&keypath_account)),
+                xpub: our_xpub.to_string(),
+            },
+        ],
+    };
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_descriptor.script_pubkey(),
+        }],
+    };
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_descriptor.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    // Add input and change infos.
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    // These add the input/output bip32_derivation entries / key infos.
+    psbt.update_input_with_descriptor(0, &input_descriptor)
+        .unwrap();
+    psbt.update_output_with_descriptor(0, &change_descriptor)
+        .unwrap();
+
+    let input_path: DerivationPath = "m/48'/1'/0'/3'/0/0".parse().unwrap();
+    let input_pubkey = simulator_xpub_at(&secp, &input_path).to_x_only_pub();
+    let mut vector = transaction_vector(
+        "policy-tr-keyspend",
+        "Signs the key-spend path of a registered BIP388 Taproot policy using only a witness UTXO and recognizes descriptor-derived change.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: policy_config.clone(),
+                keypath: keypath(&keypath_account),
+            }),
+            ..Default::default()
+        },
+        vec![taproot_key_signature(0, input_pubkey)],
+        screens::policy_tr_keyspend(),
+    );
+    vector.registrations = vec![Registration {
+        script_config: policy_config,
+        keypath: None,
+        name: "test tr keyspend policy".into(),
+    }];
+    vector
+}
+
+fn policy_tr_scriptspend() -> TestVector {
+    let secp = secp();
+    // Policy string following BIP-388 syntax, input to the BitBox.
+    let policy = "tr(@0/<0;1>/*,pk(@1/<0;1>/*))";
+
+    let our_root_fingerprint = simulator_xprv().fingerprint(&secp);
+    let keypath_account: DerivationPath = "m/48'/1'/0'/3'".parse().unwrap();
+    let our_xpub: Xpub = simulator_xpub_at(&secp, &keypath_account);
+    let some_xpub: Xpub = SOME_XPUB.parse().unwrap();
+
+    // We use the miniscript library to build a multipath descriptor including key origin so we can
+    // easily derive the receive/change descriptor, pubkey scripts, populate the PSBT input key
+    // infos and convert the sigs to final witnesses.
+    let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = policy
+        .replace(
+            "@1",
+            &format!("[{}/48'/1'/0'/3']{}", our_root_fingerprint, our_xpub),
+        )
+        .replace("@0", &some_xpub.to_string())
+        .parse()
+        .unwrap();
+    assert!(multi_descriptor.sanity_check().is_ok());
+
+    let [descriptor_receive, descriptor_change] = multi_descriptor
+        .into_single_descriptors()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    // Derive /0/0 (first receive) and /1/0 (first change) descriptors.
+    let input_descriptor = descriptor_receive.at_derivation_index(0).unwrap();
+    let change_descriptor = descriptor_change.at_derivation_index(0).unwrap();
+
+    let policy_config = ScriptConfig::Policy {
+        policy: policy.into(),
+        keys: vec![
+            // Foreign key: root fingerprint and keypath are optional.
+            KeyOriginInfo {
+                root_fingerprint: None,
+                keypath: None,
+                xpub: some_xpub.to_string(),
+            },
+            // Our key: root fingerprint and keypath are required.
+            KeyOriginInfo {
+                root_fingerprint: Some(our_root_fingerprint.to_string()),
+                keypath: Some(keypath(&keypath_account)),
+                xpub: our_xpub.to_string(),
+            },
+        ],
+    };
+
+    // A previous tx which creates some UTXOs we can reference later.
+    let prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: "3131313131313131313131313131313131313131313131313131313131313131:0"
+                .parse()
+                .unwrap(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: input_descriptor.script_pubkey(),
+        }],
+    };
+
+    let tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(0xFFFFFFFF),
+            witness: Witness::default(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(70_000_000),
+                script_pubkey: change_descriptor.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    &secp,
+                    // random private key:
+                    // 9dbb534622a6100a39b73dece43c6d4db14b9a612eb46a6c64c2bb849e283ce8
+                    "e4adbb12c3426ec71ebb10688d8ae69d531ca822a2b790acee216a7f1b95b576"
+                        .parse()
+                        .unwrap(),
+                    None,
+                ),
+            },
+        ],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+    // Add input and change infos.
+    psbt.inputs[0].witness_utxo = Some(prev_tx.output[0].clone());
+    // These add the input/output bip32_derivation entries / key infos.
+    psbt.update_input_with_descriptor(0, &input_descriptor)
+        .unwrap();
+    psbt.update_output_with_descriptor(0, &change_descriptor)
+        .unwrap();
+
+    let input_path: DerivationPath = "m/48'/1'/0'/3'/0/0".parse().unwrap();
+    let input_pubkey = simulator_xpub_at(&secp, &input_path).to_x_only_pub();
+    let leaf_hash = psbt.inputs[0].tap_key_origins.get(&input_pubkey).unwrap().0[0];
+    let mut vector = transaction_vector(
+        "policy-tr-scriptspend",
+        "Signs the script path owned by the device in a registered BIP388 Taproot policy whose internal key belongs to another signer.",
+        Coin::Tbtc,
+        psbt,
+        PsbtSignOptions {
+            force_script_config: Some(ScriptConfigWithKeypath {
+                script_config: policy_config.clone(),
+                keypath: keypath(&keypath_account),
+            }),
+            ..Default::default()
+        },
+        vec![taproot_script_signature(0, input_pubkey, leaf_hash)],
+        screens::policy_tr_scriptspend(),
+    );
+    vector.registrations = vec![Registration {
+        script_config: policy_config,
+        keypath: None,
+        name: "test tr scriptspend policy".into(),
+    }];
+    vector
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/mod.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/mod.rs
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Readable source and deterministic generator for Bitcoin transaction test vectors.
+
+mod cases;
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub const GENERATED_FILENAME: &str = "btc-transaction-test-vectors.json";
+
+/// BIP32 xprv derived from the mnemonic restored by all client simulator tests:
+/// boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple
+/// enact box walk height pull today solid off enable tide
+const SIMULATOR_BIP32_XPRV: &str = "xprv9s21ZrQH143K2qxpAMxVdyeza5dUBxY11XbJ7eKvRF51sQyhiFXgmn4P4ALi3Nf6bcG8cmPDvMMEFiAVjtXsqeZ47PJfBJif7uSYycMsx9c";
+const SIMULATOR_SEED: &str = "boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple enact box walk height pull today solid off enable tide";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestVectorFile {
+    pub simulator_seed: String,
+    pub vectors: Vec<TestVector>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestVector {
+    pub id: String,
+    pub description: String,
+    pub coin: Coin,
+    pub psbt: PsbtForm,
+    pub expected_needs_prevtxs: bool,
+    pub expectations: Vec<VersionExpectation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub registrations: Vec<Registration>,
+    /// Signature slots that signing must newly insert. Signature bytes are deliberately omitted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_signatures: Vec<ExpectedSignature>,
+    /// Output scripts that successful signing must generate, keyed by output index.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub expected_generated_outputs: BTreeMap<usize, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PsbtForm {
+    pub transaction: String,
+    #[serde(default, skip_serializing_if = "PsbtSignOptions::is_empty")]
+    pub options: PsbtSignOptions,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Coin {
+    Btc,
+    Tbtc,
+    Ltc,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VersionExpectation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_version_exclusive: Option<String>,
+    pub outcome: Outcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unsupported_version: Option<String>,
+    pub screens: Vec<Screen>,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    Success,
+    Unsupported,
+    InvalidInput,
+}
+
+/// Screens expected from the firmware UI. Released simulator stdout omits `longtouch`.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Screen {
+    Confirm {
+        title: String,
+        body: String,
+        longtouch: bool,
+    },
+    TransactionAddress {
+        amount: String,
+        address: String,
+    },
+    TransactionFee {
+        amount: String,
+        fee: String,
+        longtouch: bool,
+    },
+    Status {
+        title: String,
+        body: String,
+    },
+    Swap {
+        title: String,
+        from: String,
+        to: String,
+    },
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PsbtSignOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_script_config: Option<ScriptConfigWithKeypath>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<usize, PsbtOutputOptions>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub payment_requests: Vec<PaymentRequest>,
+    #[serde(default, skip_serializing_if = "FormatUnit::is_default")]
+    pub format_unit: FormatUnit,
+}
+
+impl PsbtSignOptions {
+    fn is_empty(&self) -> bool {
+        self.force_script_config.is_none()
+            && self.outputs.is_empty()
+            && self.payment_requests.is_empty()
+            && self.format_unit == FormatUnit::Default
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PsbtOutputOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub silent_payment_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_request_index: Option<u32>,
+}
+
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FormatUnit {
+    #[default]
+    Default,
+    Sat,
+}
+
+impl FormatUnit {
+    fn is_default(&self) -> bool {
+        *self == Self::Default
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PaymentRequest {
+    pub recipient_name: String,
+    pub total_amount: u64,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub nonce: String,
+    pub memos: Vec<PaymentRequestMemo>,
+    pub signature: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PaymentRequestMemo {
+    Text {
+        note: String,
+    },
+    CoinPurchase {
+        coin_type: u32,
+        amount: String,
+        address: String,
+        address_keypath: String,
+    },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ScriptConfigWithKeypath {
+    pub script_config: ScriptConfig,
+    pub keypath: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScriptConfig {
+    Simple {
+        script_type: SimpleType,
+    },
+    Multisig {
+        threshold: u32,
+        xpubs: Vec<String>,
+        our_xpub_index: u32,
+        script_type: MultisigScriptType,
+    },
+    Policy {
+        policy: String,
+        keys: Vec<KeyOriginInfo>,
+    },
+}
+
+impl ScriptConfig {
+    fn is_taproot(&self) -> bool {
+        match self {
+            Self::Simple {
+                script_type: SimpleType::P2tr,
+            } => true,
+            Self::Policy { policy, .. } => policy.starts_with("tr("),
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SimpleType {
+    P2wpkh,
+    P2wpkhP2sh,
+    P2tr,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MultisigScriptType {
+    P2wsh,
+    P2wshP2sh,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KeyOriginInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keypath: Option<String>,
+    pub xpub: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Registration {
+    pub script_config: ScriptConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keypath: Option<String>,
+    pub name: String,
+}
+
+#[derive(Debug)]
+pub struct FirmwareSignRequest {
+    pub script_configs: Vec<ScriptConfigWithKeypath>,
+    pub output_script_configs: Vec<ScriptConfigWithKeypath>,
+    pub version: u32,
+    pub inputs: Vec<FirmwareInput>,
+    pub outputs: Vec<FirmwareOutput>,
+    pub locktime: u32,
+    pub payment_requests: Vec<PaymentRequest>,
+    pub format_unit: FormatUnit,
+}
+
+impl FirmwareSignRequest {
+    fn needs_prevtxs(&self) -> bool {
+        self.script_configs
+            .iter()
+            .any(|config| !config.script_config.is_taproot())
+    }
+}
+
+#[derive(Debug)]
+pub struct FirmwareInput {
+    pub prev_out_hash: bitcoin::Txid,
+    pub prev_out_index: u32,
+    pub prev_out_value: u64,
+    pub sequence: u32,
+    pub keypath: bitcoin::bip32::DerivationPath,
+    pub script_config_index: u32,
+    pub prev_tx: Option<bitcoin::Transaction>,
+    pub bip352_pubkey: Option<Vec<u8>>,
+}
+
+#[derive(Debug)]
+pub struct FirmwareOutput {
+    pub ours: bool,
+    pub value: u64,
+    pub output_type: OutputType,
+    pub payload: Vec<u8>,
+    pub keypath: Option<bitcoin::bip32::DerivationPath>,
+    pub script_config_index: u32,
+    pub output_script_config_index: Option<u32>,
+    pub silent_payment_address: Option<String>,
+    pub payment_request_index: Option<u32>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum OutputType {
+    Unknown,
+    P2pkh,
+    P2sh,
+    P2wpkh,
+    P2wsh,
+    P2tr,
+    OpReturn,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpectedSignature {
+    pub input_index: usize,
+    pub kind: SignatureKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pubkey: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leaf_hash: Option<String>,
+    pub sighash: Sighash,
+}
+
+#[derive(Debug, Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureKind {
+    Ecdsa,
+    TaprootKey,
+    TaprootScript,
+}
+
+#[derive(Debug, Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Sighash {
+    All,
+    Default,
+}
+
+/// Validate invariants that execution alone cannot establish.
+fn validate(file: &TestVectorFile) -> Result<(), String> {
+    if file.vectors.is_empty() {
+        return Err("test vector file contains no vectors".into());
+    }
+
+    let mut ids = BTreeSet::new();
+    for vector in &file.vectors {
+        let id = vector.id.trim();
+        if id.is_empty() {
+            return Err("test vector has an empty id".into());
+        }
+        if !ids.insert(id) {
+            return Err(format!("duplicate test vector id '{id}'"));
+        }
+        validate_version_expectations(id, &vector.expectations)?;
+    }
+    Ok(())
+}
+
+fn parse_psbt(vector: &TestVector) -> Result<bitcoin::psbt::Psbt, String> {
+    let id = &vector.id;
+    let serialized = hex::decode(&vector.psbt.transaction)
+        .map_err(|err| format!("test vector '{id}' contains invalid PSBT hex: {err}"))?;
+    bitcoin::psbt::Psbt::deserialize(&serialized)
+        .map_err(|err| format!("test vector '{id}' contains an invalid PSBT: {err}"))
+}
+
+/// Derive the firmware signing request represented by a test vector.
+pub fn derive_sign_request(vector: &TestVector) -> Result<FirmwareSignRequest, String> {
+    let psbt = parse_psbt(vector)?;
+    cases::firmware_request_from_psbt(&psbt, &vector.psbt.options).map_err(|err| {
+        format!(
+            "test vector '{}' cannot derive its firmware signing request: {err}",
+            vector.id
+        )
+    })
+}
+
+fn validate_version_expectations(
+    vector_id: &str,
+    expectations: &[VersionExpectation],
+) -> Result<(), String> {
+    if expectations.is_empty() {
+        return Err(format!("test vector '{vector_id}' has no expectations"));
+    }
+
+    let mut previous_max = None;
+    for (index, expectation) in expectations.iter().enumerate() {
+        let min =
+            parse_version_bound(vector_id, "min_version", expectation.min_version.as_deref())?;
+        let max = parse_version_bound(
+            vector_id,
+            "max_version_exclusive",
+            expectation.max_version_exclusive.as_deref(),
+        )?;
+        if min != previous_max {
+            return Err(format!(
+                "test vector '{vector_id}' has a gap or unordered version expectations"
+            ));
+        }
+        if let (Some(min), Some(max)) = (&min, &max)
+            && min >= max
+        {
+            return Err(format!(
+                "test vector '{vector_id}' has an empty or reversed version range [{min}, {max})"
+            ));
+        }
+        if index + 1 < expectations.len() && max.is_none() {
+            return Err(format!(
+                "test vector '{vector_id}' has an unbounded non-final expectation"
+            ));
+        }
+
+        previous_max = max;
+    }
+
+    if previous_max.is_some() {
+        return Err(format!(
+            "test vector '{vector_id}' version expectations do not cover all versions"
+        ));
+    }
+    Ok(())
+}
+
+fn parse_version_bound(
+    vector_id: &str,
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<Version>, String> {
+    value
+        .map(|value| {
+            Version::parse(value).map_err(|err| {
+                format!("test vector '{vector_id}' has invalid {field} '{value}': {err}")
+            })
+        })
+        .transpose()
+}
+
+pub fn test_vectors() -> TestVectorFile {
+    TestVectorFile {
+        simulator_seed: SIMULATOR_SEED.into(),
+        vectors: cases::all(),
+    }
+}
+
+pub fn try_generate_json() -> Result<String, String> {
+    let file = test_vectors();
+    validate(&file)?;
+    let mut result = serde_json::to_string_pretty(&file).map_err(|err| err.to_string())?;
+    result.push('\n');
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    fn assert_invalid(update: impl FnOnce(&mut super::TestVectorFile), expected: &str) {
+        let mut file = super::test_vectors();
+        update(&mut file);
+        let error = super::validate(&file).unwrap_err();
+        assert!(
+            error.contains(expected),
+            "expected validation error containing '{expected}', got '{error}'"
+        );
+    }
+
+    #[test]
+    fn test_generated_vectors_are_current() {
+        let expected = include_str!("../../testdata/btc-transaction-test-vectors.json");
+        assert_eq!(super::try_generate_json().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_validate_vector_identity() {
+        assert_invalid(|file| file.vectors[0].id.clear(), "empty id");
+        assert_invalid(
+            |file| file.vectors[1].id = file.vectors[0].id.clone(),
+            "duplicate test vector id",
+        );
+    }
+
+    #[test]
+    fn test_validate_version_expectations() {
+        assert_invalid(
+            |file| {
+                file.vectors[0].expectations[1].min_version = Some("99.0.0".into());
+            },
+            "gap or unordered version expectations",
+        );
+    }
+}

--- a/src/rust/bitbox-test-vectors/src/btc_transaction/mod.rs
+++ b/src/rust/bitbox-test-vectors/src/btc_transaction/mod.rs
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Readable source and deterministic generator for Bitcoin transaction test vectors.
+
+mod cases;
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub const GENERATED_FILENAME: &str = "btc-transaction-test-vectors.json";
+
+/// BIP32 xprv derived from the mnemonic restored by all client simulator tests:
+/// boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple
+/// enact box walk height pull today solid off enable tide
+const SIMULATOR_BIP32_XPRV: &str = "xprv9s21ZrQH143K2qxpAMxVdyeza5dUBxY11XbJ7eKvRF51sQyhiFXgmn4P4ALi3Nf6bcG8cmPDvMMEFiAVjtXsqeZ47PJfBJif7uSYycMsx9c";
+const SIMULATOR_SEED: &str = "boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple enact box walk height pull today solid off enable tide";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestVectorFile {
+    pub simulator_seed: String,
+    pub vectors: Vec<TestVector>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestVector {
+    pub id: String,
+    pub description: String,
+    pub coin: Coin,
+    pub psbt: PsbtForm,
+    pub expected_needs_prevtxs: bool,
+    /// Contiguous expectations for applicable firmware versions. If the first range has a
+    /// `min_version`, clients skip this vector on older firmware.
+    pub expectations: Vec<VersionExpectation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub registrations: Vec<Registration>,
+    /// Signature slots that signing must newly insert. Signature bytes are deliberately omitted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_signatures: Vec<ExpectedSignature>,
+    /// Output scripts that successful signing must generate, keyed by output index.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub expected_generated_outputs: BTreeMap<usize, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PsbtForm {
+    pub transaction: String,
+    #[serde(default, skip_serializing_if = "PsbtSignOptions::is_empty")]
+    pub options: PsbtSignOptions,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Coin {
+    Btc,
+    Tbtc,
+    Ltc,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VersionExpectation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_version_exclusive: Option<String>,
+    pub outcome: Outcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unsupported_version: Option<String>,
+    pub screens: Vec<Screen>,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    Success,
+    Unsupported,
+    InvalidInput,
+}
+
+/// Screens expected from the firmware UI. Released simulator stdout omits `longtouch`.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Screen {
+    Confirm {
+        title: String,
+        body: String,
+        longtouch: bool,
+    },
+    TransactionAddress {
+        amount: String,
+        address: String,
+    },
+    TransactionFee {
+        amount: String,
+        fee: String,
+        longtouch: bool,
+    },
+    Status {
+        title: String,
+        body: String,
+    },
+    Swap {
+        title: String,
+        from: String,
+        to: String,
+    },
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PsbtSignOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_script_config: Option<ScriptConfigWithKeypath>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<usize, PsbtOutputOptions>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub payment_requests: Vec<PaymentRequest>,
+    #[serde(default, skip_serializing_if = "FormatUnit::is_default")]
+    pub format_unit: FormatUnit,
+}
+
+impl PsbtSignOptions {
+    fn is_empty(&self) -> bool {
+        self.force_script_config.is_none()
+            && self.outputs.is_empty()
+            && self.payment_requests.is_empty()
+            && self.format_unit == FormatUnit::Default
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PsbtOutputOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub silent_payment_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_request_index: Option<u32>,
+}
+
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FormatUnit {
+    #[default]
+    Default,
+    Sat,
+}
+
+impl FormatUnit {
+    fn is_default(&self) -> bool {
+        *self == Self::Default
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PaymentRequest {
+    pub recipient_name: String,
+    pub total_amount: u64,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub nonce: String,
+    pub memos: Vec<PaymentRequestMemo>,
+    pub signature: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PaymentRequestMemo {
+    Text {
+        note: String,
+    },
+    CoinPurchase {
+        coin_type: u32,
+        amount: String,
+        address: String,
+        address_keypath: String,
+    },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ScriptConfigWithKeypath {
+    pub script_config: ScriptConfig,
+    pub keypath: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScriptConfig {
+    Simple {
+        script_type: SimpleType,
+    },
+    Multisig {
+        threshold: u32,
+        xpubs: Vec<String>,
+        our_xpub_index: u32,
+        script_type: MultisigScriptType,
+    },
+    Policy {
+        policy: String,
+        keys: Vec<KeyOriginInfo>,
+    },
+}
+
+impl ScriptConfig {
+    fn is_taproot(&self) -> bool {
+        match self {
+            Self::Simple {
+                script_type: SimpleType::P2tr,
+            } => true,
+            Self::Policy { policy, .. } => policy.starts_with("tr("),
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SimpleType {
+    P2wpkh,
+    P2wpkhP2sh,
+    P2tr,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MultisigScriptType {
+    P2wsh,
+    P2wshP2sh,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KeyOriginInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keypath: Option<String>,
+    pub xpub: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Registration {
+    pub script_config: ScriptConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keypath: Option<String>,
+    pub name: String,
+}
+
+#[derive(Debug)]
+pub struct FirmwareSignRequest {
+    pub script_configs: Vec<ScriptConfigWithKeypath>,
+    pub output_script_configs: Vec<ScriptConfigWithKeypath>,
+    pub version: u32,
+    pub inputs: Vec<FirmwareInput>,
+    pub outputs: Vec<FirmwareOutput>,
+    pub locktime: u32,
+    pub payment_requests: Vec<PaymentRequest>,
+    pub format_unit: FormatUnit,
+}
+
+impl FirmwareSignRequest {
+    fn needs_prevtxs(&self) -> bool {
+        self.script_configs
+            .iter()
+            .any(|config| !config.script_config.is_taproot())
+    }
+}
+
+#[derive(Debug)]
+pub struct FirmwareInput {
+    pub prev_out_hash: bitcoin::Txid,
+    pub prev_out_index: u32,
+    pub prev_out_value: u64,
+    pub sequence: u32,
+    pub keypath: bitcoin::bip32::DerivationPath,
+    pub script_config_index: u32,
+    pub prev_tx: Option<bitcoin::Transaction>,
+    pub bip352_pubkey: Option<Vec<u8>>,
+}
+
+#[derive(Debug)]
+pub struct FirmwareOutput {
+    pub ours: bool,
+    pub value: u64,
+    pub output_type: OutputType,
+    pub payload: Vec<u8>,
+    pub keypath: Option<bitcoin::bip32::DerivationPath>,
+    pub script_config_index: u32,
+    pub output_script_config_index: Option<u32>,
+    pub silent_payment_address: Option<String>,
+    pub payment_request_index: Option<u32>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum OutputType {
+    Unknown,
+    P2pkh,
+    P2sh,
+    P2wpkh,
+    P2wsh,
+    P2tr,
+    OpReturn,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpectedSignature {
+    pub input_index: usize,
+    pub kind: SignatureKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pubkey: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leaf_hash: Option<String>,
+    pub sighash: Sighash,
+}
+
+#[derive(Debug, Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureKind {
+    Ecdsa,
+    TaprootKey,
+    TaprootScript,
+}
+
+#[derive(Debug, Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Sighash {
+    All,
+    Default,
+}
+
+/// Validate invariants that execution alone cannot establish.
+fn validate(file: &TestVectorFile) -> Result<(), String> {
+    if file.vectors.is_empty() {
+        return Err("test vector file contains no vectors".into());
+    }
+
+    let mut ids = BTreeSet::new();
+    for vector in &file.vectors {
+        let id = vector.id.trim();
+        if id.is_empty() {
+            return Err("test vector has an empty id".into());
+        }
+        if !ids.insert(id) {
+            return Err(format!("duplicate test vector id '{id}'"));
+        }
+        validate_version_expectations(id, &vector.expectations)?;
+    }
+    Ok(())
+}
+
+fn parse_psbt(vector: &TestVector) -> Result<bitcoin::psbt::Psbt, String> {
+    let id = &vector.id;
+    let serialized = hex::decode(&vector.psbt.transaction)
+        .map_err(|err| format!("test vector '{id}' contains invalid PSBT hex: {err}"))?;
+    bitcoin::psbt::Psbt::deserialize(&serialized)
+        .map_err(|err| format!("test vector '{id}' contains an invalid PSBT: {err}"))
+}
+
+/// Derive the firmware signing request represented by a test vector.
+pub fn derive_sign_request(vector: &TestVector) -> Result<FirmwareSignRequest, String> {
+    let psbt = parse_psbt(vector)?;
+    cases::firmware_request_from_psbt(&psbt, &vector.psbt.options).map_err(|err| {
+        format!(
+            "test vector '{}' cannot derive its firmware signing request: {err}",
+            vector.id
+        )
+    })
+}
+
+fn validate_version_expectations(
+    vector_id: &str,
+    expectations: &[VersionExpectation],
+) -> Result<(), String> {
+    if expectations.is_empty() {
+        return Err(format!("test vector '{vector_id}' has no expectations"));
+    }
+
+    let mut previous_max = None;
+    for (index, expectation) in expectations.iter().enumerate() {
+        let min =
+            parse_version_bound(vector_id, "min_version", expectation.min_version.as_deref())?;
+        let max = parse_version_bound(
+            vector_id,
+            "max_version_exclusive",
+            expectation.max_version_exclusive.as_deref(),
+        )?;
+        if index > 0 && min != previous_max {
+            return Err(format!(
+                "test vector '{vector_id}' has a gap or unordered version expectations"
+            ));
+        }
+        if let (Some(min), Some(max)) = (&min, &max)
+            && min >= max
+        {
+            return Err(format!(
+                "test vector '{vector_id}' has an empty or reversed version range [{min}, {max})"
+            ));
+        }
+        if index + 1 < expectations.len() && max.is_none() {
+            return Err(format!(
+                "test vector '{vector_id}' has an unbounded non-final expectation"
+            ));
+        }
+
+        previous_max = max;
+    }
+
+    if previous_max.is_some() {
+        return Err(format!(
+            "test vector '{vector_id}' has a bounded final version expectation"
+        ));
+    }
+    Ok(())
+}
+
+fn parse_version_bound(
+    vector_id: &str,
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<Version>, String> {
+    value
+        .map(|value| {
+            Version::parse(value).map_err(|err| {
+                format!("test vector '{vector_id}' has invalid {field} '{value}': {err}")
+            })
+        })
+        .transpose()
+}
+
+pub fn test_vectors() -> TestVectorFile {
+    TestVectorFile {
+        simulator_seed: SIMULATOR_SEED.into(),
+        vectors: cases::all(),
+    }
+}
+
+pub fn try_generate_json() -> Result<String, String> {
+    let file = test_vectors();
+    validate(&file)?;
+    let mut result = serde_json::to_string_pretty(&file).map_err(|err| err.to_string())?;
+    result.push('\n');
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    fn assert_invalid(update: impl FnOnce(&mut super::TestVectorFile), expected: &str) {
+        let mut file = super::test_vectors();
+        update(&mut file);
+        let error = super::validate(&file).unwrap_err();
+        assert!(
+            error.contains(expected),
+            "expected validation error containing '{expected}', got '{error}'"
+        );
+    }
+
+    #[test]
+    fn test_generated_vectors_are_current() {
+        let expected = include_str!("../../testdata/btc-transaction-test-vectors.json");
+        assert_eq!(super::try_generate_json().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_validate_vector_identity() {
+        assert_invalid(|file| file.vectors[0].id.clear(), "empty id");
+        assert_invalid(
+            |file| file.vectors[1].id = file.vectors[0].id.clone(),
+            "duplicate test vector id",
+        );
+    }
+
+    #[test]
+    fn test_validate_version_expectations() {
+        let mut file = super::test_vectors();
+        // A leading min version makes the vector inapplicable to older firmware; it is not a gap.
+        file.vectors[0].expectations[0].min_version = Some("1.0.0".into());
+        super::validate(&file).unwrap();
+
+        assert_invalid(
+            |file| {
+                file.vectors[0].expectations[1].min_version = Some("99.0.0".into());
+            },
+            "gap or unordered version expectations",
+        );
+    }
+}

--- a/src/rust/bitbox-test-vectors/src/lib.rs
+++ b/src/rust/bitbox-test-vectors/src/lib.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Readable sources and deterministic generators for portable BitBox test vectors.
+
+// The firmware workspace links rust-bitcoin against its unprefixed secp256k1-zkp build.
+use bitbox_secp256k1 as _;
+
+pub mod btc_transaction;

--- a/src/rust/bitbox-test-vectors/src/main.rs
+++ b/src/rust/bitbox-test-vectors/src/main.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+enum Mode {
+    Write(PathBuf),
+    Check,
+    Help,
+}
+
+fn canonical_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata")
+        .join(bitbox_test_vectors::btc_transaction::GENERATED_FILENAME)
+}
+
+fn parse_args() -> Result<Mode, String> {
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    match args.as_slice() {
+        [] => Ok(Mode::Write(canonical_path())),
+        [arg] if arg == "--check" => Ok(Mode::Check),
+        [arg] if arg == "--help" || arg == "-h" => Ok(Mode::Help),
+        [output] if !output.to_string_lossy().starts_with('-') => {
+            Ok(Mode::Write(PathBuf::from(output)))
+        }
+        _ => Err("usage: generate-btc-test-vectors [--check | OUTPUT]".into()),
+    }
+}
+
+fn write(output: &Path, generated: &str) -> Result<(), String> {
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+    std::fs::write(output, generated)
+        .map_err(|err| format!("failed to write {}: {err}", output.display()))?;
+    println!("Wrote {}", output.display());
+    Ok(())
+}
+
+fn check(generated: &str) -> Result<(), String> {
+    let canonical = canonical_path();
+    let committed = std::fs::read_to_string(&canonical)
+        .map_err(|err| format!("failed to read {}: {err}", canonical.display()))?;
+    if committed != generated {
+        return Err(format!(
+            "{} is stale; run generate-btc-test-vectors",
+            canonical.display()
+        ));
+    }
+    println!("{} is current", canonical.display());
+    Ok(())
+}
+
+fn run() -> Result<(), String> {
+    let mode = parse_args()?;
+    if matches!(mode, Mode::Help) {
+        println!("usage: generate-btc-test-vectors [--check | OUTPUT]");
+        return Ok(());
+    }
+
+    let generated = bitbox_test_vectors::btc_transaction::try_generate_json()?;
+    match mode {
+        Mode::Write(output) => write(&output, &generated),
+        Mode::Check => check(&generated),
+        Mode::Help => unreachable!(),
+    }
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    }
+}

--- a/src/rust/bitbox-test-vectors/testdata/btc-transaction-test-vectors.json
+++ b/src/rust/bitbox-test-vectors/testdata/btc-transaction-test-vectors.json
@@ -1,0 +1,4858 @@
+{
+  "simulator_seed": "boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple enact box walk height pull today solid off enable tide",
+  "vectors": [
+    {
+      "id": "taproot-key-spend",
+      "description": "Signs two BIP86 Taproot key-spend inputs and recognizes a BIP86 change output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100b20200000002f8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270000000000fffffffff8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270100000000ffffffff0200e1f50500000000225120cc9235442b0f4fdf2f3c39516207c389e08fed3ae6cfa90cdb820d791a9d6ba4002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001012b00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db42221169e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434319004c00739d56000080010000800000008000000000010000000117209e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434300010520c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f7852107c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f78519004c00739d56000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "taproot_key",
+          "pubkey": "9e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a40574343",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "mixed-spend",
+      "description": "Signs P2TR, native P2WPKH and nested P2SH-P2WPKH inputs from one previous transaction and recognizes BIP86 change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100db0200000003e3ba22f94fa7f97d19e4b6c31853ce54c220cf225952b1ba9082ba0c1ba316260000000000ffffffffe3ba22f94fa7f97d19e4b6c31853ce54c220cf225952b1ba9082ba0c1ba316260100000000ffffffffe3ba22f94fa7f97d19e4b6c31853ce54c220cf225952b1ba9082ba0c1ba316260200000000ffffffff0200e1f50500000000225120cc9235442b0f4fdf2f3c39516207c389e08fed3ae6cfa90cdb820d791a9d6ba4002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a2782094400e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc66870000000021166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a2782094400e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc668700000000220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a2782094400e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc668700000000010416001468a00bbd6de555d756e92815e523b789def6c0b022060329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0184c00739d310000800100008000000080000000000000000000010520c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f7852107c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f78519004c00739d56000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 TBTC",
+              "fee": "1.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 TBTC",
+              "fee": "1.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        },
+        {
+          "input_index": 2,
+          "kind": "ecdsa",
+          "pubkey": "0329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "op-return",
+      "description": "Signs a P2WPKH spend with a zero-value OP_RETURN output containing one printable data push and a P2WPKH change output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01006802000000012b769ad9a4c846c82a6005040bbbc22a05ce02e42a6e1787a8ba8e57977bb7080000000000ffffffff0240aeeb02000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e9500000000000000000d6a0b68656c6c6f20776f726c640000000000010052020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0180f0fa0200000000160014bfbb8f964b61fb712f04587acaebea9e103161bc0000000001011f80f0fa0200000000160014bfbb8f964b61fb712f04587acaebea9e103161bc220602e62431dfc2aa92e24d23118f8f078894ee118271ddc13715c5bd33d7d2ffe229184c00739d540000800100008000000080000000000500000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN",
+              "body": "hello world",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.01000000 TBTC",
+              "fee": "0.01000000 TBTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02e62431dfc2aa92e24d23118f8f078894ee118271ddc13715c5bd33d7d2ffe229",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multisig-p2wsh",
+      "description": "Signs the device branch of a registered 1-of-2 sortedmulti P2WSH input, recognizes descriptor-derived change, and finalizes the witness.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001189002448bf29a8299625a5e0bbba99c561bd2ea07c71bb55b72be77e00becd60000000000ffffffff02801d2c04000000002200208dd9dc6a4969db2b4ed0a01a078e16c92328ea56ba3854f7416138132d2e6e48002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002200208b7d9944e24b23ca0e5d02a1233611fbaf2faf95bfc17cd35d68a800309352ec000000000105475121024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed20921039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde52ae2206024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed2090c4707983700000000000000002206039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde1c4c00739d300000800100008000000080020000800000000000000000000101475121031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb2103d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c52ae2202031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb1c4c00739d300000800100008000000080020000800100000000000000220203d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c0c4707983701000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 1,
+              "xpubs": [
+                "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+                "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh"
+            },
+            "keypath": "m/48'/1'/0'/2'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "multisig",
+            "threshold": 1,
+            "xpubs": [
+              "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+              "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+            ],
+            "our_xpub_index": 0,
+            "script_type": "p2wsh"
+          },
+          "keypath": "m/48'/1'/0'/2'",
+          "name": "test wsh multisig"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-wsh",
+      "description": "Signs the device branch of a registered BIP388 WSH or-policy and recognizes descriptor-derived change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff010089020000000117bb7376f1aed39ca76fac738a9eecfb490d3d8e0d9cb47a08b227dd04bb7abc0000000000ffffffff02801d2c0400000000220020593d9bd9f01f27f05e9a8ad4096961eb5f1bcd43a6fed6f2df9020fc82673560002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002200204bff256253c47cfb36eb7d58f4e6b97d484701191075ecde1d3332ecdf8111010000000001054821033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2ac7c21024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed209ac9b2206024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed2090c4707983700000000000000002206033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21c4c00739d3000008001000080000000800300008000000000000000000001014821028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aac7c2103d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074cac9b2202028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1c4c00739d300000800100008000000080030000800100000000000000220203d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c0c4707983701000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test wsh policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test wsh policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test wsh policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+              }
+            ]
+          },
+          "name": "test wsh policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-keyspend",
+      "description": "Signs the key-spend path of a registered BIP388 Taproot policy using only a witness UTXO and recognizes descriptor-derived change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001c0470cb5928e1e538404293a10b5c47e8d2482e27834ec4fb855d2c9e708a1480000000000ffffffff02801d2c04000000002251202cf99a9e98b0ee07ccb287502f76b2f856af59b726a746cd1ab303adc6749129002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120eb86719b281a383608399cab552dbd40368c66cd958f38bcb42347830e729ef021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21d004c00739d3000008001000080000000800300008000000000000000000117203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2000105208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a21078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1d004c00739d3000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*)",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n1 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr keyspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*)",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/1",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n1 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr keyspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*)",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/1",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*)",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test tr keyspend policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-scriptspend",
+      "description": "Signs the script path owned by the device in a registered BIP388 Taproot policy whose internal key belongs to another signer.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000014625d1da866927cc28dae6171aabba10fdb6abaee03829bc717fa57c05fc6b1c0000000000ffffffff02801d2c04000000002251206ea53e5447e4771e25f4e3ef3e3c5973e00ed2a4f7680507134a797b7df3c3cc002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120d0692388c73a40274236cad74af812db4d49ecf07b0838e644189693c4a1c87f2215c14f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed20923203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2acc021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b23d01c3aa2951885f3ddabebfba4eb4873dbdb2c41e287562d542cf8782e2a857071b4c00739d30000080010000800000008003000080000000000000000021164f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed2090d004707983700000000000000000117204f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed209011820c3aa2951885f3ddabebfba4eb4873dbdb2c41e287562d542cf8782e2a857071b00010520d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c01062500c022208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aac21078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a3d01bdda447b6076e3cc5aef2434e05b03e88a74dba86599553f3371fac3e86112b74c00739d3000008001000080000000800300008001000000000000002107d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c0d004707983701000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+              "keys": [
+                {
+                  "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+                },
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr scriptspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr scriptspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+            "keys": [
+              {
+                "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+              },
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test tr scriptspend policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_script",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "leaf_hash": "c3aa2951885f3ddabebfba4eb4873dbdb2c41e287562d542cf8782e2a857071b",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "taproot-to-non-taproot-change",
+      "description": "Signs all-Taproot inputs with P2WPKH change, requiring previous transactions for the added non-Taproot output config.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100a60200000002f8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270000000000fffffffff8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270100000000ffffffff0200e1f505000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef140000000000010089020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0200e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db4220000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e00010089020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0200e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db4220000000001012b00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db42221169e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434319004c00739d56000080010000800000008000000000010000000117209e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434300220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "taproot_key",
+          "pubkey": "9e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a40574343",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "silent-payment",
+      "description": "Signs mixed inputs with BIP352 metadata and a device-generated silent-payment output.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100b9020000000314f5c987750e136e84be08a812ad8273b6597dbd76ded0806e714c183644cdc40000000000ffffffff14f5c987750e136e84be08a812ad8273b6597dbd76ded0806e714c183644cdc40100000000ffffffff14f5c987750e136e84be08a812ad8273b6597dbd76ded0806e714c183644cdc40200000000ffffffff0200e1f50500000000225120aaf8631d8fffabc65d283faa12aedc768bdc669c1ba6ff1166f356f13eefe089002d31010000000000000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a294300e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b00e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870000000001012b00e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a29432116cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff0952719004c00739d5600008000000080000000800000000000000000011720cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff095270001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a294300e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b00e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d54000080000000800000008000000000000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a294300e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b00e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870000000001012000e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870104160014d14ce318a324bc9eb4ff285d94ee02a297c0496f220603d47c62767f5463ffc008b9250fa6bb7eac11f2aff84804cf19d80ea46922bd73184c00739d31000080000000800000008000000000000000000001052067426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee5210767426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee519004c00739d56000080000000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "silent_payment_address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            }
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 BTC",
+              "fee": "1.80000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 BTC",
+              "fee": "1.80000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff09527",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        },
+        {
+          "input_index": 2,
+          "kind": "ecdsa",
+          "pubkey": "03d47c62767f5463ffc008b9250fa6bb7eac11f2aff84804cf19d80ea46922bd73",
+          "sighash": "all"
+        }
+      ],
+      "expected_generated_outputs": {
+        "1": "5120d826829cb603fc008e5ef99d0818f2126d3569c3ab8a6cd069f07a20e892bd59"
+      }
+    },
+    {
+      "id": "send-self-same-account",
+      "description": "Covers ownership detection for the input account, suppression of change confirmation and version-specific account labels.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100720200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff0280f0fa020000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d310100000000160014fc6b321f780a2401be6884e5bf84520a27820944000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d310000800100008000000080010000000000000000220203a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.22.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox02: tb1ql34ny8mcpgjqr0ngsnjmlpzjpgncyz2ygh2gye"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.22.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (same account): tb1ql34ny8mcpgjqr0ngsnjmlpzjpgncyz2ygh2gye"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (same account): tb1q l34n y8mc pgjq r0ng snjm lpzj pgnc yz2y gh2g ye"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "send-self-different-account",
+      "description": "Covers ownership detection for another account and version-specific account labels.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100720200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff0280f0fa020000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d31010000000016001460f1b576c18bdbece2606cac70378f2974aed9ef000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d310000800100008000000080010000000000000000220203cee733ae6350507a6c63656d45de6dfc98a252a9f242116cfbe6c6ade2626b0c184c00739d540000800100008001000080000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.22.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1qvrcm2akp30d7ecnqdjk8qdu09962ak005rcp6j"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.22.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (account #2): tb1qvrcm2akp30d7ecnqdjk8qdu09962ak005rcp6j"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (account #2): tb1q vrcm 2akp 30d7 ecnq djk8 qdu0 9962 ak00 5rcp 6j"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "payment-request",
+      "description": "Covers signed SLIP-24 payment-request metadata, merchant and multiline memo screens, address suppression and the pre-v9.24 simulator merchant limitation.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100720200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff0280f0fa020000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d3101000000001600142d997091b1574170c30720dbba9d06a367d68351000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d31000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "text",
+                  "note": "TextMemo line1\nTextMemo line2"
+                }
+              ],
+              "signature": "3e67d38390b3d32938bd3e3c8f239b201efc278fedadf371bea9561c94da89ea450ad806eeae079983babd8158ac9c7c6a3c12e589435e7535a571d562f9f337"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "Test Merchant"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Memo from\n\nTest Merchant",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 1/2",
+              "body": "TextMemo line1",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 2/2",
+              "body": "TextMemo line2",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "payment-request-owned-output",
+      "description": "Covers version-specific handling of payment-request metadata attached to an output owned by this device, rejected since v9.26.3.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff02801d2c0400000000225120cc9235442b0f4fdf2f3c39516207c389e08fed3ae6cfa90cdb820d791a9d6ba4002d310100000000160014fc6b321f780a2401be6884e5bf84520a27820944000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e00010520c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f7852107c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f78519004c00739d560000800100008000000080010000000000000000220203a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "text",
+                  "note": "TextMemo line1\nTextMemo line2"
+                }
+              ],
+              "signature": "4e7837fadb6a322439108c295906d50229f5fd79a1624957e12eeb171cf4ceed36b854ba948ed2630ec89b38aec462b06ed236ea32fa74ad9040dadf430712cd"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.3",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "Test Merchant"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Memo from\n\nTest Merchant",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 1/2",
+              "body": "TextMemo line1",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 2/2",
+              "body": "TextMemo line2",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.3",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "multiple-output-types-bitcoin-coin",
+      "description": "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001c38bf8f182f907c18224bd5f9cbd843e118019c68c288f5045bc4941672d30380000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd20296490000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600140b664ee927e3e41c6f5acd135d5b31fca4ed8e4a640000000000000016001491d160f1749d830eec2b9402b0b1fcc5ccd52ab1000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f0000000001011f8057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f22060218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d184c00739d54000080000000800a000080000000000500000000000000002202024ea6cfaca7a9f7689293a9b67c77e0a3e5aa8b160b5cfa12474b52767b4b94cf184c00739d54000080000000800a000080010000000300000000220202b8564af1c586c4477df4c233987002147a77987163bdc0535d364569306a74b6184c00739d54000080000000800a000080010000001e00000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 BTC",
+              "address": "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "0.05419010 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 BTC",
+              "address": "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1q xven xven xven xven xven xven xven xven 2ymj t8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "0.05419010 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multiple-output-types-bitcoin-satoshi",
+      "description": "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001c38bf8f182f907c18224bd5f9cbd843e118019c68c288f5045bc4941672d30380000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd20296490000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600140b664ee927e3e41c6f5acd135d5b31fca4ed8e4a640000000000000016001491d160f1749d830eec2b9402b0b1fcc5ccd52ab1000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f0000000001011f8057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f22060218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d184c00739d54000080000000800a000080000000000500000000000000002202024ea6cfaca7a9f7689293a9b67c77e0a3e5aa8b160b5cfa12474b52767b4b94cf184c00739d54000080000000800a000080010000000300000000220202b8564af1c586c4477df4c233987002147a77987163bdc0535d364569306a74b6184c00739d54000080000000800a000080010000001e00000000",
+        "options": {
+          "format_unit": "sat"
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "100000000 sat",
+              "address": "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "1234567890 sat",
+              "address": "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "6000 sat",
+              "address": "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "7000 sat",
+              "address": "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1339999900 sat",
+              "fee": "5419010 sat",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "100000000 sat",
+              "address": "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "1234567890 sat",
+              "address": "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "6000 sat",
+              "address": "bc1q xven xven xven xven xven xven xven xven 2ymj t8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "7000 sat",
+              "address": "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1339999900 sat",
+              "fee": "5419010 sat",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multiple-output-types-litecoin-coin",
+      "description": "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction.",
+      "coin": "ltc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001df6504f0b9af7c7d6795aa190cb900553f2b56690c26ed0d5b8439086dedb9bf0000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd20296490000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600146874a290ffa9444d417e413635eb17a610282aef640000000000000016001466d4383af71817173d87697435a67185d787eb0e000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014f3f3b2cac1d6582e72c41c7db73f4d1c8eb642500000000001011f8057ff7800000000160014f3f3b2cac1d6582e72c41c7db73f4d1c8eb64250220602bad6b8353f8ad1cc4cfc775b05ab9f834a1d132ac36e4cafdc43d8c2c99ebc46184c00739d54000080020000800a0000800000000005000000000000000022020394b3d8170d82ca3dab3feaa5846c5e659cf2f970fc535597aa96c921ed747bdd184c00739d54000080020000800a00008001000000030000000022020349e62be3b83b966bb79dfb50aac69ca112df3237b0ec5cbb069321d2dc363d84184c00739d54000080020000800a000080010000001e00000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 LTC",
+              "address": "LLnCCHbSzfwWquEdaS5TF2Yt7uz5Qb1SZ1"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 LTC",
+              "address": "MB1e6aUeL3Zj4s4H2ZqFBHaaHd7kvvzTco"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 LTC",
+              "address": "ltc1qxvenxvenxvenxvenxvenxvenxvenxvenwcpknh"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 LTC",
+              "address": "ltc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqwr7k5s"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 LTC",
+              "fee": "0.05419010 LTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 LTC",
+              "address": "LLnC CHbS zfwW quEd aS5T F2Yt 7uz5 Qb1S Z1"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 LTC",
+              "address": "MB1e 6aUe L3Zj 4s4H 2ZqF BHaa Hd7k vvzT co"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 LTC",
+              "address": "ltc1 qxve nxve nxve nxve nxve nxve nxve nxve nwcp knh"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 LTC",
+              "address": "ltc1 qg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z qwr7 k5s"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 LTC",
+              "fee": "0.05419010 LTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02bad6b8353f8ad1cc4cfc775b05ab9f834a1d132ac36e4cafdc43d8c2c99ebc46",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "high-fee-rounding",
+      "description": "Displays the 18.1% high-fee warning and requires the final longtouch on the warning instead of the fee screen.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001c38bf8f182f907c18224bd5f9cbd843e118019c68c288f5045bc4941672d30380000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd240aa3d0000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600140b664ee927e3e41c6f5acd135d5b31fca4ed8e4a640000000000000016001491d160f1749d830eec2b9402b0b1fcc5ccd52ab1000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f0000000001011f8057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f22060218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d184c00739d54000080000000800a000080000000000500000000000000002202024ea6cfaca7a9f7689293a9b67c77e0a3e5aa8b160b5cfa12474b52767b4b94cf184c00739d54000080000000800a000080010000000300000000220202b8564af1c586c4477df4c233987002147a77987163bdc0535d364569306a74b6184c00739d54000080000000800a000080010000001e00000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 18.1%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "10.34567890 BTC",
+              "address": "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "2.05419010 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 18.1%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "10.34567890 BTC",
+              "address": "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1q xven xven xven xven xven xven xven xven 2ymj t8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "2.05419010 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 18.1%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "swap-payment-request",
+      "description": "Displays and signs a Bitcoin-to-Ethereum coin-purchase payment request.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff02801d2c04000000001600141133a71526b176aac7b2462bc5bff36abe68a18a002d310100000000225120da28dbf53b86ae59ae156af3745bb326f44ce309dda97345708c8d3dd45755a6000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d54000080000000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "coin_purchase",
+                  "coin_type": 60,
+                  "amount": "0.25 ETH",
+                  "address": "0x416E88840Eb6353E49252Da2a2c140eA1f969D1a",
+                  "address_keypath": "m/44'/60'/0'/0/0"
+                }
+              ],
+              "signature": "917d3514b2358406730f42952efe0a873255788314a9cf2906474c1e2cefd8cb0e35791ef8211463d37a007e3d9d3a0ec11736250b7e089156c53e5ebf40413d"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "Test Merchant"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "Test Merchant"
+            },
+            {
+              "type": "swap",
+              "title": "Swap",
+              "from": "0.20000000 BTC",
+              "to": "0.25 ETH"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "swap-payment-request-unsupported-source",
+      "description": "Rejects a coin-purchase payment request whose source account is Bitcoin testnet.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "coin_purchase",
+                  "coin_type": 60,
+                  "amount": "0.25 ETH",
+                  "address": "0x416E88840Eb6353E49252Da2a2c140eA1f969D1a",
+                  "address_keypath": "m/44'/60'/0'/0/0"
+                }
+              ],
+              "signature": "c231191f200c3259f71a509dc644b49ab14332fdde4b63a12aaa19b744f188f872e7c60cc6a7e5823acb1f849659e16664fbf2680749bd2101b33cdb49bb8dce"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "Test Merchant"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "p2wpkh-p2sh",
+      "description": "Signs a nested SegWit input and recognizes nested SegWit change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007e020000000118daf26c629c509a7ea9da4fa3a32393c330c526aa6466e2a2e2f880ee9cf50e0000000000ffffffff02801d2c040000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005302000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc66870000000001012000e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc6687010416001468a00bbd6de555d756e92815e523b789def6c0b022060329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0184c00739d31000080010000800000008000000000000000000001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d31000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "high-input-address-index",
+      "description": "Spends an owned input at address index 100000 without treating the high spend path as a receive-address verification request.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d02000000014e52523f00352b5da9aca9fcb5dfb4a6c1e0cb8632718e187e0ffefaec0a5eb90000000000ffffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014c2e296c295380207dfdc535c8872c043d9bf52d30000000001011f00e1f50500000000160014c2e296c295380207dfdc535c8872c043d9bf52d3220603ce6f00e8e7302e323faf1f26ce2584307cb1bcef2a2b2140c6013c67bb9b991b184c00739d54000080010000800000008000000000a086010000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03ce6f00e8e7302e323faf1f26ce2584307cb1bcef2a2b2140c6013c67bb9b991b",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-zero",
+      "description": "Suppresses the locktime confirmation when locktime is zero even if the sequence signals RBF.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000fdffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-non-rbf",
+      "description": "Displays block locktime 10 and its non-rbf sequence semantics.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000feffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef140a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is not RBF",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is not RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is not RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-rbf",
+      "description": "Displays block locktime 10 and its rbf sequence semantics.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000fdffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef140a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is RBF",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-litecoin-non-rbf-sequence",
+      "description": "Displays a Litecoin block locktime without Bitcoin-specific RBF wording.",
+      "coin": "ltc",
+      "psbt": {
+        "transaction": "70736274ff01007102000000018660b164e26bff1622e4172600f4011bd824211a4ef4201d92c0b0fb290f9b730000000000feffffff02801d2c04000000001600146514c2779c7ee0f8e09ae4f2999c334e5254c70e002d310100000000160014751e76e8199196d454941c45d1b3a323f1433bd60a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f160000000001011f00e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f162206032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2184c00739d5400008002000080000000800000000000000000002202039537a5fa4fa947baa7b215407914d5fcb3709c554ff5750bf0ba931b3cda24ae184c00739d54000080020000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1 qw50 8d6q ejxt dg4y 5r3z arva ry0c 5xw7 kgmn 4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-litecoin-rbf-sequence",
+      "description": "Displays a Litecoin block locktime without Bitcoin-specific RBF wording.",
+      "coin": "ltc",
+      "psbt": {
+        "transaction": "70736274ff01007102000000018660b164e26bff1622e4172600f4011bd824211a4ef4201d92c0b0fb290f9b730000000000fdffffff02801d2c04000000001600146514c2779c7ee0f8e09ae4f2999c334e5254c70e002d310100000000160014751e76e8199196d454941c45d1b3a323f1433bd60a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f160000000001011f00e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f162206032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2184c00739d5400008002000080000000800000000000000000002202039537a5fa4fa947baa7b215407914d5fcb3709c554ff5750bf0ba931b3cda24ae184c00739d54000080020000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1 qw50 8d6q ejxt dg4y 5r3z arva ry0c 5xw7 kgmn 4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "p2tr-output-mainnet",
+      "description": "Displays and signs a mainnet P2TR recipient output from a native SegWit account.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff02801d2c04000000001600141133a71526b176aac7b2462bc5bff36abe68a18a002d310100000000225120da28dbf53b86ae59ae156af3745bb326f44ce309dda97345708c8d3dd45755a6000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d54000080000000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "bc1pmg5dhafms6h9nts4dtehgkanym6yeccfmk5hx3ts3jxnm4zh2knqv80ha5"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "bc1p mg5d hafm s6h9 nts4 dteh gkan ym6y eccf mk5h x3ts 3jxn m4zh 2knq v80h a5"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "silent-payment-owned-output",
+      "description": "Covers version-specific handling of silent-payment metadata attached to an output owned by this device, rejected since v9.26.3.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001a49f3e93836b9131d84d700f422b07ff6f6ffa379499b910c0f153e18f3dac3c0000000000ffffffff02801d2c0400000000225120aaf8631d8fffabc65d283faa12aedc768bdc669c1ba6ff1166f356f13eefe089002d310100000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a29430000000001012b00e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a29432116cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff0952719004c00739d5600008000000080000000800000000000000000011720cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff095270001052067426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee5210767426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee519004c00739d560000800000008000000080010000000000000000220202c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d540000800000008000000080000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "silent_payment_address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            }
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.22.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "This BitBox02: sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.22.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "This BitBox (same account): sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "max_version_exclusive": "9.26.3",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "This BitBox (same account): sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.3",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff09527",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "op-return-nonascii",
+      "description": "Displays a non-ASCII OP_RETURN payload as hexadecimal and signs the transaction.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff030000000000000000076a050102030405801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN\ndata (hex)",
+              "body": "0102030405",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN\ndata (hex)",
+              "body": "0102030405",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "op-return-nonzero-value",
+      "description": "Rejects a nonzero-value OP_RETURN output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100930200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff0364000000000000000d6a0b68656c6c6f20776f726c64801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "op-return-silent-payment",
+      "description": "Rejects silent-payment metadata on an OP_RETURN output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100930200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff0300000000000000000d6a0b68656c6c6f20776f726c64801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "0": {
+              "silent_payment_address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            }
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "op-return-payment-request",
+      "description": "Rejects payment-request metadata on an OP_RETURN output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100930200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff0300000000000000000d6a0b68656c6c6f20776f726c64801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "0": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 1,
+              "memos": [
+                {
+                  "type": "text",
+                  "note": "TextMemo line1\nTextMemo line2"
+                }
+              ],
+              "signature": "93582744d5fab8b70cd2f1686bb7baf76e2797f095a83a6029f04c8c92d11bca4f274a71ef0ac79ce65b87241feb770823a1525d64f85e69104081d6ad397601"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "multisig-not-registered",
+      "description": "Rejects a valid 1-of-2 P2WSH multisig transaction when its account has not been registered.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff010089020000000131816c7584e8fb28ce853874eeb709394562c6e99eb9b6f3987d205dcc6933880000000000ffffffff02801d2c040000000022002049934b3c5c97bbd8e9e77ca525ddbad2addcf929f5dd3b83d2c017ab65e54382002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020276686da70f18aec8090484fc1a58b0808b2f6c7aa9f88191ec47166bd805c9e0000000001012b00e1f50500000000220020276686da70f18aec8090484fc1a58b0808b2f6c7aa9f88191ec47166bd805c9e0105475121031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad21039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde52ae2206031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad1c0dbd0cc33000008001000080000000800200008000000000000000002206039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde1c4c00739d30000080010000800000008002000080000000000000000000010147512102e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b21031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb52ae220202e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b1c0dbd0cc33000008001000080000000800200008001000000000000002202031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb1c4c00739d3000008001000080000000800200008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 1,
+              "xpubs": [
+                "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+                "tpubDFX8u4cajvyZrQGikAfBcRt5EqVj4C9xB1HEQSZfN5weSUq4ULeMra6GXY8fM6hwgBX3WZ8TCP7nvMQu3hM4zvUHqWPhU9oq8HNV4ixboTz"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh"
+            },
+            "keypath": "m/48'/1'/0'/2'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "multisig-p2wsh-p2sh",
+      "description": "Signs and finalizes a registered 1-of-2 nested P2SH-P2WSH multisig transaction.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007e02000000017a26adfe8f25b544220236a6516252b9eb746a620ffd210679634285fc890dd50000000000ffffffff02801d2c040000000017a914c88f04120fca1cbbd8e1a9dac997a5d99d8ca09d87002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005302000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f5050000000017a9143b3a20e6b4121c867e5a8e1bf1c3c85504b1ff13870000000001012000e1f5050000000017a9143b3a20e6b4121c867e5a8e1bf1c3c85504b1ff13870104220020cd9833d9c1ca210e8e5984f8fffa56f40770409811f431ea1c6daa0cd7cfba7f010547512102efb2f859bf983f02f6c17664426a9992985b3bdac83184b0162993d398f8ba0d2103f506dd0e67b1d3f035a6055961a3ac5510dff004069e9d025930338fd8e20c8852ae220602efb2f859bf983f02f6c17664426a9992985b3bdac83184b0162993d398f8ba0d1c0dbd0cc3300000800100008000000080010000800000000000000000220603f506dd0e67b1d3f035a6055961a3ac5510dff004069e9d025930338fd8e20c881c4c00739d3000008001000080000000800100008000000000000000000001002200209a8754cc38326f8daa604b0d1f4d803f6bd714cf428490ed6cb5407b05ea91cd01014751210235294f21973f87de509b16ef8f71bf9c353c0d450db814a428709f80a2a347f32103fd271ddb4968f17ea1aab754c4283c05e58ee5810868e845ad7d2b06ef30a87452ae22020235294f21973f87de509b16ef8f71bf9c353c0d450db814a428709f80a2a347f31c0dbd0cc3300000800100008000000080010000800100000000000000220203fd271ddb4968f17ea1aab754c4283c05e58ee5810868e845ad7d2b06ef30a8741c4c00739d3000008001000080000000800100008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 1,
+              "xpubs": [
+                "xpub6EhivkawbkKDNQtJHZFjbd79dLGtC1yTcWn7WHPaCdpa8jXS8mU4y9tdYqzhrUVt3w6QR6vjx66nbUX4s2Hw5V5oer76XzKpRVMExC7zpLG",
+                "tpubDFX8u4cajvyZqUGS5AVgPb7GUpAJJ5nbkVMnw1m2ajrHaZmknbxuWDac2P2zyiB35UcgqwmVAeVzGEVV9qbji6tzYRCTiWwPGvtUULR4DLM"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh_p2sh"
+            },
+            "keypath": "m/48'/1'/0'/1'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test sh-wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test sh-wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test sh-wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "multisig",
+            "threshold": 1,
+            "xpubs": [
+              "xpub6EhivkawbkKDNQtJHZFjbd79dLGtC1yTcWn7WHPaCdpa8jXS8mU4y9tdYqzhrUVt3w6QR6vjx66nbUX4s2Hw5V5oer76XzKpRVMExC7zpLG",
+              "tpubDFX8u4cajvyZqUGS5AVgPb7GUpAJJ5nbkVMnw1m2ajrHaZmknbxuWDac2P2zyiB35UcgqwmVAeVzGEVV9qbji6tzYRCTiWwPGvtUULR4DLM"
+            ],
+            "our_xpub_index": 0,
+            "script_type": "p2wsh_p2sh"
+          },
+          "keypath": "m/48'/1'/0'/1'",
+          "name": "test sh-wsh multisig"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03f506dd0e67b1d3f035a6055961a3ac5510dff004069e9d025930338fd8e20c88",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multisig-large",
+      "description": "Adds the seventh signature to a registered 7-of-15 P2WSH multisig transaction whose PSBT already contains six cosigner signatures.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001cb44be13195cb0246f334d02fc36179e5c8d03e5bb812f97b039c5920413280f0000000000ffffffff02801d2c0400000000220020472cd252fa25c59c9e7f876cca3cbf4585826ff6f66b5e465feddc94cf50a5cc002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f505000000002200208d69e9431a924d7a5cd26f9cf85b2a3bc9d91dc06266f4a24b2ea13fdd1da1780000000001012b00e1f505000000002200208d69e9431a924d7a5cd26f9cf85b2a3bc9d91dc06266f4a24b2ea13fdd1da17822020266dc638844899b98e0d23a40deb72ec14b4842fbd3e70f65f1a955b6cf9f5e50483045022100bf0316ed68454f814fe83efb4ae013339d044b003336a1c68ed80bf9123d9fb2022045ba0d2a90aadfd3b062036e03ba1f6cf8c2aa2bd5d4c5bf1728d4648b5cd87801220202fdb3657418ffef1ed8f513b9e4d9a886ce9798a6b766e5da018417f981395feb483045022100aa4344593f229829440738816c3ed451191898a1761f1e1157a008e7ba5bfb68022030f17cd5f5006baded37e56ecb2480fd3a05b44aa88fe2f870b4974326a04d52012202031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad483045022100a62043f3af8c106c3ef3d0aad0f7c36940627fa06792e19b178e5cd39c4fe9850220793fa3990ed0fa526018e835aed5cab8206827ddbea30a86cf2421c9cc3fb686012202039446d050672e4829214199332a974a5ec1ec80ab0cd4dfc395e2e37a79af87f0473044022002958b416ce5a3c9722cdd07c45addbc679ec34d63bd138207583b258031300c02204d36fd84522cd7831fc06dbd5e611e7bccfc23098a752808a5a252ba05060070012202039b319f5be7dcd91450775a73dc9f163c20ad6eb08e611f220342d53fb0d70e204730440220630b0e820c0e2e7940929a3190b374a649c2e0f0aa78077806551aad57d20b7c02202a2448562899d865f43805441331533721827925b386841818df7b5e406989e101220203ca2121456edf5d624b9bed7d7f507e40b088b313d5773f19df45e71b96278421483045022100dc2b897a4ae2ae446fb7fe7f94836f1136c7ad3c5deb4cb4ccd1eccd224c3f7a02205e4506f6edd9981ba7bb7578454b4c4250de3070db29b74c20c21f5d88e599b2010105fd01025721020faf2667c643963b00041bea043d6fd2e91f3db842b8ccfddefd0f5615bfe9b4210266dc638844899b98e0d23a40deb72ec14b4842fbd3e70f65f1a955b6cf9f5e502102bcdd4e3e30bdb4219ef1836d0f573b81574639b189225039deaefb5bd75153152102e73cddb837ae9bcb40d3f6cf72e133d77505daf9fe03a5c359822a45332391a82102eb12fd1be52ba727e325bd880e8b0ac28769c3850301f3c333c98c0d420b65ec2102fdb3657418ffef1ed8f513b9e4d9a886ce9798a6b766e5da018417f981395feb21031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad2103440396891d7d6c9f623635e4c1a4f66edca6dca79c11debe0dc58a0f10f9079421034a0ad5543e4978b96f5a06959b281298e4079fe2fd71efaa0604a93fa9305891210353983ae233c60e81243818ffa3ce635d65d666238c1e7503e31e9f2186cc714521039446d050672e4829214199332a974a5ec1ec80ab0cd4dfc395e2e37a79af87f021039b319f5be7dcd91450775a73dc9f163c20ad6eb08e611f220342d53fb0d70e2021039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde2103bbc0345e402e1f8838e0ea1669fc79f452cfcc7136a3ff91f621833fbc154f6a2103ca2121456edf5d624b9bed7d7f507e40b088b313d5773f19df45e71b962784215fae2206020faf2667c643963b00041bea043d6fd2e91f3db842b8ccfddefd0f5615bfe9b41ce9324a6c30000080010000800000008002000080000000000000000022060266dc638844899b98e0d23a40deb72ec14b4842fbd3e70f65f1a955b6cf9f5e501c73bccd56300000800100008000000080020000800000000000000000220602bcdd4e3e30bdb4219ef1836d0f573b81574639b189225039deaefb5bd75153151cd0bee5ae300000800100008000000080020000800000000000000000220602e73cddb837ae9bcb40d3f6cf72e133d77505daf9fe03a5c359822a45332391a81cc8c72c6c300000800100008000000080020000800000000000000000220602eb12fd1be52ba727e325bd880e8b0ac28769c3850301f3c333c98c0d420b65ec1c0bbe8456300000800100008000000080020000800000000000000000220602fdb3657418ffef1ed8f513b9e4d9a886ce9798a6b766e5da018417f981395feb1cac9a9e9e3000008001000080000000800200008000000000000000002206031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad1c0dbd0cc3300000800100008000000080020000800000000000000000220603440396891d7d6c9f623635e4c1a4f66edca6dca79c11debe0dc58a0f10f907941c0ed45ef03000008001000080000000800200008000000000000000002206034a0ad5543e4978b96f5a06959b281298e4079fe2fd71efaa0604a93fa93058911c9e1cb09d30000080010000800000008002000080000000000000000022060353983ae233c60e81243818ffa3ce635d65d666238c1e7503e31e9f2186cc71451c7fb8ad413000008001000080000000800200008000000000000000002206039446d050672e4829214199332a974a5ec1ec80ab0cd4dfc395e2e37a79af87f01c054f2f713000008001000080000000800200008000000000000000002206039b319f5be7dcd91450775a73dc9f163c20ad6eb08e611f220342d53fb0d70e201c41559f4f3000008001000080000000800200008000000000000000002206039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde1c4c00739d300000800100008000000080020000800000000000000000220603bbc0345e402e1f8838e0ea1669fc79f452cfcc7136a3ff91f621833fbc154f6a1c5d3e97e0300000800100008000000080020000800000000000000000220603ca2121456edf5d624b9bed7d7f507e40b088b313d5773f19df45e71b962784211c1a34b3e5300000800100008000000080020000800000000000000000000101fd01025721021f7e9e9befaa3424398f347b5b2f78d5f893498f6f8ec488dd2f9f22ea18c7bc21029c20cd5acd30db6bf7aeaf7f83cc171adc87cba7498bd7e673304db6e0a86b5b2102b29e8ea9305c52a928175756d9c979db1768ce8643badface43e1c4661aa1fec2102d63ffb041633c0c721c9dd16fabdcd0a413a5d20786fd798e9ea5458a9d0145f2102e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b21031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb21031fd8d9ae7b5cdd43427ff940ee8b485d7b0e79e2cbb53c111f736db8309dd6cb2103206d7162cc432f2b79039f839a8eb4b9155b407b9178ebf46fc29de2c23965e421034434b5c28fe2b71f01328b3af87647d7729a9ad1d1d1646d3f0b87cd0dfd06b6210347504a67f3b4bfdef20beaa5790304ce34927e740929f2caddc032ae8d653a7921035c3445de6a048ab9e905c86bc6d481890088fa7d51309a439bfeb4af77fc7650210365a176ac65d10de83778956b560630f341a6f6b43584acc0271083cff36ace35210376b63bd235b30bc9042c7b500be79e7fbebbc4f6e723c8b798aea84769acb1ea21037d33decd1fee9418357a1e419813a898f7aa006b9a59ca241fb46ad29b774fcb2103c69f4d4950ed98135ff37e631731881dd01060db8dae4ccda2f8c0a796f5c4e85fae2202021f7e9e9befaa3424398f347b5b2f78d5f893498f6f8ec488dd2f9f22ea18c7bc1c0bbe84563000008001000080000000800200008001000000000000002202029c20cd5acd30db6bf7aeaf7f83cc171adc87cba7498bd7e673304db6e0a86b5b1c0ed45ef0300000800100008000000080020000800100000000000000220202b29e8ea9305c52a928175756d9c979db1768ce8643badface43e1c4661aa1fec1c1a34b3e5300000800100008000000080020000800100000000000000220202d63ffb041633c0c721c9dd16fabdcd0a413a5d20786fd798e9ea5458a9d0145f1c41559f4f300000800100008000000080020000800100000000000000220202e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b1c0dbd0cc33000008001000080000000800200008001000000000000002202031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb1c4c00739d3000008001000080000000800200008001000000000000002202031fd8d9ae7b5cdd43427ff940ee8b485d7b0e79e2cbb53c111f736db8309dd6cb1c73bccd56300000800100008000000080020000800100000000000000220203206d7162cc432f2b79039f839a8eb4b9155b407b9178ebf46fc29de2c23965e41c9e1cb09d3000008001000080000000800200008001000000000000002202034434b5c28fe2b71f01328b3af87647d7729a9ad1d1d1646d3f0b87cd0dfd06b61cac9a9e9e30000080010000800000008002000080010000000000000022020347504a67f3b4bfdef20beaa5790304ce34927e740929f2caddc032ae8d653a791cc8c72c6c3000008001000080000000800200008001000000000000002202035c3445de6a048ab9e905c86bc6d481890088fa7d51309a439bfeb4af77fc76501c7fb8ad4130000080010000800000008002000080010000000000000022020365a176ac65d10de83778956b560630f341a6f6b43584acc0271083cff36ace351c054f2f7130000080010000800000008002000080010000000000000022020376b63bd235b30bc9042c7b500be79e7fbebbc4f6e723c8b798aea84769acb1ea1c5d3e97e03000008001000080000000800200008001000000000000002202037d33decd1fee9418357a1e419813a898f7aa006b9a59ca241fb46ad29b774fcb1ce9324a6c300000800100008000000080020000800100000000000000220203c69f4d4950ed98135ff37e631731881dd01060db8dae4ccda2f8c0a796f5c4e81cd0bee5ae3000008001000080000000800200008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 7,
+              "xpubs": [
+                "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+                "tpubDFX8u4cajvyZrQGikAfBcRt5EqVj4C9xB1HEQSZfN5weSUq4ULeMra6GXY8fM6hwgBX3WZ8TCP7nvMQu3hM4zvUHqWPhU9oq8HNV4ixboTz",
+                "tpubDFCqK5T7J3FUasUXA1xsminXkeaPSxe1id2K4KCEaszuTNKERymaiZHTnUcjGDf4b57XinAHauwSh1uDRmNVMtfhiStJWsf83MZLA1tC5qi",
+                "tpubDEKEr89i7dBFXrrpkK2KZQy9aMw6Dg8idr1ysbZJ94mWk6uaFAy4DmYMw7LMDSEaeSJdAcgshdLATcbr6T9hQoouRphfHC9aBQqiWAh8wRF",
+                "tpubDERfkonU8krEq7knZXFPFrS5bnbhsyXhV7wdM9agZuzD6YgM95LgBWKzAkPeZMseTWRj2PPcbw2kEjcrBctJEzLNUu2VLz1Fixehoc5z4aq",
+                "tpubDECMwLTAdWk5RcgKaaLKaP83R586xMFtBhH5osdzdF6VbEwFpQp3uiiaHrKGPnqmfDUKFtSQE5ForxoBYgJWEHA5B2T9i5GP5ZAuScWKXgH",
+                "tpubDEuxzYbnkbY2XHQZjzcDV2Vk4DH4oZwLefGso1jXfFsTyhVV5HxZvVUrSdGLc9AVBTNcCDZh5qw7RgPiibMfMVWtHpjzoErqJcvukzFSpbf",
+                "tpubDEccsjksu3ddEUnx5FkNADMy9YkLi3p6vQGpdgFDSypMfYZs7amRL94ucqyHGZrVDMrBc937ptj4SKihNiYJtnRgiZ742hpxfnAgynaQno5",
+                "tpubDF1U1F2s28Rv71bukRRTLUN3hiTgKDGjxGVrFAYXYo1qaWFNsUnA4MoyFtKoytQyLHfmE267HDo3VDgDUfk2hQwb3ary3aNojzkT1sTe5oi",
+                "tpubDF8LvKCNR3JMayQDTRRqBD3PLhVng5wk6bYvCpsrhe5Mffon2sSFrLBz9J3WCdLqsoeUjMiG1gqsiiM8RVNw6eSfqbRyFsSt2sZPd54GoVi",
+                "tpubDEgfQ9SqcnKyEkVmEEkx9AaQ3pZN1nSZQjZxtCcTVytAk62DggB6FiuH12cFeygFLgDPsYtBYDp8FCQDrdgZLrpp2cFhnsFur55kWid1DYg",
+                "tpubDEHvZYZJ5N3jGxHTJJ1LSWdoD3SUSSz7zUhUPLrTMC7SoEkthZVzfFz8qSYAYF1Rg6LjKTsBZMeNJivd4iDyjbQQ6JcyZe2eHB3WENiQECP",
+                "tpubDEjJyDs2yboyzkczJ5ADEmU9yJNqCgmpUPBqW5CVSPCxg8Q59ZwDqRCBwUrDmR29iY8BJGfBa5bq9MBhYpnqjaQvNQdFHqGX99W6ocPX63z",
+                "tpubDFFcidKjrkaTSz4R4s9Y5ijp3dzHkJ9XZ2JkLanjkUskBBbFvjxfQMeU5L52ANJtgpiMRyjK4WzJ6qkK22KQsScHbiQBEsstjVKLoxZynZm",
+                "tpubDF3ds3VKs6p4YjvSLY848WwW21fxiaYGdn5cZEUZ5CwKwMveavxSNA3GhJHqZkFkXa5DTeT1ZKjThtFY8KDfNAuvF95SDcXEoGXNq5bs9nT"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh"
+            },
+            "keypath": "m/48'/1'/0'/2'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "7-of-15\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test large multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "7-of-15\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test large multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "7-of-15\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test large multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "multisig",
+            "threshold": 7,
+            "xpubs": [
+              "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+              "tpubDFX8u4cajvyZrQGikAfBcRt5EqVj4C9xB1HEQSZfN5weSUq4ULeMra6GXY8fM6hwgBX3WZ8TCP7nvMQu3hM4zvUHqWPhU9oq8HNV4ixboTz",
+              "tpubDFCqK5T7J3FUasUXA1xsminXkeaPSxe1id2K4KCEaszuTNKERymaiZHTnUcjGDf4b57XinAHauwSh1uDRmNVMtfhiStJWsf83MZLA1tC5qi",
+              "tpubDEKEr89i7dBFXrrpkK2KZQy9aMw6Dg8idr1ysbZJ94mWk6uaFAy4DmYMw7LMDSEaeSJdAcgshdLATcbr6T9hQoouRphfHC9aBQqiWAh8wRF",
+              "tpubDERfkonU8krEq7knZXFPFrS5bnbhsyXhV7wdM9agZuzD6YgM95LgBWKzAkPeZMseTWRj2PPcbw2kEjcrBctJEzLNUu2VLz1Fixehoc5z4aq",
+              "tpubDECMwLTAdWk5RcgKaaLKaP83R586xMFtBhH5osdzdF6VbEwFpQp3uiiaHrKGPnqmfDUKFtSQE5ForxoBYgJWEHA5B2T9i5GP5ZAuScWKXgH",
+              "tpubDEuxzYbnkbY2XHQZjzcDV2Vk4DH4oZwLefGso1jXfFsTyhVV5HxZvVUrSdGLc9AVBTNcCDZh5qw7RgPiibMfMVWtHpjzoErqJcvukzFSpbf",
+              "tpubDEccsjksu3ddEUnx5FkNADMy9YkLi3p6vQGpdgFDSypMfYZs7amRL94ucqyHGZrVDMrBc937ptj4SKihNiYJtnRgiZ742hpxfnAgynaQno5",
+              "tpubDF1U1F2s28Rv71bukRRTLUN3hiTgKDGjxGVrFAYXYo1qaWFNsUnA4MoyFtKoytQyLHfmE267HDo3VDgDUfk2hQwb3ary3aNojzkT1sTe5oi",
+              "tpubDF8LvKCNR3JMayQDTRRqBD3PLhVng5wk6bYvCpsrhe5Mffon2sSFrLBz9J3WCdLqsoeUjMiG1gqsiiM8RVNw6eSfqbRyFsSt2sZPd54GoVi",
+              "tpubDEgfQ9SqcnKyEkVmEEkx9AaQ3pZN1nSZQjZxtCcTVytAk62DggB6FiuH12cFeygFLgDPsYtBYDp8FCQDrdgZLrpp2cFhnsFur55kWid1DYg",
+              "tpubDEHvZYZJ5N3jGxHTJJ1LSWdoD3SUSSz7zUhUPLrTMC7SoEkthZVzfFz8qSYAYF1Rg6LjKTsBZMeNJivd4iDyjbQQ6JcyZe2eHB3WENiQECP",
+              "tpubDEjJyDs2yboyzkczJ5ADEmU9yJNqCgmpUPBqW5CVSPCxg8Q59ZwDqRCBwUrDmR29iY8BJGfBa5bq9MBhYpnqjaQvNQdFHqGX99W6ocPX63z",
+              "tpubDFFcidKjrkaTSz4R4s9Y5ijp3dzHkJ9XZ2JkLanjkUskBBbFvjxfQMeU5L52ANJtgpiMRyjK4WzJ6qkK22KQsScHbiQBEsstjVKLoxZynZm",
+              "tpubDF3ds3VKs6p4YjvSLY848WwW21fxiaYGdn5cZEUZ5CwKwMveavxSNA3GhJHqZkFkXa5DTeT1ZKjThtFY8KDfNAuvF95SDcXEoGXNq5bs9nT"
+            ],
+            "our_xpub_index": 0,
+            "script_type": "p2wsh"
+          },
+          "keypath": "m/48'/1'/0'/2'",
+          "name": "test large multisig"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-keyspend-with-script-tree",
+      "description": "Signs a Taproot policy key path whose tweak commits to a script tree.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001481b25e956e13b122e0155ee1066ff2620345d94c51e6c2b7889e0daac298db00000000000ffffffff02801d2c0400000000225120916ffdd6fe3d0adf420c6d71702a944b8f22db3277d4b24721f2f1deb96e8a46002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120d06244555fe882d1190e968e20f053018fe20114014338e89149d314ef4352d92215c13a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2232034c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de2acc0211634c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de23d01d9c7b0c5dc86c4594427111e20854229a2bded47788886c3b3e5093c5d9d9f56c5e4fe1a30000080010000800000008003000080000000000000000021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21d004c00739d3000008001000080000000800300008000000000000000000117203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2011820d9c7b0c5dc86c4594427111e20854229a2bded47788886c3b3e5093c5d9d9f56000105208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a01062500c022203df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563bac21073df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563b3d016a4a33d1169c5d57685ea4668790c7ce35fc9af5f8002aea692c3296287f548fc5e4fe1a30000080010000800000008003000080010000000000000021078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1d004c00739d3000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/**,pk(@1/**))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr tweaked keyspend",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/**,pk(@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr tweaked keyspend",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/**,pk(@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/**,pk(@1/**))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test tr tweaked keyspend"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-unspendable-internal-key",
+      "description": "Signs a Taproot script path with a provably unspendable internal key and displays that property in the policy review.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001a8346bd79715029f26a2628a872d2299934cfc774bb3c4e52209ef404f07278f0000000000ffffffff02801d2c0400000000225120f191a4cb0a3d8f8b47251bc375159b8ff3aac672264cb0e0c9c5adeba37a09e4002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120c5340ec5fb5662a6ef7290f9dffedf9c727d503c2f69377cb4c8560e9f02e45b4114bc0eab168b76abf60a0a6f3c197ea0f9b7973e27ca1aba50daa09c62de813c68e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c08558405d9d7da26d848dd9562ab95b348ac6414e1bc28a2f8ccd839b7dd5b452abc513d099a0f0efcd011fdcc9b5f18b3c69cb9122391b751e274a67dc74b61757ab5d2215c01ab64872242fff67a9cc2429d50bd615532e55122665e448ae0e53a3f4a2ce594720bc0eab168b76abf60a0a6f3c197ea0f9b7973e27ca1aba50daa09c62de813c68ac203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2ba529cc021161ab64872242fff67a9cc2429d50bd615532e55122665e448ae0e53a3f4a2ce590d007c461e5d000000000000000021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b23d01e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c085584c00739d3000008001000080000000800300008000000000000000002116bc0eab168b76abf60a0a6f3c197ea0f9b7973e27ca1aba50daa09c62de813c683d01e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c0855808f56e293000008001000080000000800300008000000000000000000117201ab64872242fff67a9cc2429d50bd615532e55122665e448ae0e53a3f4a2ce59011820e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c0855800010520349092f96b1dd44a23e6a05986e7934bae5d6a87b9a050c1e13b38a0ae4e52c101064900c04620dbe4edc0edbcb5f212c9fa1d1bcbdb4b3f6e875a5ea52ac3cafed4057379302bac208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aba529c2107349092f96b1dd44a23e6a05986e7934bae5d6a87b9a050c1e13b38a0ae4e52c10d007c461e5d010000000000000021078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a3d014b40a0f212ea2f428474b933288cec2f2a50121ba995173e8d601dbb1b2d9a784c00739d3000008001000080000000800300008001000000000000002107dbe4edc0edbcb5f212c9fa1d1bcbdb4b3f6e875a5ea52ac3cafed4057379302b3d014b40a0f212ea2f428474b933288cec2f2a50121ba995173e8d601dbb1b2d9a7808f56e293000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+              "keys": [
+                {
+                  "xpub": "tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8"
+                },
+                {
+                  "xpub": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi"
+                },
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test unspendable policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test unspendable policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+            "keys": [
+              {
+                "xpub": "tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8"
+              },
+              {
+                "xpub": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi"
+              },
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test unspendable policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_script",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "leaf_hash": "e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c08558",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-unspendable-internal-key-complex",
+      "description": "Signs the satisfiable branch of a multi-leaf Taproot policy with a provably unspendable internal key, distinct multipaths and a relative-timelock sibling branch.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000017079ce1d2dffec9e935d2a74cd4a702f722e651939daeb27faf3953f14fa5c3a0000000000ffffffff02801d2c04000000002251203ad5b7757d2dc6cd5e5ec17a0603352d401de5d69fc48f9c6ec1a3ac2b8e194f002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120eaef7e275cce42763c22a441d0e5b254c794d51e8123f5562441346dac40848c4114eeab1c2d28079589eb9e55bbd86765ffce87514a1feca661ee3d88f0e04643c9b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a404eb58edfa3eec62bf0fccefc4e73dafb7e74009a81e22a24ea6f1dae95e558273eb0f851610819384de73f327e2ffe0d3751a8b785f9db8648d2bb074559eaef4215c159165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed3309e075b5976239a09b6b08d128ec95a42f328a625c26213f9568d7768d853f4974720eeab1c2d28079589eb9e55bbd86765ffce87514a1feca661ee3d88f0e04643c9ac203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2ba529cc04215c159165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed330b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a4920ca89423a6e0a0673b51bfd05212d8963c14a8db6cd3d7cba5dabaff97d4e3ed8ac201d7d773d42ed516b73555c715929badf8ddb135b25779b475157a49ed946af79ba519d52b2c021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b23d01b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a4c00739d300000800100008000000080030000800000000000000000211659165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed3300d007c461e5d00000000000000002116eeab1c2d28079589eb9e55bbd86765ffce87514a1feca661ee3d88f0e04643c93d01b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a4040280c30000080010000800000008002000080000000000000000001172059165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed3300118207754188d95aa29ae86dcf87406dfb5ed0e1d6da02a9ad5104b95f5f81abf79a4000105209ba26f33424bc7330bf3f683129516387fdc20f5baf09046ea9eaa2ed71516d401069401c0482006048aec624d548af178a98ec862e0efaa5c2fcf8fb07f5146f410918eb21eefac20c621b132507c49d0f974e71d89e3017fe4f4ca8aa7c73c291d7a4edd1a6399a6ba519d52b201c04620ddad6824617b6a1bd330aab5c263f039b7ebe04196792fe90d203752e9c37809ac208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aba529c21078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a3d01d3064571589c8c4e858bc4dd2efe190b4e2d9d3da7d96306eb9702e5401d2f264c00739d30000080010000800000008003000080010000000000000021079ba26f33424bc7330bf3f683129516387fdc20f5baf09046ea9eaa2ed71516d40d007c461e5d01000000000000002107ddad6824617b6a1bd330aab5c263f039b7ebe04196792fe90d203752e9c378093d01d3064571589c8c4e858bc4dd2efe190b4e2d9d3da7d96306eb9702e5401d2f264040280c3000008001000080000000800200008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+              "keys": [
+                {
+                  "xpub": "tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm"
+                },
+                {
+                  "root_fingerprint": "4040280c",
+                  "keypath": "m/48'/1'/0'/2'",
+                  "xpub": "tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR"
+                },
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test complex unspendable",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "[4040280c/48'/1'/0'/2']tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test complex unspendable",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "[4040280c/48'/1'/0'/2']tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+            "keys": [
+              {
+                "xpub": "tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm"
+              },
+              {
+                "root_fingerprint": "4040280c",
+                "keypath": "m/48'/1'/0'/2'",
+                "xpub": "tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR"
+              },
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test complex unspendable"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_script",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "leaf_hash": "b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-different-multipath-derivations",
+      "description": "Signs and finalizes a registered WSH policy whose two keys use different receive and change branches.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff010089020000000149aa85e2c639e52c4984cba528c60ef347f47f35917519ecba279514841928470000000000ffffffff02801d2c0400000000220020d0a6b11cf5a05594e6fad40948646011c6307c84906d318f348f5effaaa97b02002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020e267e95e105bd40e8fbf3bdda795da8bc943949f4accec407d45b469f514b4830000000001012b00e1f50500000000220020e267e95e105bd40e8fbf3bdda795da8bc943949f4accec407d45b469f514b483220203e7d88a65b1ca31ccc898193ab72acdce9b0c0076a9ba8f4ef06bd0ccd4d01d034730440220182d262d790be3d24e15dd8e74057bacf77f678ef0e82bdecce4386ab3252a7c02205651ad4a74158357b08c05bd88dec8c2522bb91013332f963374b45722c842a401010547522102b95c8bf277d3e7d7de1ad4fbb4921c5bd1cefeb3ebf38987bdd4688b9cfcbb722103e7d88a65b1ca31ccc898193ab72acdce9b0c0076a9ba8f4ef06bd0ccd4d01d0352ae220602b95c8bf277d3e7d7de1ad4fbb4921c5bd1cefeb3ebf38987bdd4688b9cfcbb721c4c00739d300000800100008000000080030000800a00000000000000220603e7d88a65b1ca31ccc898193ab72acdce9b0c0076a9ba8f4ef06bd0ccd4d01d031cc5e4fe1a300000800100008000000080030000801400000000000000000101475221034c130edc7e1574821af949c79d64052475e85f7f659cbbbd4b99c79bdf840dc92102627713c28bf52eb7012ac66a69b333fca5f9c8794fb5751ceb0cb50484546b3952ae220202627713c28bf52eb7012ac66a69b333fca5f9c8794fb5751ceb0cb50484546b391cc5e4fe1a3000008001000080000000800300008015000000000000002202034c130edc7e1574821af949c79d64052475e85f7f659cbbbd4b99c79bdf840dc91c4c00739d300000800100008000000080030000800b000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test multipath policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test multipath policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test multipath policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test multipath policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02b95c8bf277d3e7d7de1ad4fbb4921c5bd1cefeb3ebf38987bdd4688b9cfcbb72",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-wrong-account-keypath",
+      "description": "Rejects a registered policy when the signing account keypath does not match the device key in the policy.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000011b6e58cffa2f032e498aa516a97410d53fc282bee867fb9653192aa223bd02de0000000000ffffffff02801d2c040000000022002032001963e09213e7387b90c3374944bdbbaf69f554060bb040626f0b428f1850002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0000000001012b00e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0105475221033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2210234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de252ae22060234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de21cc5e4fe1a3000008001000080000000800300008000000000000000002206033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21c4c00739d300000800100008000000080030000800000000000000000000101475221028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a21023df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563b52ae2202023df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563b1cc5e4fe1a3000008001000080000000800300008001000000000000002202028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1c4c00739d3000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(multi(2,@0/**,@1/**))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/4'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test policy account",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/**,@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(multi(2,@0/**,@1/**))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test policy account"
+        }
+      ]
+    },
+    {
+      "id": "policy-change-index-too-high",
+      "description": "Rejects a registered policy change output at address index 10000.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000011b6e58cffa2f032e498aa516a97410d53fc282bee867fb9653192aa223bd02de0000000000ffffffff02801d2c0400000000220020bd6a0b3bc28769ca2a7ef1aa12f7c052beb977fd61a1c55a9e5a3d6cecce0cbb002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0000000001012b00e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0105475221033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2210234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de252ae22060234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de21cc5e4fe1a3000008001000080000000800300008000000000000000002206033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21c4c00739d3000008001000080000000800300008000000000000000000001014752210252631b8aca4b08e95acacae7daf3bfdad38a8651821a1009008fdd04a90d17bc210275db5c17fe98b071caf5e724752d268263106509e2bc2d3fa468168702329e9452ae22020252631b8aca4b08e95acacae7daf3bfdad38a8651821a1009008fdd04a90d17bc1c4c00739d30000080010000800000008003000080010000001027000022020275db5c17fe98b071caf5e724752d268263106509e2bc2d3fa468168702329e941cc5e4fe1a3000008001000080000000800300008001000000102700000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(multi(2,@0/**,@1/**))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test policy account",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/**,@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(multi(2,@0/**,@1/**))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test policy account"
+        }
+      ]
+    }
+  ]
+}

--- a/src/rust/bitbox-test-vectors/testdata/btc-transaction-test-vectors.json
+++ b/src/rust/bitbox-test-vectors/testdata/btc-transaction-test-vectors.json
@@ -1,0 +1,4520 @@
+{
+  "simulator_seed": "boring mistake dish oyster truth pigeon viable emerge sort crash wire portion cannon couple enact box walk height pull today solid off enable tide",
+  "vectors": [
+    {
+      "id": "taproot-key-spend",
+      "description": "Signs two BIP86 Taproot key-spend inputs and recognizes a BIP86 change output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100b20200000002f8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270000000000fffffffff8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270100000000ffffffff0200e1f50500000000225120cc9235442b0f4fdf2f3c39516207c389e08fed3ae6cfa90cdb820d791a9d6ba4002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001012b00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db42221169e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434319004c00739d56000080010000800000008000000000010000000117209e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434300010520c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f7852107c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f78519004c00739d56000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "taproot_key",
+          "pubkey": "9e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a40574343",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "mixed-spend",
+      "description": "Signs P2TR, native P2WPKH and nested P2SH-P2WPKH inputs from one previous transaction and recognizes BIP86 change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100db0200000003e3ba22f94fa7f97d19e4b6c31853ce54c220cf225952b1ba9082ba0c1ba316260000000000ffffffffe3ba22f94fa7f97d19e4b6c31853ce54c220cf225952b1ba9082ba0c1ba316260100000000ffffffffe3ba22f94fa7f97d19e4b6c31853ce54c220cf225952b1ba9082ba0c1ba316260200000000ffffffff0200e1f50500000000225120cc9235442b0f4fdf2f3c39516207c389e08fed3ae6cfa90cdb820d791a9d6ba4002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a2782094400e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc66870000000021166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a2782094400e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc668700000000220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a2782094400e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc668700000000010416001468a00bbd6de555d756e92815e523b789def6c0b022060329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0184c00739d310000800100008000000080000000000000000000010520c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f7852107c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f78519004c00739d56000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 TBTC",
+              "fee": "1.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 TBTC",
+              "fee": "1.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        },
+        {
+          "input_index": 2,
+          "kind": "ecdsa",
+          "pubkey": "0329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "op-return",
+      "description": "Signs a P2WPKH spend with a zero-value OP_RETURN output containing one printable data push and a P2WPKH change output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01006802000000012b769ad9a4c846c82a6005040bbbc22a05ce02e42a6e1787a8ba8e57977bb7080000000000ffffffff0240aeeb02000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e9500000000000000000d6a0b68656c6c6f20776f726c640000000000010052020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0180f0fa0200000000160014bfbb8f964b61fb712f04587acaebea9e103161bc0000000001011f80f0fa0200000000160014bfbb8f964b61fb712f04587acaebea9e103161bc220602e62431dfc2aa92e24d23118f8f078894ee118271ddc13715c5bd33d7d2ffe229184c00739d540000800100008000000080000000000500000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN",
+              "body": "hello world",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.01000000 TBTC",
+              "fee": "0.01000000 TBTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02e62431dfc2aa92e24d23118f8f078894ee118271ddc13715c5bd33d7d2ffe229",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multisig-p2wsh",
+      "description": "Signs the device branch of a registered 1-of-2 sortedmulti P2WSH input, recognizes descriptor-derived change, and finalizes the witness.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001189002448bf29a8299625a5e0bbba99c561bd2ea07c71bb55b72be77e00becd60000000000ffffffff02801d2c04000000002200208dd9dc6a4969db2b4ed0a01a078e16c92328ea56ba3854f7416138132d2e6e48002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002200208b7d9944e24b23ca0e5d02a1233611fbaf2faf95bfc17cd35d68a800309352ec000000000105475121024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed20921039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde52ae2206024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed2090c4707983700000000000000002206039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde1c4c00739d300000800100008000000080020000800000000000000000000101475121031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb2103d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c52ae2202031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb1c4c00739d300000800100008000000080020000800100000000000000220203d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c0c4707983701000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 1,
+              "xpubs": [
+                "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+                "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh"
+            },
+            "keypath": "m/48'/1'/0'/2'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "multisig",
+            "threshold": 1,
+            "xpubs": [
+              "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+              "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+            ],
+            "our_xpub_index": 0,
+            "script_type": "p2wsh"
+          },
+          "keypath": "m/48'/1'/0'/2'",
+          "name": "test wsh multisig"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-wsh",
+      "description": "Signs the device branch of a registered BIP388 WSH or-policy and recognizes descriptor-derived change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff010089020000000117bb7376f1aed39ca76fac738a9eecfb490d3d8e0d9cb47a08b227dd04bb7abc0000000000ffffffff02801d2c0400000000220020593d9bd9f01f27f05e9a8ad4096961eb5f1bcd43a6fed6f2df9020fc82673560002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002200204bff256253c47cfb36eb7d58f4e6b97d484701191075ecde1d3332ecdf8111010000000001054821033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2ac7c21024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed209ac9b2206024f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed2090c4707983700000000000000002206033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21c4c00739d3000008001000080000000800300008000000000000000000001014821028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aac7c2103d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074cac9b2202028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1c4c00739d300000800100008000000080030000800100000000000000220203d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c0c4707983701000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test wsh policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test wsh policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(or_b(pk(@0/<0;1>/*),s:pk(@1/<0;1>/*)))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+              }
+            ]
+          },
+          "name": "test wsh policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-keyspend",
+      "description": "Signs the key-spend path of a registered BIP388 Taproot policy using only a witness UTXO and recognizes descriptor-derived change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001c0470cb5928e1e538404293a10b5c47e8d2482e27834ec4fb855d2c9e708a1480000000000ffffffff02801d2c04000000002251202cf99a9e98b0ee07ccb287502f76b2f856af59b726a746cd1ab303adc6749129002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120eb86719b281a383608399cab552dbd40368c66cd958f38bcb42347830e729ef021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21d004c00739d3000008001000080000000800300008000000000000000000117203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2000105208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a21078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1d004c00739d3000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*)",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n1 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr keyspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*)",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/1",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n1 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr keyspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*)",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/1",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*)",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test tr keyspend policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-scriptspend",
+      "description": "Signs the script path owned by the device in a registered BIP388 Taproot policy whose internal key belongs to another signer.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000014625d1da866927cc28dae6171aabba10fdb6abaee03829bc717fa57c05fc6b1c0000000000ffffffff02801d2c04000000002251206ea53e5447e4771e25f4e3ef3e3c5973e00ed2a4f7680507134a797b7df3c3cc002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120d0692388c73a40274236cad74af812db4d49ecf07b0838e644189693c4a1c87f2215c14f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed20923203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2acc021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b23d01c3aa2951885f3ddabebfba4eb4873dbdb2c41e287562d542cf8782e2a857071b4c00739d30000080010000800000008003000080000000000000000021164f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed2090d004707983700000000000000000117204f9153a64648289b50ba2fdf6a20feaf912d05fb00dbc65d53b0ad1ef84ed209011820c3aa2951885f3ddabebfba4eb4873dbdb2c41e287562d542cf8782e2a857071b00010520d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c01062500c022208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aac21078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a3d01bdda447b6076e3cc5aef2434e05b03e88a74dba86599553f3371fac3e86112b74c00739d3000008001000080000000800300008001000000000000002107d84603fefb986e343dc535bb6c24c47fdb6c4052c2c36b29598f1aecf5a1074c0d004707983701000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+              "keys": [
+                {
+                  "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+                },
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr scriptspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr scriptspend policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*,pk(@1/<0;1>/*))",
+            "keys": [
+              {
+                "xpub": "tpubDFgycCkexSxkdZfeyaasDHityE97kiYM1BeCNoivDHvydGugKtoNobt4vEX6YSHNPy2cqmWQHKjKxciJuocepsGPGxcDZVmiMBnxgA1JKQk"
+              },
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test tr scriptspend policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_script",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "leaf_hash": "c3aa2951885f3ddabebfba4eb4873dbdb2c41e287562d542cf8782e2a857071b",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "taproot-to-non-taproot-change",
+      "description": "Signs all-Taproot inputs with P2WPKH change, requiring previous transactions for the added non-Taproot output config.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100a60200000002f8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270000000000fffffffff8e60a3e44fa93f5d7a7b57dc5983aac5d50f84071772938b4ddff45ce9bf3270100000000ffffffff0200e1f505000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef140000000000010089020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0200e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db4220000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e00010089020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0200e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db4220000000001012b00e1f5050000000022512036c6a3ef943986e3fdfb7d5a750ae013f746966f6fe0971d3bdc7360f29db42221169e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434319004c00739d56000080010000800000008000000000010000000117209e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a4057434300220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1.00000000 TBTC",
+              "fee": "0.80000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 400.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "taproot_key",
+          "pubkey": "9e2a4b40d2c021b903ca48aa305545f56716f5c85e998bdc677d968a40574343",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "silent-payment",
+      "description": "Signs mixed inputs with BIP352 metadata and a device-generated silent-payment output.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100b9020000000314f5c987750e136e84be08a812ad8273b6597dbd76ded0806e714c183644cdc40000000000ffffffff14f5c987750e136e84be08a812ad8273b6597dbd76ded0806e714c183644cdc40100000000ffffffff14f5c987750e136e84be08a812ad8273b6597dbd76ded0806e714c183644cdc40200000000ffffffff0200e1f50500000000225120aaf8631d8fffabc65d283faa12aedc768bdc669c1ba6ff1166f356f13eefe089002d31010000000000000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a294300e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b00e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870000000001012b00e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a29432116cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff0952719004c00739d5600008000000080000000800000000000000000011720cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff095270001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a294300e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b00e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d54000080000000800000008000000000000000000001009d020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0300e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a294300e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b00e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870000000001012000e1f5050000000017a914ee9a3e5e0bedc5ec5c7e2461c62b5f0b5109c4f9870104160014d14ce318a324bc9eb4ff285d94ee02a297c0496f220603d47c62767f5463ffc008b9250fa6bb7eac11f2aff84804cf19d80ea46922bd73184c00739d31000080000000800000008000000000000000000001052067426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee5210767426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee519004c00739d56000080000000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "silent_payment_address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            }
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 BTC",
+              "fee": "1.80000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "2.00000000 BTC",
+              "fee": "1.80000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 900.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff09527",
+          "sighash": "default"
+        },
+        {
+          "input_index": 1,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        },
+        {
+          "input_index": 2,
+          "kind": "ecdsa",
+          "pubkey": "03d47c62767f5463ffc008b9250fa6bb7eac11f2aff84804cf19d80ea46922bd73",
+          "sighash": "all"
+        }
+      ],
+      "expected_generated_outputs": {
+        "1": "5120d826829cb603fc008e5ef99d0818f2126d3569c3ab8a6cd069f07a20e892bd59"
+      }
+    },
+    {
+      "id": "send-self-same-account",
+      "description": "Covers ownership detection for the input account, suppression of change confirmation and version-specific account labels.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100720200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff0280f0fa020000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d310100000000160014fc6b321f780a2401be6884e5bf84520a27820944000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d310000800100008000000080010000000000000000220203a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.22.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox02: tb1ql34ny8mcpgjqr0ngsnjmlpzjpgncyz2ygh2gye"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.22.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (same account): tb1ql34ny8mcpgjqr0ngsnjmlpzjpgncyz2ygh2gye"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (same account): tb1q l34n y8mc pgjq r0ng snjm lpzj pgnc yz2y gh2g ye"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "send-self-different-account",
+      "description": "Covers ownership detection for another account and version-specific account labels.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100720200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff0280f0fa020000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d31010000000016001460f1b576c18bdbece2606cac70378f2974aed9ef000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d310000800100008000000080010000000000000000220203cee733ae6350507a6c63656d45de6dfc98a252a9f242116cfbe6c6ade2626b0c184c00739d540000800100008001000080000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.22.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1qvrcm2akp30d7ecnqdjk8qdu09962ak005rcp6j"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.22.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (account #2): tb1qvrcm2akp30d7ecnqdjk8qdu09962ak005rcp6j"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "This BitBox (account #2): tb1q vrcm 2akp 30d7 ecnq djk8 qdu0 9962 ak00 5rcp 6j"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "payment-request",
+      "description": "Covers signed SLIP-24 payment-request metadata, merchant and multiline memo screens, address suppression and the pre-v9.24 simulator merchant limitation.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100720200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff0280f0fa020000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d3101000000001600142d997091b1574170c30720dbba9d06a367d68351000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e0001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d31000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "text",
+                  "note": "TextMemo line1\nTextMemo line2"
+                }
+              ],
+              "signature": "3e67d38390b3d32938bd3e3c8f239b201efc278fedadf371bea9561c94da89ea450ad806eeae079983babd8158ac9c7c6a3c12e589435e7535a571d562f9f337"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "Test Merchant"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Memo from\n\nTest Merchant",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 1/2",
+              "body": "TextMemo line1",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 2/2",
+              "body": "TextMemo line2",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.50000000 TBTC",
+              "fee": "0.30000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 150.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "payment-request-owned-output",
+      "description": "Covers version-specific handling of payment-request metadata attached to an output owned by this device, rejected since v9.26.3.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001b68d0167988df1602974d874a0f28f65525c86a88d66a09c92587a19408a30db0000000000ffffffff02801d2c0400000000225120cc9235442b0f4fdf2f3c39516207c389e08fed3ae6cfa90cdb820d791a9d6ba4002d310100000000160014fc6b321f780a2401be6884e5bf84520a27820944000000000001005e020000000131313131313131313131313131313131313131313131313131313131313131310000000000ffffffff0100e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a0000000001012b00e1f505000000002251205745c9989285350a6aa88c88f6fb3c43e6bcce823446a0920eb3bc6a93995f1a21166c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e19004c00739d56000080010000800000008000000000000000000117206c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e00010520c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f7852107c5de774ff4c41546478d7e273827d26d2b0908bcfa86cb5861c29f0b05d1f78519004c00739d560000800100008000000080010000000000000000220203a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "text",
+                  "note": "TextMemo line1\nTextMemo line2"
+                }
+              ],
+              "signature": "4e7837fadb6a322439108c295906d50229f5fd79a1624957e12eeb171cf4ceed36b854ba948ed2630ec89b38aec462b06ed236ea32fa74ad9040dadf430712cd"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.3",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "Test Merchant"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Memo from\n\nTest Merchant",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 1/2",
+              "body": "TextMemo line1",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Memo 2/2",
+              "body": "TextMemo line2",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.3",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "6c9e72468f297c110e46bfedd7ffe83ab20470a1ae6a7fc13ccf94986541292e",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "multiple-output-types-bitcoin-coin",
+      "description": "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001c38bf8f182f907c18224bd5f9cbd843e118019c68c288f5045bc4941672d30380000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd20296490000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600140b664ee927e3e41c6f5acd135d5b31fca4ed8e4a640000000000000016001491d160f1749d830eec2b9402b0b1fcc5ccd52ab1000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f0000000001011f8057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f22060218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d184c00739d54000080000000800a000080000000000500000000000000002202024ea6cfaca7a9f7689293a9b67c77e0a3e5aa8b160b5cfa12474b52767b4b94cf184c00739d54000080000000800a000080010000000300000000220202b8564af1c586c4477df4c233987002147a77987163bdc0535d364569306a74b6184c00739d54000080000000800a000080010000001e00000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 BTC",
+              "address": "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "0.05419010 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 BTC",
+              "address": "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1q xven xven xven xven xven xven xven xven 2ymj t8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "0.05419010 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multiple-output-types-bitcoin-satoshi",
+      "description": "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001c38bf8f182f907c18224bd5f9cbd843e118019c68c288f5045bc4941672d30380000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd20296490000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600140b664ee927e3e41c6f5acd135d5b31fca4ed8e4a640000000000000016001491d160f1749d830eec2b9402b0b1fcc5ccd52ab1000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f0000000001011f8057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f22060218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d184c00739d54000080000000800a000080000000000500000000000000002202024ea6cfaca7a9f7689293a9b67c77e0a3e5aa8b160b5cfa12474b52767b4b94cf184c00739d54000080000000800a000080010000000300000000220202b8564af1c586c4477df4c233987002147a77987163bdc0535d364569306a74b6184c00739d54000080000000800a000080010000001e00000000",
+        "options": {
+          "format_unit": "sat"
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "100000000 sat",
+              "address": "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "1234567890 sat",
+              "address": "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "6000 sat",
+              "address": "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "7000 sat",
+              "address": "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1339999900 sat",
+              "fee": "5419010 sat",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "100000000 sat",
+              "address": "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "1234567890 sat",
+              "address": "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "6000 sat",
+              "address": "bc1q xven xven xven xven xven xven xven xven 2ymj t8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "7000 sat",
+              "address": "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "1339999900 sat",
+              "fee": "5419010 sat",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multiple-output-types-litecoin-coin",
+      "description": "Displays P2PKH, P2SH, P2WPKH and P2WSH recipients, warns about two change outputs, and signs the transaction.",
+      "coin": "ltc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001df6504f0b9af7c7d6795aa190cb900553f2b56690c26ed0d5b8439086dedb9bf0000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd20296490000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600146874a290ffa9444d417e413635eb17a610282aef640000000000000016001466d4383af71817173d87697435a67185d787eb0e000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014f3f3b2cac1d6582e72c41c7db73f4d1c8eb642500000000001011f8057ff7800000000160014f3f3b2cac1d6582e72c41c7db73f4d1c8eb64250220602bad6b8353f8ad1cc4cfc775b05ab9f834a1d132ac36e4cafdc43d8c2c99ebc46184c00739d54000080020000800a0000800000000005000000000000000022020394b3d8170d82ca3dab3feaa5846c5e659cf2f970fc535597aa96c921ed747bdd184c00739d54000080020000800a00008001000000030000000022020349e62be3b83b966bb79dfb50aac69ca112df3237b0ec5cbb069321d2dc363d84184c00739d54000080020000800a000080010000001e00000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 LTC",
+              "address": "LLnCCHbSzfwWquEdaS5TF2Yt7uz5Qb1SZ1"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 LTC",
+              "address": "MB1e6aUeL3Zj4s4H2ZqFBHaaHd7kvvzTco"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 LTC",
+              "address": "ltc1qxvenxvenxvenxvenxvenxvenxvenxvenwcpknh"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 LTC",
+              "address": "ltc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqwr7k5s"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 LTC",
+              "fee": "0.05419010 LTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 LTC",
+              "address": "LLnC CHbS zfwW quEd aS5T F2Yt 7uz5 Qb1S Z1"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "12.34567890 LTC",
+              "address": "MB1e 6aUe L3Zj 4s4H 2ZqF BHaa Hd7k vvzT co"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 LTC",
+              "address": "ltc1 qxve nxve nxve nxve nxve nxve nxve nxve nwcp knh"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 LTC",
+              "address": "ltc1 qg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z qwr7 k5s"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 LTC",
+              "fee": "0.05419010 LTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02bad6b8353f8ad1cc4cfc775b05ab9f834a1d132ac36e4cafdc43d8c2c99ebc46",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "high-fee-rounding",
+      "description": "Displays the 18.1% high-fee warning and requires the final longtouch on the warning instead of the fee screen.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100fdfd000100000001c38bf8f182f907c18224bd5f9cbd843e118019c68c288f5045bc4941672d30380000000000ffffffff0600e1f505000000001976a914111111111111111111111111111111111111111188acd240aa3d0000000017a91422222222222222222222222222222222222222228770170000000000001600143333333333333333333333333333333333333333581b000000000000220020444444444444444444444444444444444444444444444444444444444444444480902029000000001600140b664ee927e3e41c6f5acd135d5b31fca4ed8e4a640000000000000016001491d160f1749d830eec2b9402b0b1fcc5ccd52ab1000000000001005201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff018057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f0000000001011f8057ff7800000000160014cda0c8fb9f429f6090136946d7c928e77117847f22060218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d184c00739d54000080000000800a000080000000000500000000000000002202024ea6cfaca7a9f7689293a9b67c77e0a3e5aa8b160b5cfa12474b52767b4b94cf184c00739d54000080000000800a000080010000000300000000220202b8564af1c586c4477df4c233987002147a77987163bdc0535d364569306a74b6184c00739d54000080000000800a000080010000001e00000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZEw5Hcv1hTb6YUQJ69y1V7uhcoDz92PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "10.34567890 BTC",
+              "address": "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1qxvenxvenxvenxvenxvenxvenxvenxven2ymjt8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1qg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqd8sxw4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "2.05419010 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 18.1%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "1.00000000 BTC",
+              "address": "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "10.34567890 BTC",
+              "address": "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00006000 BTC",
+              "address": "bc1q xven xven xven xven xven xven xven xven 2ymj t8"
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.00007000 BTC",
+              "address": "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4"
+            },
+            {
+              "type": "confirm",
+              "title": "Warning",
+              "body": "There are 2\nchange outputs.\nProceed?",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "13.39999900 BTC",
+              "fee": "2.05419010 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 18.1%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0218f980e27a3f46860d15cbeb0aba08ed32bf5de22be5a3b80e26cfec5727eb1d",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "swap-payment-request",
+      "description": "Displays and signs a Bitcoin-to-Ethereum coin-purchase payment request.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff02801d2c04000000001600141133a71526b176aac7b2462bc5bff36abe68a18a002d310100000000225120da28dbf53b86ae59ae156af3745bb326f44ce309dda97345708c8d3dd45755a6000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d54000080000000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "coin_purchase",
+                  "coin_type": 60,
+                  "amount": "0.25 ETH",
+                  "address": "0x416E88840Eb6353E49252Da2a2c140eA1f969D1a",
+                  "address_keypath": "m/44'/60'/0'/0/0"
+                }
+              ],
+              "signature": "917d3514b2358406730f42952efe0a873255788314a9cf2906474c1e2cefd8cb0e35791ef8211463d37a007e3d9d3a0ec11736250b7e089156c53e5ebf40413d"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "Test Merchant"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "Test Merchant"
+            },
+            {
+              "type": "swap",
+              "title": "Swap",
+              "from": "0.20000000 BTC",
+              "to": "0.25 ETH"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "swap-payment-request-unsupported-source",
+      "description": "Rejects a coin-purchase payment request whose source account is Bitcoin testnet.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 20000000,
+              "memos": [
+                {
+                  "type": "coin_purchase",
+                  "coin_type": 60,
+                  "amount": "0.25 ETH",
+                  "address": "0x416E88840Eb6353E49252Da2a2c140eA1f969D1a",
+                  "address_keypath": "m/44'/60'/0'/0/0"
+                }
+              ],
+              "signature": "c231191f200c3259f71a509dc644b49ab14332fdde4b63a12aaa19b744f188f872e7c60cc6a7e5823acb1f849659e16664fbf2680749bd2101b33cdb49bb8dce"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "Test Merchant"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "p2wpkh-p2sh",
+      "description": "Signs a nested SegWit input and recognizes nested SegWit change.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007e020000000118daf26c629c509a7ea9da4fa3a32393c330c526aa6466e2a2e2f880ee9cf50e0000000000ffffffff02801d2c040000000017a9147946b34fad2af6a7ed141651188fb6d7082b8ef987002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005302000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc66870000000001012000e1f5050000000017a914f566e83e9f22881747e8308ed56afd5fa0abbc6687010416001468a00bbd6de555d756e92815e523b789def6c0b022060329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0184c00739d31000080010000800000008000000000000000000001001600142f4e1eff50d5156d90c5a7d62b7ef3825d5b6db7220203a06059ec858225435fd867601375832479a21ccaef653d6a7920a4cee4797e73184c00739d31000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "0329b834de159b7b1ff5d2bcc4b10ba2611169dff448a59df7f0c84c2c54b9b7d0",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "high-input-address-index",
+      "description": "Spends an owned input at address index 100000 without treating the high spend path as a receive-address verification request.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d02000000014e52523f00352b5da9aca9fcb5dfb4a6c1e0cb8632718e187e0ffefaec0a5eb90000000000ffffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014c2e296c295380207dfdc535c8872c043d9bf52d30000000001011f00e1f50500000000160014c2e296c295380207dfdc535c8872c043d9bf52d3220603ce6f00e8e7302e323faf1f26ce2584307cb1bcef2a2b2140c6013c67bb9b991b184c00739d54000080010000800000008000000000a086010000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03ce6f00e8e7302e323faf1f26ce2584307cb1bcef2a2b2140c6013c67bb9b991b",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-zero",
+      "description": "Suppresses the locktime confirmation when locktime is zero even if the sequence signals RBF.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000fdffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-non-rbf",
+      "description": "Displays block locktime 10 and its non-rbf sequence semantics.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000feffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef140a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is not RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is not RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-rbf",
+      "description": "Displays block locktime 10 and its rbf sequence semantics.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000fdffffff02801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef140a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d540000800100008000000080000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\nTransaction is RBF",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-litecoin-non-rbf-sequence",
+      "description": "Displays a Litecoin block locktime without Bitcoin-specific RBF wording.",
+      "coin": "ltc",
+      "psbt": {
+        "transaction": "70736274ff01007102000000018660b164e26bff1622e4172600f4011bd824211a4ef4201d92c0b0fb290f9b730000000000feffffff02801d2c04000000001600146514c2779c7ee0f8e09ae4f2999c334e5254c70e002d310100000000160014751e76e8199196d454941c45d1b3a323f1433bd60a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f160000000001011f00e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f162206032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2184c00739d5400008002000080000000800000000000000000002202039537a5fa4fa947baa7b215407914d5fcb3709c554ff5750bf0ba931b3cda24ae184c00739d54000080020000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1 qw50 8d6q ejxt dg4y 5r3z arva ry0c 5xw7 kgmn 4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "locktime-litecoin-rbf-sequence",
+      "description": "Displays a Litecoin block locktime without Bitcoin-specific RBF wording.",
+      "coin": "ltc",
+      "psbt": {
+        "transaction": "70736274ff01007102000000018660b164e26bff1622e4172600f4011bd824211a4ef4201d92c0b0fb290f9b730000000000fdffffff02801d2c04000000001600146514c2779c7ee0f8e09ae4f2999c334e5254c70e002d310100000000160014751e76e8199196d454941c45d1b3a323f1433bd60a0000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f160000000001011f00e1f50500000000160014da2f19386bd475b275e76917886fc8340cce9f162206032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2184c00739d5400008002000080000000800000000000000000002202039537a5fa4fa947baa7b215407914d5fcb3709c554ff5750bf0ba931b3cda24ae184c00739d54000080020000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 LTC",
+              "address": "ltc1 qw50 8d6q ejxt dg4y 5r3z arva ry0c 5xw7 kgmn 4n9"
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Locktime on block:\n10\n",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 LTC",
+              "fee": "0.10000000 LTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "032780e5412e19ac486f2be57004bc34d0f9957468bfa2b0fa1c8e689819d97df2",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "p2tr-output-mainnet",
+      "description": "Displays and signs a mainnet P2TR recipient output from a native SegWit account.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff02801d2c04000000001600141133a71526b176aac7b2462bc5bff36abe68a18a002d310100000000225120da28dbf53b86ae59ae156af3745bb326f44ce309dda97345708c8d3dd45755a6000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d54000080000000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "bc1pmg5dhafms6h9nts4dtehgkanym6yeccfmk5hx3ts3jxnm4zh2knqv80ha5"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "bc1p mg5d hafm s6h9 nts4 dteh gkan ym6y eccf mk5h x3ts 3jxn m4zh 2knq v80h a5"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "silent-payment-owned-output",
+      "description": "Covers version-specific handling of silent-payment metadata attached to an output owned by this device, rejected since v9.26.3.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff01007d0200000001a49f3e93836b9131d84d700f422b07ff6f6ffa379499b910c0f153e18f3dac3c0000000000ffffffff02801d2c0400000000225120aaf8631d8fffabc65d283faa12aedc768bdc669c1ba6ff1166f356f13eefe089002d310100000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a29430000000001012b00e1f5050000000022512041ea70bc6cdc9e38c9faa847f0b9e8ce082b3be15fa6d137fbbab6cb138a29432116cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff0952719004c00739d5600008000000080000000800000000000000000011720cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff095270001052067426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee5210767426cdc697740fe8fcedd942ae76b85b22d73db568fc32d7ced988f387f0ee519004c00739d560000800000008000000080010000000000000000220202c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d540000800000008000000080000000000000000000",
+        "options": {
+          "outputs": {
+            "1": {
+              "silent_payment_address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            }
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.22.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "This BitBox02: sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.22.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "This BitBox (same account): sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "max_version_exclusive": "9.26.3",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 BTC",
+              "address": "This BitBox (same account): sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 BTC",
+              "fee": "0.10000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.3",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "cd47d5291421bd92a7dd849beb7f0d13f1c7c98067e3c23ff98de62c1ff09527",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "op-return-nonascii",
+      "description": "Displays a non-ASCII OP_RETURN payload as hexadecimal and signs the transaction.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008d0200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff030000000000000000076a050102030405801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN\ndata (hex)",
+              "body": "0102030405",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN\ndata (hex)",
+              "body": "0102030405",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "op-return-nonzero-value",
+      "description": "Rejects a nonzero-value OP_RETURN output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100930200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff0364000000000000000d6a0b68656c6c6f20776f726c64801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "op-return-silent-payment",
+      "description": "Rejects silent-payment metadata on an OP_RETURN output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100930200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff0300000000000000000d6a0b68656c6c6f20776f726c64801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "0": {
+              "silent_payment_address": "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+            }
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "op-return-payment-request",
+      "description": "Rejects payment-request metadata on an OP_RETURN output.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100930200000001703a366633ea48d0ffd13c1dd1d33c7a0cdcb9b29fb7174ac23842ea36b897c20000000000ffffffff0300000000000000000d6a0b68656c6c6f20776f726c64801d2c04000000001600149e2597ee0b2fbffec6275bd6cab7d2b4737b6e95002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc6b321f780a2401be6884e5bf84520a278209440000000001011f00e1f50500000000160014fc6b321f780a2401be6884e5bf84520a27820944220603a9a6f11db052a402ccd0e2a2a31c4ad196b93db5b1ad1a3bdf8f23882d42b3c3184c00739d54000080010000800000008000000000000000000000220202dca870342cf7bc12c2d6c23dc6a0761160b1ff54e820be4b48c8f3ba9a8dc239184c00739d54000080010000800000008001000000000000000000",
+        "options": {
+          "outputs": {
+            "0": {
+              "payment_request_index": 0
+            }
+          },
+          "payment_requests": [
+            {
+              "recipient_name": "Test Merchant",
+              "total_amount": 1,
+              "memos": [
+                {
+                  "type": "text",
+                  "note": "TextMemo line1\nTextMemo line2"
+                }
+              ],
+              "signature": "93582744d5fab8b70cd2f1686bb7baf76e2797f095a83a6029f04c8c92d11bca4f274a71ef0ac79ce65b87241feb770823a1525d64f85e69104081d6ad397601"
+            }
+          ]
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "all-change-high-fee",
+      "description": "Uses the verified input total for a high-fee warning when every output is change.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100520200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff0180c3c901000000001600141133a71526b176aac7b2462bc5bff36abe68a18a000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d540000800000008000000080010000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.27.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_fee",
+              "amount": "0.70000000 BTC",
+              "fee": "0.70000000 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.27.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_fee",
+              "amount": "0.70000000 BTC",
+              "fee": "0.70000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 70.0%\nof all inputs.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "all-change-high-fee-op-return",
+      "description": "Uses the verified input total for a high-fee warning when all spendable outputs are change and an OP_RETURN output is present.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100650200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff0280c3c901000000001600141133a71526b176aac7b2462bc5bff36abe68a18a00000000000000000a6a086d65746164617461000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d54000080000000800000008001000000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.24.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.24.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.24.0",
+          "max_version_exclusive": "9.27.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN",
+              "body": "metadata",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.70000000 BTC",
+              "fee": "0.70000000 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.27.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "OP_RETURN",
+              "body": "metadata",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.70000000 BTC",
+              "fee": "0.70000000 BTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 70.0%\nof all inputs.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "all-change-fee-below-threshold",
+      "description": "Does not warn when the fee of an all-change transaction is below 10% of the verified input total.",
+      "coin": "btc",
+      "psbt": {
+        "transaction": "70736274ff0100520200000001013018e6e997b8e9b80d0244f11e3c68ba7107d8bb9a359a16a9a796d64e85550000000000ffffffff01c095a905000000001600141133a71526b176aac7b2462bc5bff36abe68a18a000000000001005202000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b0000000001011f00e1f50500000000160014fc8c96dd45eed60d714647d787e74d2b33b5ae9b220602c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048184c00739d5400008000000080000000800000000000000000002202034fc8251f3b2e939dccf75db7c9edf0e8cbc88ec662c0119e961e586ebebe3731184c00739d540000800000008000000080010000000000000000"
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "transaction_fee",
+              "amount": "0.05000000 BTC",
+              "fee": "0.05000000 BTC",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02c6f297dd7bcc0a38a527b3f2289cf91816cae2845a605080fd5fc9af4a945048",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multisig-not-registered",
+      "description": "Rejects a valid 1-of-2 P2WSH multisig transaction when its account has not been registered.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff010089020000000131816c7584e8fb28ce853874eeb709394562c6e99eb9b6f3987d205dcc6933880000000000ffffffff02801d2c040000000022002049934b3c5c97bbd8e9e77ca525ddbad2addcf929f5dd3b83d2c017ab65e54382002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020276686da70f18aec8090484fc1a58b0808b2f6c7aa9f88191ec47166bd805c9e0000000001012b00e1f50500000000220020276686da70f18aec8090484fc1a58b0808b2f6c7aa9f88191ec47166bd805c9e0105475121031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad21039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde52ae2206031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad1c0dbd0cc33000008001000080000000800200008000000000000000002206039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde1c4c00739d30000080010000800000008002000080000000000000000000010147512102e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b21031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb52ae220202e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b1c0dbd0cc33000008001000080000000800200008001000000000000002202031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb1c4c00739d3000008001000080000000800200008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 1,
+              "xpubs": [
+                "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+                "tpubDFX8u4cajvyZrQGikAfBcRt5EqVj4C9xB1HEQSZfN5weSUq4ULeMra6GXY8fM6hwgBX3WZ8TCP7nvMQu3hM4zvUHqWPhU9oq8HNV4ixboTz"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh"
+            },
+            "keypath": "m/48'/1'/0'/2'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "outcome": "invalid_input",
+          "screens": []
+        }
+      ]
+    },
+    {
+      "id": "multisig-p2wsh-p2sh",
+      "description": "Signs and finalizes a registered 1-of-2 nested P2SH-P2WSH multisig transaction.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01007e02000000017a26adfe8f25b544220236a6516252b9eb746a620ffd210679634285fc890dd50000000000ffffffff02801d2c040000000017a914c88f04120fca1cbbd8e1a9dac997a5d99d8ca09d87002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005302000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f5050000000017a9143b3a20e6b4121c867e5a8e1bf1c3c85504b1ff13870000000001012000e1f5050000000017a9143b3a20e6b4121c867e5a8e1bf1c3c85504b1ff13870104220020cd9833d9c1ca210e8e5984f8fffa56f40770409811f431ea1c6daa0cd7cfba7f010547512102efb2f859bf983f02f6c17664426a9992985b3bdac83184b0162993d398f8ba0d2103f506dd0e67b1d3f035a6055961a3ac5510dff004069e9d025930338fd8e20c8852ae220602efb2f859bf983f02f6c17664426a9992985b3bdac83184b0162993d398f8ba0d1c0dbd0cc3300000800100008000000080010000800000000000000000220603f506dd0e67b1d3f035a6055961a3ac5510dff004069e9d025930338fd8e20c881c4c00739d3000008001000080000000800100008000000000000000000001002200209a8754cc38326f8daa604b0d1f4d803f6bd714cf428490ed6cb5407b05ea91cd01014751210235294f21973f87de509b16ef8f71bf9c353c0d450db814a428709f80a2a347f32103fd271ddb4968f17ea1aab754c4283c05e58ee5810868e845ad7d2b06ef30a87452ae22020235294f21973f87de509b16ef8f71bf9c353c0d450db814a428709f80a2a347f31c0dbd0cc3300000800100008000000080010000800100000000000000220203fd271ddb4968f17ea1aab754c4283c05e58ee5810868e845ad7d2b06ef30a8741c4c00739d3000008001000080000000800100008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 1,
+              "xpubs": [
+                "xpub6EhivkawbkKDNQtJHZFjbd79dLGtC1yTcWn7WHPaCdpa8jXS8mU4y9tdYqzhrUVt3w6QR6vjx66nbUX4s2Hw5V5oer76XzKpRVMExC7zpLG",
+                "tpubDFX8u4cajvyZqUGS5AVgPb7GUpAJJ5nbkVMnw1m2ajrHaZmknbxuWDac2P2zyiB35UcgqwmVAeVzGEVV9qbji6tzYRCTiWwPGvtUULR4DLM"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh_p2sh"
+            },
+            "keypath": "m/48'/1'/0'/1'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test sh-wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "1-of-2\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test sh-wsh multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "multisig",
+            "threshold": 1,
+            "xpubs": [
+              "xpub6EhivkawbkKDNQtJHZFjbd79dLGtC1yTcWn7WHPaCdpa8jXS8mU4y9tdYqzhrUVt3w6QR6vjx66nbUX4s2Hw5V5oer76XzKpRVMExC7zpLG",
+              "tpubDFX8u4cajvyZqUGS5AVgPb7GUpAJJ5nbkVMnw1m2ajrHaZmknbxuWDac2P2zyiB35UcgqwmVAeVzGEVV9qbji6tzYRCTiWwPGvtUULR4DLM"
+            ],
+            "our_xpub_index": 0,
+            "script_type": "p2wsh_p2sh"
+          },
+          "keypath": "m/48'/1'/0'/1'",
+          "name": "test sh-wsh multisig"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "03f506dd0e67b1d3f035a6055961a3ac5510dff004069e9d025930338fd8e20c88",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "multisig-large",
+      "description": "Adds the seventh signature to a registered 7-of-15 P2WSH multisig transaction whose PSBT already contains six cosigner signatures.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001cb44be13195cb0246f334d02fc36179e5c8d03e5bb812f97b039c5920413280f0000000000ffffffff02801d2c0400000000220020472cd252fa25c59c9e7f876cca3cbf4585826ff6f66b5e465feddc94cf50a5cc002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f505000000002200208d69e9431a924d7a5cd26f9cf85b2a3bc9d91dc06266f4a24b2ea13fdd1da1780000000001012b00e1f505000000002200208d69e9431a924d7a5cd26f9cf85b2a3bc9d91dc06266f4a24b2ea13fdd1da17822020266dc638844899b98e0d23a40deb72ec14b4842fbd3e70f65f1a955b6cf9f5e50483045022100bf0316ed68454f814fe83efb4ae013339d044b003336a1c68ed80bf9123d9fb2022045ba0d2a90aadfd3b062036e03ba1f6cf8c2aa2bd5d4c5bf1728d4648b5cd87801220202fdb3657418ffef1ed8f513b9e4d9a886ce9798a6b766e5da018417f981395feb483045022100aa4344593f229829440738816c3ed451191898a1761f1e1157a008e7ba5bfb68022030f17cd5f5006baded37e56ecb2480fd3a05b44aa88fe2f870b4974326a04d52012202031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad483045022100a62043f3af8c106c3ef3d0aad0f7c36940627fa06792e19b178e5cd39c4fe9850220793fa3990ed0fa526018e835aed5cab8206827ddbea30a86cf2421c9cc3fb686012202039446d050672e4829214199332a974a5ec1ec80ab0cd4dfc395e2e37a79af87f0473044022002958b416ce5a3c9722cdd07c45addbc679ec34d63bd138207583b258031300c02204d36fd84522cd7831fc06dbd5e611e7bccfc23098a752808a5a252ba05060070012202039b319f5be7dcd91450775a73dc9f163c20ad6eb08e611f220342d53fb0d70e204730440220630b0e820c0e2e7940929a3190b374a649c2e0f0aa78077806551aad57d20b7c02202a2448562899d865f43805441331533721827925b386841818df7b5e406989e101220203ca2121456edf5d624b9bed7d7f507e40b088b313d5773f19df45e71b96278421483045022100dc2b897a4ae2ae446fb7fe7f94836f1136c7ad3c5deb4cb4ccd1eccd224c3f7a02205e4506f6edd9981ba7bb7578454b4c4250de3070db29b74c20c21f5d88e599b2010105fd01025721020faf2667c643963b00041bea043d6fd2e91f3db842b8ccfddefd0f5615bfe9b4210266dc638844899b98e0d23a40deb72ec14b4842fbd3e70f65f1a955b6cf9f5e502102bcdd4e3e30bdb4219ef1836d0f573b81574639b189225039deaefb5bd75153152102e73cddb837ae9bcb40d3f6cf72e133d77505daf9fe03a5c359822a45332391a82102eb12fd1be52ba727e325bd880e8b0ac28769c3850301f3c333c98c0d420b65ec2102fdb3657418ffef1ed8f513b9e4d9a886ce9798a6b766e5da018417f981395feb21031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad2103440396891d7d6c9f623635e4c1a4f66edca6dca79c11debe0dc58a0f10f9079421034a0ad5543e4978b96f5a06959b281298e4079fe2fd71efaa0604a93fa9305891210353983ae233c60e81243818ffa3ce635d65d666238c1e7503e31e9f2186cc714521039446d050672e4829214199332a974a5ec1ec80ab0cd4dfc395e2e37a79af87f021039b319f5be7dcd91450775a73dc9f163c20ad6eb08e611f220342d53fb0d70e2021039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde2103bbc0345e402e1f8838e0ea1669fc79f452cfcc7136a3ff91f621833fbc154f6a2103ca2121456edf5d624b9bed7d7f507e40b088b313d5773f19df45e71b962784215fae2206020faf2667c643963b00041bea043d6fd2e91f3db842b8ccfddefd0f5615bfe9b41ce9324a6c30000080010000800000008002000080000000000000000022060266dc638844899b98e0d23a40deb72ec14b4842fbd3e70f65f1a955b6cf9f5e501c73bccd56300000800100008000000080020000800000000000000000220602bcdd4e3e30bdb4219ef1836d0f573b81574639b189225039deaefb5bd75153151cd0bee5ae300000800100008000000080020000800000000000000000220602e73cddb837ae9bcb40d3f6cf72e133d77505daf9fe03a5c359822a45332391a81cc8c72c6c300000800100008000000080020000800000000000000000220602eb12fd1be52ba727e325bd880e8b0ac28769c3850301f3c333c98c0d420b65ec1c0bbe8456300000800100008000000080020000800000000000000000220602fdb3657418ffef1ed8f513b9e4d9a886ce9798a6b766e5da018417f981395feb1cac9a9e9e3000008001000080000000800200008000000000000000002206031cf0f0f1bf784a99e0c007f162d5df97563915d74004ed3fa2403f2fd1569fad1c0dbd0cc3300000800100008000000080020000800000000000000000220603440396891d7d6c9f623635e4c1a4f66edca6dca79c11debe0dc58a0f10f907941c0ed45ef03000008001000080000000800200008000000000000000002206034a0ad5543e4978b96f5a06959b281298e4079fe2fd71efaa0604a93fa93058911c9e1cb09d30000080010000800000008002000080000000000000000022060353983ae233c60e81243818ffa3ce635d65d666238c1e7503e31e9f2186cc71451c7fb8ad413000008001000080000000800200008000000000000000002206039446d050672e4829214199332a974a5ec1ec80ab0cd4dfc395e2e37a79af87f01c054f2f713000008001000080000000800200008000000000000000002206039b319f5be7dcd91450775a73dc9f163c20ad6eb08e611f220342d53fb0d70e201c41559f4f3000008001000080000000800200008000000000000000002206039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde1c4c00739d300000800100008000000080020000800000000000000000220603bbc0345e402e1f8838e0ea1669fc79f452cfcc7136a3ff91f621833fbc154f6a1c5d3e97e0300000800100008000000080020000800000000000000000220603ca2121456edf5d624b9bed7d7f507e40b088b313d5773f19df45e71b962784211c1a34b3e5300000800100008000000080020000800000000000000000000101fd01025721021f7e9e9befaa3424398f347b5b2f78d5f893498f6f8ec488dd2f9f22ea18c7bc21029c20cd5acd30db6bf7aeaf7f83cc171adc87cba7498bd7e673304db6e0a86b5b2102b29e8ea9305c52a928175756d9c979db1768ce8643badface43e1c4661aa1fec2102d63ffb041633c0c721c9dd16fabdcd0a413a5d20786fd798e9ea5458a9d0145f2102e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b21031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb21031fd8d9ae7b5cdd43427ff940ee8b485d7b0e79e2cbb53c111f736db8309dd6cb2103206d7162cc432f2b79039f839a8eb4b9155b407b9178ebf46fc29de2c23965e421034434b5c28fe2b71f01328b3af87647d7729a9ad1d1d1646d3f0b87cd0dfd06b6210347504a67f3b4bfdef20beaa5790304ce34927e740929f2caddc032ae8d653a7921035c3445de6a048ab9e905c86bc6d481890088fa7d51309a439bfeb4af77fc7650210365a176ac65d10de83778956b560630f341a6f6b43584acc0271083cff36ace35210376b63bd235b30bc9042c7b500be79e7fbebbc4f6e723c8b798aea84769acb1ea21037d33decd1fee9418357a1e419813a898f7aa006b9a59ca241fb46ad29b774fcb2103c69f4d4950ed98135ff37e631731881dd01060db8dae4ccda2f8c0a796f5c4e85fae2202021f7e9e9befaa3424398f347b5b2f78d5f893498f6f8ec488dd2f9f22ea18c7bc1c0bbe84563000008001000080000000800200008001000000000000002202029c20cd5acd30db6bf7aeaf7f83cc171adc87cba7498bd7e673304db6e0a86b5b1c0ed45ef0300000800100008000000080020000800100000000000000220202b29e8ea9305c52a928175756d9c979db1768ce8643badface43e1c4661aa1fec1c1a34b3e5300000800100008000000080020000800100000000000000220202d63ffb041633c0c721c9dd16fabdcd0a413a5d20786fd798e9ea5458a9d0145f1c41559f4f300000800100008000000080020000800100000000000000220202e48ca9c37f3f4b23010171cde63b3e22e752c5f0bda353bb1a443385b76ba38b1c0dbd0cc33000008001000080000000800200008001000000000000002202031bc4da3f6dfefcc269e08ac1edfffb1bf928790b0ed888d6047adbbd0ec27acb1c4c00739d3000008001000080000000800200008001000000000000002202031fd8d9ae7b5cdd43427ff940ee8b485d7b0e79e2cbb53c111f736db8309dd6cb1c73bccd56300000800100008000000080020000800100000000000000220203206d7162cc432f2b79039f839a8eb4b9155b407b9178ebf46fc29de2c23965e41c9e1cb09d3000008001000080000000800200008001000000000000002202034434b5c28fe2b71f01328b3af87647d7729a9ad1d1d1646d3f0b87cd0dfd06b61cac9a9e9e30000080010000800000008002000080010000000000000022020347504a67f3b4bfdef20beaa5790304ce34927e740929f2caddc032ae8d653a791cc8c72c6c3000008001000080000000800200008001000000000000002202035c3445de6a048ab9e905c86bc6d481890088fa7d51309a439bfeb4af77fc76501c7fb8ad4130000080010000800000008002000080010000000000000022020365a176ac65d10de83778956b560630f341a6f6b43584acc0271083cff36ace351c054f2f7130000080010000800000008002000080010000000000000022020376b63bd235b30bc9042c7b500be79e7fbebbc4f6e723c8b798aea84769acb1ea1c5d3e97e03000008001000080000000800200008001000000000000002202037d33decd1fee9418357a1e419813a898f7aa006b9a59ca241fb46ad29b774fcb1ce9324a6c300000800100008000000080020000800100000000000000220203c69f4d4950ed98135ff37e631731881dd01060db8dae4ccda2f8c0a796f5c4e81cd0bee5ae3000008001000080000000800200008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "multisig",
+              "threshold": 7,
+              "xpubs": [
+                "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+                "tpubDFX8u4cajvyZrQGikAfBcRt5EqVj4C9xB1HEQSZfN5weSUq4ULeMra6GXY8fM6hwgBX3WZ8TCP7nvMQu3hM4zvUHqWPhU9oq8HNV4ixboTz",
+                "tpubDFCqK5T7J3FUasUXA1xsminXkeaPSxe1id2K4KCEaszuTNKERymaiZHTnUcjGDf4b57XinAHauwSh1uDRmNVMtfhiStJWsf83MZLA1tC5qi",
+                "tpubDEKEr89i7dBFXrrpkK2KZQy9aMw6Dg8idr1ysbZJ94mWk6uaFAy4DmYMw7LMDSEaeSJdAcgshdLATcbr6T9hQoouRphfHC9aBQqiWAh8wRF",
+                "tpubDERfkonU8krEq7knZXFPFrS5bnbhsyXhV7wdM9agZuzD6YgM95LgBWKzAkPeZMseTWRj2PPcbw2kEjcrBctJEzLNUu2VLz1Fixehoc5z4aq",
+                "tpubDECMwLTAdWk5RcgKaaLKaP83R586xMFtBhH5osdzdF6VbEwFpQp3uiiaHrKGPnqmfDUKFtSQE5ForxoBYgJWEHA5B2T9i5GP5ZAuScWKXgH",
+                "tpubDEuxzYbnkbY2XHQZjzcDV2Vk4DH4oZwLefGso1jXfFsTyhVV5HxZvVUrSdGLc9AVBTNcCDZh5qw7RgPiibMfMVWtHpjzoErqJcvukzFSpbf",
+                "tpubDEccsjksu3ddEUnx5FkNADMy9YkLi3p6vQGpdgFDSypMfYZs7amRL94ucqyHGZrVDMrBc937ptj4SKihNiYJtnRgiZ742hpxfnAgynaQno5",
+                "tpubDF1U1F2s28Rv71bukRRTLUN3hiTgKDGjxGVrFAYXYo1qaWFNsUnA4MoyFtKoytQyLHfmE267HDo3VDgDUfk2hQwb3ary3aNojzkT1sTe5oi",
+                "tpubDF8LvKCNR3JMayQDTRRqBD3PLhVng5wk6bYvCpsrhe5Mffon2sSFrLBz9J3WCdLqsoeUjMiG1gqsiiM8RVNw6eSfqbRyFsSt2sZPd54GoVi",
+                "tpubDEgfQ9SqcnKyEkVmEEkx9AaQ3pZN1nSZQjZxtCcTVytAk62DggB6FiuH12cFeygFLgDPsYtBYDp8FCQDrdgZLrpp2cFhnsFur55kWid1DYg",
+                "tpubDEHvZYZJ5N3jGxHTJJ1LSWdoD3SUSSz7zUhUPLrTMC7SoEkthZVzfFz8qSYAYF1Rg6LjKTsBZMeNJivd4iDyjbQQ6JcyZe2eHB3WENiQECP",
+                "tpubDEjJyDs2yboyzkczJ5ADEmU9yJNqCgmpUPBqW5CVSPCxg8Q59ZwDqRCBwUrDmR29iY8BJGfBa5bq9MBhYpnqjaQvNQdFHqGX99W6ocPX63z",
+                "tpubDFFcidKjrkaTSz4R4s9Y5ijp3dzHkJ9XZ2JkLanjkUskBBbFvjxfQMeU5L52ANJtgpiMRyjK4WzJ6qkK22KQsScHbiQBEsstjVKLoxZynZm",
+                "tpubDF3ds3VKs6p4YjvSLY848WwW21fxiaYGdn5cZEUZ5CwKwMveavxSNA3GhJHqZkFkXa5DTeT1ZKjThtFY8KDfNAuvF95SDcXEoGXNq5bs9nT"
+              ],
+              "our_xpub_index": 0,
+              "script_type": "p2wsh"
+            },
+            "keypath": "m/48'/1'/0'/2'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "7-of-15\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test large multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "7-of-15\nBTC Testnet multisig",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "test large multisig",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "multisig",
+            "threshold": 7,
+            "xpubs": [
+              "xpub6EhivkawbkKDRT9Z59WwqhAzZZe7NQhxPgYc67nHbagRxoSbKEiZ6x4P4bE6s48GHvAHaGH8hsQfJ4RSSeNbVdYp7Kii2UGWKn8x2bQDtiR",
+              "tpubDFX8u4cajvyZrQGikAfBcRt5EqVj4C9xB1HEQSZfN5weSUq4ULeMra6GXY8fM6hwgBX3WZ8TCP7nvMQu3hM4zvUHqWPhU9oq8HNV4ixboTz",
+              "tpubDFCqK5T7J3FUasUXA1xsminXkeaPSxe1id2K4KCEaszuTNKERymaiZHTnUcjGDf4b57XinAHauwSh1uDRmNVMtfhiStJWsf83MZLA1tC5qi",
+              "tpubDEKEr89i7dBFXrrpkK2KZQy9aMw6Dg8idr1ysbZJ94mWk6uaFAy4DmYMw7LMDSEaeSJdAcgshdLATcbr6T9hQoouRphfHC9aBQqiWAh8wRF",
+              "tpubDERfkonU8krEq7knZXFPFrS5bnbhsyXhV7wdM9agZuzD6YgM95LgBWKzAkPeZMseTWRj2PPcbw2kEjcrBctJEzLNUu2VLz1Fixehoc5z4aq",
+              "tpubDECMwLTAdWk5RcgKaaLKaP83R586xMFtBhH5osdzdF6VbEwFpQp3uiiaHrKGPnqmfDUKFtSQE5ForxoBYgJWEHA5B2T9i5GP5ZAuScWKXgH",
+              "tpubDEuxzYbnkbY2XHQZjzcDV2Vk4DH4oZwLefGso1jXfFsTyhVV5HxZvVUrSdGLc9AVBTNcCDZh5qw7RgPiibMfMVWtHpjzoErqJcvukzFSpbf",
+              "tpubDEccsjksu3ddEUnx5FkNADMy9YkLi3p6vQGpdgFDSypMfYZs7amRL94ucqyHGZrVDMrBc937ptj4SKihNiYJtnRgiZ742hpxfnAgynaQno5",
+              "tpubDF1U1F2s28Rv71bukRRTLUN3hiTgKDGjxGVrFAYXYo1qaWFNsUnA4MoyFtKoytQyLHfmE267HDo3VDgDUfk2hQwb3ary3aNojzkT1sTe5oi",
+              "tpubDF8LvKCNR3JMayQDTRRqBD3PLhVng5wk6bYvCpsrhe5Mffon2sSFrLBz9J3WCdLqsoeUjMiG1gqsiiM8RVNw6eSfqbRyFsSt2sZPd54GoVi",
+              "tpubDEgfQ9SqcnKyEkVmEEkx9AaQ3pZN1nSZQjZxtCcTVytAk62DggB6FiuH12cFeygFLgDPsYtBYDp8FCQDrdgZLrpp2cFhnsFur55kWid1DYg",
+              "tpubDEHvZYZJ5N3jGxHTJJ1LSWdoD3SUSSz7zUhUPLrTMC7SoEkthZVzfFz8qSYAYF1Rg6LjKTsBZMeNJivd4iDyjbQQ6JcyZe2eHB3WENiQECP",
+              "tpubDEjJyDs2yboyzkczJ5ADEmU9yJNqCgmpUPBqW5CVSPCxg8Q59ZwDqRCBwUrDmR29iY8BJGfBa5bq9MBhYpnqjaQvNQdFHqGX99W6ocPX63z",
+              "tpubDFFcidKjrkaTSz4R4s9Y5ijp3dzHkJ9XZ2JkLanjkUskBBbFvjxfQMeU5L52ANJtgpiMRyjK4WzJ6qkK22KQsScHbiQBEsstjVKLoxZynZm",
+              "tpubDF3ds3VKs6p4YjvSLY848WwW21fxiaYGdn5cZEUZ5CwKwMveavxSNA3GhJHqZkFkXa5DTeT1ZKjThtFY8KDfNAuvF95SDcXEoGXNq5bs9nT"
+            ],
+            "our_xpub_index": 0,
+            "script_type": "p2wsh"
+          },
+          "keypath": "m/48'/1'/0'/2'",
+          "name": "test large multisig"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "039fb11f1394842eeeadd04ec165f713c49cb875443da2bc05d994ec118d7d1fde",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-keyspend-with-script-tree",
+      "description": "Signs a Taproot policy key path whose tweak commits to a script tree.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001481b25e956e13b122e0155ee1066ff2620345d94c51e6c2b7889e0daac298db00000000000ffffffff02801d2c0400000000225120916ffdd6fe3d0adf420c6d71702a944b8f22db3277d4b24721f2f1deb96e8a46002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120d06244555fe882d1190e968e20f053018fe20114014338e89149d314ef4352d92215c13a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2232034c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de2acc0211634c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de23d01d9c7b0c5dc86c4594427111e20854229a2bded47788886c3b3e5093c5d9d9f56c5e4fe1a30000080010000800000008003000080000000000000000021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21d004c00739d3000008001000080000000800300008000000000000000000117203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2011820d9c7b0c5dc86c4594427111e20854229a2bded47788886c3b3e5093c5d9d9f56000105208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a01062500c022203df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563bac21073df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563b3d016a4a33d1169c5d57685ea4668790c7ce35fc9af5f8002aea692c3296287f548fc5e4fe1a30000080010000800000008003000080010000000000000021078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1d004c00739d3000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/**,pk(@1/**))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr tweaked keyspend",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/**,pk(@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test tr tweaked keyspend",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/**,pk(@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/**,pk(@1/**))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test tr tweaked keyspend"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_key",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-unspendable-internal-key",
+      "description": "Signs a Taproot script path with a provably unspendable internal key and displays that property in the policy review.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff0100890200000001a8346bd79715029f26a2628a872d2299934cfc774bb3c4e52209ef404f07278f0000000000ffffffff02801d2c0400000000225120f191a4cb0a3d8f8b47251bc375159b8ff3aac672264cb0e0c9c5adeba37a09e4002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120c5340ec5fb5662a6ef7290f9dffedf9c727d503c2f69377cb4c8560e9f02e45b4114bc0eab168b76abf60a0a6f3c197ea0f9b7973e27ca1aba50daa09c62de813c68e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c08558405d9d7da26d848dd9562ab95b348ac6414e1bc28a2f8ccd839b7dd5b452abc513d099a0f0efcd011fdcc9b5f18b3c69cb9122391b751e274a67dc74b61757ab5d2215c01ab64872242fff67a9cc2429d50bd615532e55122665e448ae0e53a3f4a2ce594720bc0eab168b76abf60a0a6f3c197ea0f9b7973e27ca1aba50daa09c62de813c68ac203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2ba529cc021161ab64872242fff67a9cc2429d50bd615532e55122665e448ae0e53a3f4a2ce590d007c461e5d000000000000000021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b23d01e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c085584c00739d3000008001000080000000800300008000000000000000002116bc0eab168b76abf60a0a6f3c197ea0f9b7973e27ca1aba50daa09c62de813c683d01e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c0855808f56e293000008001000080000000800300008000000000000000000117201ab64872242fff67a9cc2429d50bd615532e55122665e448ae0e53a3f4a2ce59011820e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c0855800010520349092f96b1dd44a23e6a05986e7934bae5d6a87b9a050c1e13b38a0ae4e52c101064900c04620dbe4edc0edbcb5f212c9fa1d1bcbdb4b3f6e875a5ea52ac3cafed4057379302bac208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aba529c2107349092f96b1dd44a23e6a05986e7934bae5d6a87b9a050c1e13b38a0ae4e52c10d007c461e5d010000000000000021078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a3d014b40a0f212ea2f428474b933288cec2f2a50121ba995173e8d601dbb1b2d9a784c00739d3000008001000080000000800300008001000000000000002107dbe4edc0edbcb5f212c9fa1d1bcbdb4b3f6e875a5ea52ac3cafed4057379302b3d014b40a0f212ea2f428474b933288cec2f2a50121ba995173e8d601dbb1b2d9a7808f56e293000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+              "keys": [
+                {
+                  "xpub": "tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8"
+                },
+                {
+                  "xpub": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi"
+                },
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test unspendable policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test unspendable policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*,multi_a(2,@1/<0;1>/*,@2/<0;1>/*))",
+            "keys": [
+              {
+                "xpub": "tpubD6NzVbkrYhZ4XnyFMCH9qsN7VhcUSwyj5MN4juKrFBbgE9e3qCpEQsHSmq4zHA2FAkSwBQEzFGKjvXtb2xrRLioqRdqAkqN3Y9WrBf7yNj8"
+              },
+              {
+                "xpub": "tpubDF93VcTYKK2grTowjbqJMst4gS19G6rtWTNKcBnxCpQfs2BaFShNYoBDisxqhTsBWj4YhigxVArhhZN43NyWBH4E3puXS7tCrHsbjb2dvBi"
+              },
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test unspendable policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_script",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "leaf_hash": "e0ed23b292365b738059122f0e9f6887887b474a1e9593cb55e872c7a0c08558",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-tr-unspendable-internal-key-complex",
+      "description": "Signs the satisfiable branch of a multi-leaf Taproot policy with a provably unspendable internal key, distinct multipaths and a relative-timelock sibling branch.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000017079ce1d2dffec9e935d2a74cd4a702f722e651939daeb27faf3953f14fa5c3a0000000000ffffffff02801d2c04000000002251203ad5b7757d2dc6cd5e5ec17a0603352d401de5d69fc48f9c6ec1a3ac2b8e194f002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001012b00e1f50500000000225120eaef7e275cce42763c22a441d0e5b254c794d51e8123f5562441346dac40848c4114eeab1c2d28079589eb9e55bbd86765ffce87514a1feca661ee3d88f0e04643c9b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a404eb58edfa3eec62bf0fccefc4e73dafb7e74009a81e22a24ea6f1dae95e558273eb0f851610819384de73f327e2ffe0d3751a8b785f9db8648d2bb074559eaef4215c159165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed3309e075b5976239a09b6b08d128ec95a42f328a625c26213f9568d7768d853f4974720eeab1c2d28079589eb9e55bbd86765ffce87514a1feca661ee3d88f0e04643c9ac203a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2ba529cc04215c159165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed330b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a4920ca89423a6e0a0673b51bfd05212d8963c14a8db6cd3d7cba5dabaff97d4e3ed8ac201d7d773d42ed516b73555c715929badf8ddb135b25779b475157a49ed946af79ba519d52b2c021163a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b23d01b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a4c00739d300000800100008000000080030000800000000000000000211659165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed3300d007c461e5d00000000000000002116eeab1c2d28079589eb9e55bbd86765ffce87514a1feca661ee3d88f0e04643c93d01b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a4040280c30000080010000800000008002000080000000000000000001172059165ae2e78cafa08859f5d42370b903e931f4d0d76247a3ecdcdeffc3eed3300118207754188d95aa29ae86dcf87406dfb5ed0e1d6da02a9ad5104b95f5f81abf79a4000105209ba26f33424bc7330bf3f683129516387fdc20f5baf09046ea9eaa2ed71516d401069401c0482006048aec624d548af178a98ec862e0efaa5c2fcf8fb07f5146f410918eb21eefac20c621b132507c49d0f974e71d89e3017fe4f4ca8aa7c73c291d7a4edd1a6399a6ba519d52b201c04620ddad6824617b6a1bd330aab5c263f039b7ebe04196792fe90d203752e9c37809ac208c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44aba529c21078c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a3d01d3064571589c8c4e858bc4dd2efe190b4e2d9d3da7d96306eb9702e5401d2f264c00739d30000080010000800000008003000080010000000000000021079ba26f33424bc7330bf3f683129516387fdc20f5baf09046ea9eaa2ed71516d40d007c461e5d01000000000000002107ddad6824617b6a1bd330aab5c263f039b7ebe04196792fe90d203752e9c378093d01d3064571589c8c4e858bc4dd2efe190b4e2d9d3da7d96306eb9702e5401d2f264040280c3000008001000080000000800200008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+              "keys": [
+                {
+                  "xpub": "tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm"
+                },
+                {
+                  "root_fingerprint": "4040280c",
+                  "keypath": "m/48'/1'/0'/2'",
+                  "xpub": "tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR"
+                },
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": false,
+      "expectations": [
+        {
+          "max_version_exclusive": "9.21.0",
+          "outcome": "unsupported",
+          "unsupported_version": "9.21.0",
+          "screens": []
+        },
+        {
+          "min_version": "9.21.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test complex unspendable",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "[4040280c/48'/1'/0'/2']tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n3 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test complex unspendable",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/3",
+              "body": "Provably unspendable: tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/3",
+              "body": "[4040280c/48'/1'/0'/2']tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 3/3",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})",
+            "keys": [
+              {
+                "xpub": "tpubD6NzVbkrYhZ4YRYppNDw8BpfEz6cSU8qt45Eoqpj8YtPLFXoZsb3dYdAyLFp32GeY3b5ccVdtr45ajBGBDHgapb53xT9kMBcpHSF7yA8kXm"
+              },
+              {
+                "root_fingerprint": "4040280c",
+                "keypath": "m/48'/1'/0'/2'",
+                "xpub": "tpubDEWR7iVng7GH7BhbVBa6avnELDTSWEWHtAethvSrYYLEFm1XB1qT4Fb9xkPGZ9S7zU1FFrpVc6wRSo5BRNYvDAP7Edr5a6FJSjeCt7tWgQR"
+              },
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              }
+            ]
+          },
+          "name": "test complex unspendable"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "taproot_script",
+          "pubkey": "3a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2",
+          "leaf_hash": "b2edc93766200490b5d77842a9424fd5686d22c4c14fb13dec8784164160521a",
+          "sighash": "default"
+        }
+      ]
+    },
+    {
+      "id": "policy-different-multipath-derivations",
+      "description": "Signs and finalizes a registered WSH policy whose two keys use different receive and change branches.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff010089020000000149aa85e2c639e52c4984cba528c60ef347f47f35917519ecba279514841928470000000000ffffffff02801d2c0400000000220020d0a6b11cf5a05594e6fad40948646011c6307c84906d318f348f5effaaa97b02002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020e267e95e105bd40e8fbf3bdda795da8bc943949f4accec407d45b469f514b4830000000001012b00e1f50500000000220020e267e95e105bd40e8fbf3bdda795da8bc943949f4accec407d45b469f514b483220203e7d88a65b1ca31ccc898193ab72acdce9b0c0076a9ba8f4ef06bd0ccd4d01d034730440220182d262d790be3d24e15dd8e74057bacf77f678ef0e82bdecce4386ab3252a7c02205651ad4a74158357b08c05bd88dec8c2522bb91013332f963374b45722c842a401010547522102b95c8bf277d3e7d7de1ad4fbb4921c5bd1cefeb3ebf38987bdd4688b9cfcbb722103e7d88a65b1ca31ccc898193ab72acdce9b0c0076a9ba8f4ef06bd0ccd4d01d0352ae220602b95c8bf277d3e7d7de1ad4fbb4921c5bd1cefeb3ebf38987bdd4688b9cfcbb721c4c00739d300000800100008000000080030000800a00000000000000220603e7d88a65b1ca31ccc898193ab72acdce9b0c0076a9ba8f4ef06bd0ccd4d01d031cc5e4fe1a300000800100008000000080030000801400000000000000000101475221034c130edc7e1574821af949c79d64052475e85f7f659cbbbd4b99c79bdf840dc92102627713c28bf52eb7012ac66a69b333fca5f9c8794fb5751ceb0cb50484546b3952ae220202627713c28bf52eb7012ac66a69b333fca5f9c8794fb5751ceb0cb50484546b391cc5e4fe1a3000008001000080000000800300008015000000000000002202034c130edc7e1574821af949c79d64052475e85f7f659cbbbd4b99c79bdf840dc91c4c00739d300000800100008000000080030000800b000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "min_version": "9.20.0",
+          "max_version_exclusive": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test multipath policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1pff8vkq80pu2cgtu7ttgad2znw62v2lguhw6ptrppwns6nrpqau2qcuz37d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        },
+        {
+          "min_version": "9.26.0",
+          "outcome": "success",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test multipath policy",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            },
+            {
+              "type": "transaction_address",
+              "amount": "0.20000000 TBTC",
+              "address": "tb1p ff8v kq80 pu2c gtu7 ttga d2zn w62v 2lgu hw6p trpp wns6 nrpq au2q cuz3 7d"
+            },
+            {
+              "type": "transaction_fee",
+              "amount": "0.30000000 TBTC",
+              "fee": "0.10000000 TBTC",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "High fee",
+              "body": "The fee is 50.0%\nthe send amount.\nProceed?",
+              "longtouch": true
+            },
+            {
+              "type": "status",
+              "title": "Transaction",
+              "body": "confirmed"
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test multipath policy"
+        }
+      ],
+      "expected_signatures": [
+        {
+          "input_index": 0,
+          "kind": "ecdsa",
+          "pubkey": "02b95c8bf277d3e7d7de1ad4fbb4921c5bd1cefeb3ebf38987bdd4688b9cfcbb72",
+          "sighash": "all"
+        }
+      ]
+    },
+    {
+      "id": "policy-wrong-account-keypath",
+      "description": "Rejects a registered policy when the signing account keypath does not match the device key in the policy.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000011b6e58cffa2f032e498aa516a97410d53fc282bee867fb9653192aa223bd02de0000000000ffffffff02801d2c040000000022002032001963e09213e7387b90c3374944bdbbaf69f554060bb040626f0b428f1850002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0000000001012b00e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0105475221033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2210234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de252ae22060234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de21cc5e4fe1a3000008001000080000000800300008000000000000000002206033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21c4c00739d300000800100008000000080030000800000000000000000000101475221028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a21023df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563b52ae2202023df70ec9451b9dbf9b910e974fc8f060abfe662091836e09f3acd9017c04563b1cc5e4fe1a3000008001000080000000800300008001000000000000002202028c35dddf5bd951db2bf053d944200d11f029f37af9b5255025338f7eb9aae44a1c4c00739d3000008001000080000000800300008001000000000000000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(multi(2,@0/**,@1/**))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/4'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test policy account",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/**,@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(multi(2,@0/**,@1/**))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test policy account"
+        }
+      ]
+    },
+    {
+      "id": "policy-change-index-too-high",
+      "description": "Rejects a registered policy change output at address index 10000.",
+      "coin": "tbtc",
+      "psbt": {
+        "transaction": "70736274ff01008902000000011b6e58cffa2f032e498aa516a97410d53fc282bee867fb9653192aa223bd02de0000000000ffffffff02801d2c0400000000220020bd6a0b3bc28769ca2a7ef1aa12f7c052beb977fd61a1c55a9e5a3d6cecce0cbb002d3101000000002251204a4ecb00ef0f15842f9e5ad1d6a8537694c57d1cbbb4158c2174e1a98c20ef14000000000001005e02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0100e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0000000001012b00e1f50500000000220020f5531a34c3dfbcded4d3717e6019b88c4878f964df8c9bf54b3f0256d591e7aa0105475221033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b2210234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de252ae22060234c5ed02e3e62b122655859db72a9a896aa261e8b56dc26c5ce7459ffcc08de21cc5e4fe1a3000008001000080000000800300008000000000000000002206033a1712b41eb509147fbbd80c3fac4af4ad0f0eaeaef36e6e08918002afd8e9b21c4c00739d3000008001000080000000800300008000000000000000000001014752210252631b8aca4b08e95acacae7daf3bfdad38a8651821a1009008fdd04a90d17bc210275db5c17fe98b071caf5e724752d268263106509e2bc2d3fa468168702329e9452ae22020252631b8aca4b08e95acacae7daf3bfdad38a8651821a1009008fdd04a90d17bc1c4c00739d30000080010000800000008003000080010000001027000022020275db5c17fe98b071caf5e724752d268263106509e2bc2d3fa468168702329e941cc5e4fe1a3000008001000080000000800300008001000000102700000000",
+        "options": {
+          "force_script_config": {
+            "script_config": {
+              "type": "policy",
+              "policy": "wsh(multi(2,@0/**,@1/**))",
+              "keys": [
+                {
+                  "root_fingerprint": "4c00739d",
+                  "keypath": "m/48'/1'/0'/3'",
+                  "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+                },
+                {
+                  "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+                }
+              ]
+            },
+            "keypath": "m/48'/1'/0'/3'"
+          }
+        }
+      },
+      "expected_needs_prevtxs": true,
+      "expectations": [
+        {
+          "outcome": "invalid_input",
+          "screens": [
+            {
+              "type": "confirm",
+              "title": "Spend from",
+              "body": "BTC Testnet\npolicy with\n2 keys",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Name",
+              "body": "test policy account",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "",
+              "body": "Show policy\ndetails?",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Policy",
+              "body": "wsh(multi(2,@0/**,@1/**))",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 1/2",
+              "body": "This device: [4c00739d/48'/1'/0'/3']tpubDF5MSzQdK2GfjmkNvrCZzpJhFt3if1HmrAdimugmGqWDCXYpkjxHpFZYuDxYYDAnnFMLMjLkMGvij2XV8pLtHBejgGy5RvNW4875nFGBDWv",
+              "longtouch": false
+            },
+            {
+              "type": "confirm",
+              "title": "Key 2/2",
+              "body": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y",
+              "longtouch": false
+            }
+          ]
+        }
+      ],
+      "registrations": [
+        {
+          "script_config": {
+            "type": "policy",
+            "policy": "wsh(multi(2,@0/**,@1/**))",
+            "keys": [
+              {
+                "root_fingerprint": "4c00739d",
+                "keypath": "m/48'/1'/0'/3'",
+                "xpub": "xpub6EhivkawbkKDTyZXUfDUntyKvkx4fcniJY3RRMdcvvkKTEt7gX7CfotifBsm1iDYzLpRk9pspB6g2r2sjxVePkCScgDmkPiGUAWg2ESMKNA"
+              },
+              {
+                "xpub": "tpubDFfyBnQAERJZWHv4W5rrhkpKJnPjycGzBpv8H1WgFjpkK7bVpuKw6JkeNvXqJix6csrQP3QgPZ19Yed2kbc7sniVHtNiQkX3cHsBxEqnz7Y"
+              }
+            ]
+          },
+          "name": "test policy account"
+        }
+      ]
+    }
+  ]
+}

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -119,6 +119,8 @@ firmware = []
 
 [dev-dependencies]
 async_test = { path = "../async_test" }
+bitbox-test-vectors = { path = "../bitbox-test-vectors" }
+semver = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 util = { path = "../util", features = ["testing"] }

--- a/src/rust/bitbox02-rust/Cargo.toml
+++ b/src/rust/bitbox02-rust/Cargo.toml
@@ -122,6 +122,8 @@ firmware = []
 
 [dev-dependencies]
 async_test = { path = "../async_test" }
+bitbox-test-vectors = { path = "../bitbox-test-vectors" }
+semver = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 util = { path = "../util", features = ["testing"] }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -1361,6 +1361,8 @@ mod tests {
     use crate::hal::{Memory, testing::TestingHal};
     use crate::keystore::testing::{mock_unlocked, mock_unlocked_using_mnemonic};
     use alloc::boxed::Box;
+    use alloc::collections::{BTreeMap, BTreeSet};
+    use bitbox_test_vectors::btc_transaction as btc_test_vectors;
     use hex_lit::hex;
     use pb::btc_payment_request_request::{Memo, memo};
     use util::bip32::HARDENED;
@@ -1740,6 +1742,670 @@ mod tests {
             }));
     }
 
+    fn keypath_components(keypath: &bitcoin::bip32::DerivationPath) -> Vec<u32> {
+        keypath.as_ref().iter().copied().map(u32::from).collect()
+    }
+
+    fn vector_keypath(keypath: &str) -> Vec<u32> {
+        keypath_components(&keypath.parse().unwrap())
+    }
+
+    fn vector_coin(coin: btc_test_vectors::Coin) -> pb::BtcCoin {
+        match coin {
+            btc_test_vectors::Coin::Btc => pb::BtcCoin::Btc,
+            btc_test_vectors::Coin::Tbtc => pb::BtcCoin::Tbtc,
+            btc_test_vectors::Coin::Ltc => pb::BtcCoin::Ltc,
+        }
+    }
+
+    fn vector_script_config(config: &btc_test_vectors::ScriptConfig) -> pb::BtcScriptConfig {
+        use btc_test_vectors::ScriptConfig;
+
+        let config = match config {
+            ScriptConfig::Simple { script_type } => {
+                let simple_type = match script_type {
+                    btc_test_vectors::SimpleType::P2wpkh => SimpleType::P2wpkh,
+                    btc_test_vectors::SimpleType::P2wpkhP2sh => SimpleType::P2wpkhP2sh,
+                    btc_test_vectors::SimpleType::P2tr => SimpleType::P2tr,
+                };
+                pb::btc_script_config::Config::SimpleType(simple_type as _)
+            }
+            ScriptConfig::Multisig {
+                threshold,
+                xpubs,
+                our_xpub_index,
+                script_type,
+            } => {
+                let script_type = match script_type {
+                    btc_test_vectors::MultisigScriptType::P2wsh => {
+                        pb::btc_script_config::multisig::ScriptType::P2wsh
+                    }
+                    btc_test_vectors::MultisigScriptType::P2wshP2sh => {
+                        pb::btc_script_config::multisig::ScriptType::P2wshP2sh
+                    }
+                };
+                pb::btc_script_config::Config::Multisig(pb::btc_script_config::Multisig {
+                    threshold: *threshold,
+                    xpubs: xpubs.iter().map(|xpub| parse_xpub(xpub).unwrap()).collect(),
+                    our_xpub_index: *our_xpub_index,
+                    script_type: script_type as _,
+                })
+            }
+            ScriptConfig::Policy { policy, keys } => {
+                pb::btc_script_config::Config::Policy(pb::btc_script_config::Policy {
+                    policy: policy.clone(),
+                    keys: keys
+                        .iter()
+                        .map(|key| pb::KeyOriginInfo {
+                            root_fingerprint: key
+                                .root_fingerprint
+                                .as_deref()
+                                .map(hex::decode)
+                                .transpose()
+                                .unwrap()
+                                .unwrap_or_default(),
+                            keypath: key
+                                .keypath
+                                .as_deref()
+                                .map(vector_keypath)
+                                .unwrap_or_default(),
+                            xpub: Some(parse_xpub(&key.xpub).unwrap()),
+                        })
+                        .collect(),
+                })
+            }
+        };
+        pb::BtcScriptConfig {
+            config: Some(config),
+        }
+    }
+
+    fn vector_script_config_with_keypath(
+        config: &btc_test_vectors::ScriptConfigWithKeypath,
+    ) -> pb::BtcScriptConfigWithKeypath {
+        pb::BtcScriptConfigWithKeypath {
+            script_config: Some(vector_script_config(&config.script_config)),
+            keypath: vector_keypath(&config.keypath),
+        }
+    }
+
+    fn vector_prevtx(
+        input: &btc_test_vectors::FirmwareInput,
+    ) -> (
+        u32,
+        Vec<pb::BtcPrevTxInputRequest>,
+        Vec<pb::BtcPrevTxOutputRequest>,
+        u32,
+    ) {
+        let Some(prev_tx) = input.prev_tx.as_ref() else {
+            return (0, vec![], vec![], 0);
+        };
+        let inputs = prev_tx
+            .input
+            .iter()
+            .map(|input| pb::BtcPrevTxInputRequest {
+                prev_out_hash: input.previous_output.txid.to_byte_array().to_vec(),
+                prev_out_index: input.previous_output.vout,
+                signature_script: input.script_sig.as_bytes().to_vec(),
+                sequence: input.sequence.0,
+            })
+            .collect();
+        let outputs = prev_tx
+            .output
+            .iter()
+            .map(|output| pb::BtcPrevTxOutputRequest {
+                value: output.value.to_sat(),
+                pubkey_script: output.script_pubkey.as_bytes().to_vec(),
+            })
+            .collect();
+        (
+            u32::try_from(prev_tx.version.0).unwrap(),
+            inputs,
+            outputs,
+            prev_tx.lock_time.to_consensus_u32(),
+        )
+    }
+
+    fn vector_input(
+        vector: &btc_test_vectors::TestVector,
+        input_index: usize,
+        input: &btc_test_vectors::FirmwareInput,
+    ) -> TxInput {
+        let signature = vector
+            .expected_signatures
+            .iter()
+            .find(|signature| signature.input_index == input_index);
+        let host_nonce = signature
+            .is_some_and(|signature| signature.kind == btc_test_vectors::SignatureKind::Ecdsa)
+            .then(|| vec![u8::try_from(input_index + 1).unwrap(); 32]);
+        let host_nonce_commitment =
+            host_nonce
+                .as_ref()
+                .map(|host_nonce| pb::AntiKleptoHostNonceCommitment {
+                    commitment: bitbox_secp256k1::ecdsa_anti_exfil_host_commit(
+                        SECP256K1, host_nonce,
+                    )
+                    .unwrap(),
+                });
+        let (prevtx_version, prevtx_inputs, prevtx_outputs, prevtx_locktime) = vector_prevtx(input);
+
+        TxInput {
+            input: pb::BtcSignInputRequest {
+                prev_out_hash: input.prev_out_hash.to_byte_array().to_vec(),
+                prev_out_index: input.prev_out_index,
+                prev_out_value: input.prev_out_value,
+                sequence: input.sequence,
+                keypath: keypath_components(&input.keypath),
+                script_config_index: input.script_config_index,
+                host_nonce_commitment,
+            },
+            prevtx_version,
+            prevtx_inputs,
+            prevtx_outputs,
+            prevtx_locktime,
+            host_nonce,
+        }
+    }
+
+    fn vector_output(output: &btc_test_vectors::FirmwareOutput) -> pb::BtcSignOutputRequest {
+        let output_type = match output.output_type {
+            btc_test_vectors::OutputType::Unknown => pb::BtcOutputType::Unknown,
+            btc_test_vectors::OutputType::P2pkh => pb::BtcOutputType::P2pkh,
+            btc_test_vectors::OutputType::P2sh => pb::BtcOutputType::P2sh,
+            btc_test_vectors::OutputType::P2wpkh => pb::BtcOutputType::P2wpkh,
+            btc_test_vectors::OutputType::P2wsh => pb::BtcOutputType::P2wsh,
+            btc_test_vectors::OutputType::P2tr => pb::BtcOutputType::P2tr,
+            btc_test_vectors::OutputType::OpReturn => pb::BtcOutputType::OpReturn,
+        };
+        pb::BtcSignOutputRequest {
+            ours: output.ours,
+            r#type: output_type as _,
+            value: output.value,
+            payload: output.payload.clone(),
+            keypath: output
+                .keypath
+                .as_ref()
+                .map(keypath_components)
+                .unwrap_or_default(),
+            script_config_index: output.script_config_index,
+            payment_request_index: output.payment_request_index,
+            silent_payment: output.silent_payment_address.as_ref().map(|address| {
+                pb::btc_sign_output_request::SilentPayment {
+                    address: address.clone(),
+                }
+            }),
+            output_script_config_index: output.output_script_config_index,
+        }
+    }
+
+    fn vector_payment_request(
+        request: &btc_test_vectors::PaymentRequest,
+    ) -> pb::BtcPaymentRequestRequest {
+        pb::BtcPaymentRequestRequest {
+            recipient_name: request.recipient_name.clone(),
+            memos: request
+                .memos
+                .iter()
+                .map(|memo| match memo {
+                    btc_test_vectors::PaymentRequestMemo::Text { note } => Memo {
+                        memo: Some(memo::Memo::TextMemo(memo::TextMemo { note: note.clone() })),
+                    },
+                    btc_test_vectors::PaymentRequestMemo::CoinPurchase {
+                        coin_type,
+                        amount,
+                        address,
+                        address_keypath,
+                    } => Memo {
+                        memo: Some(memo::Memo::CoinPurchaseMemo(memo::CoinPurchaseMemo {
+                            coin_type: *coin_type,
+                            amount: amount.clone(),
+                            address: address.clone(),
+                            address_derivation: Some(
+                                memo::coin_purchase_memo::AddressDerivation::Eth(
+                                    memo::coin_purchase_memo::EthAddressDerivation {
+                                        keypath: vector_keypath(address_keypath),
+                                    },
+                                ),
+                            ),
+                        })),
+                    },
+                })
+                .collect(),
+            nonce: hex::decode(&request.nonce).unwrap(),
+            total_amount: request.total_amount,
+            signature: hex::decode(&request.signature).unwrap(),
+        }
+    }
+
+    fn vector_transaction(
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+    ) -> Transaction {
+        Transaction {
+            coin: vector_coin(vector.coin),
+            total_confirmations: 0,
+            version: request.version,
+            inputs: request
+                .inputs
+                .iter()
+                .enumerate()
+                .map(|(index, input)| vector_input(vector, index, input))
+                .collect(),
+            outputs: request.outputs.iter().map(vector_output).collect(),
+            locktime: request.locktime,
+            payment_request: request.payment_requests.first().map(vector_payment_request),
+        }
+    }
+
+    fn vector_init_request(
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+    ) -> pb::BtcSignInitRequest {
+        pb::BtcSignInitRequest {
+            coin: vector_coin(vector.coin) as _,
+            script_configs: request
+                .script_configs
+                .iter()
+                .map(vector_script_config_with_keypath)
+                .collect(),
+            output_script_configs: request
+                .output_script_configs
+                .iter()
+                .map(vector_script_config_with_keypath)
+                .collect(),
+            version: request.version,
+            num_inputs: request.inputs.len() as _,
+            num_outputs: request.outputs.len() as _,
+            locktime: request.locktime,
+            format_unit: match request.format_unit {
+                btc_test_vectors::FormatUnit::Default => FormatUnit::Default,
+                btc_test_vectors::FormatUnit::Sat => FormatUnit::Sat,
+            } as _,
+            contains_silent_payment_outputs: request
+                .outputs
+                .iter()
+                .any(|output| output.silent_payment_address.is_some()),
+        }
+    }
+
+    fn register_vector_configs(hal: &mut TestingHal<'_>, vector: &btc_test_vectors::TestVector) {
+        let coin = vector_coin(vector.coin);
+        for registration in &vector.registrations {
+            let config = vector_script_config(&registration.script_config);
+            match config.config.as_ref().unwrap() {
+                pb::btc_script_config::Config::Multisig(multisig) => {
+                    let keypath = vector_keypath(registration.keypath.as_deref().unwrap());
+                    let hash = super::super::multisig::get_hash(
+                        coin,
+                        multisig,
+                        super::super::multisig::SortXpubs::Yes,
+                        &keypath,
+                    )
+                    .unwrap();
+                    hal.memory
+                        .multisig_set_by_hash(&hash, &registration.name)
+                        .unwrap();
+                }
+                pb::btc_script_config::Config::Policy(policy) => {
+                    let hash = super::super::policies::get_hash(coin, policy).unwrap();
+                    hal.memory
+                        .multisig_set_by_hash(&hash, &registration.name)
+                        .unwrap();
+                }
+                pb::btc_script_config::Config::SimpleType(_) => {
+                    panic!("simple script configs cannot be registered")
+                }
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct VectorObservations {
+        pending_request: Option<(NextType, usize)>,
+        prevtx_inputs: BTreeSet<usize>,
+        antiklepto_inputs: BTreeSet<usize>,
+        signatures: BTreeMap<usize, Vec<u8>>,
+        generated_outputs: BTreeMap<usize, Vec<u8>>,
+    }
+
+    impl VectorObservations {
+        fn observe(&mut self, response: &Response) {
+            let next = extract_next(response);
+            if let Some((request_type, index)) = self.pending_request.take() {
+                if next.has_signature {
+                    assert!(matches!(
+                        request_type,
+                        NextType::Input | NextType::HostNonce
+                    ));
+                    assert!(
+                        self.signatures
+                            .insert(index, next.signature.clone())
+                            .is_none()
+                    );
+                }
+                if !next.generated_output_pkscript.is_empty() {
+                    assert_eq!(request_type, NextType::Output);
+                    assert!(!next.silent_payment_dleq_proof.is_empty());
+                    assert!(
+                        self.generated_outputs
+                            .insert(index, next.generated_output_pkscript.clone())
+                            .is_none()
+                    );
+                } else {
+                    assert!(next.silent_payment_dleq_proof.is_empty());
+                }
+            }
+
+            let request_type = NextType::try_from(next.r#type).unwrap();
+            match request_type {
+                NextType::PrevtxInit => {
+                    self.prevtx_inputs.insert(next.index as usize);
+                }
+                NextType::HostNonce => {
+                    assert!(next.anti_klepto_signer_commitment.is_some());
+                    self.antiklepto_inputs.insert(next.index as usize);
+                }
+                _ => assert!(next.anti_klepto_signer_commitment.is_none()),
+            }
+            if request_type != NextType::Done {
+                self.pending_request = Some((request_type, next.index as usize));
+            }
+        }
+    }
+
+    fn current_vector_expectation(
+        vector: &btc_test_vectors::TestVector,
+    ) -> &btc_test_vectors::VersionExpectation {
+        let current = semver::Version::parse(
+            crate::version::FIRMWARE_VERSION_SHORT
+                .strip_prefix('v')
+                .unwrap(),
+        )
+        .unwrap();
+        vector
+            .expectations
+            .iter()
+            .find(|expectation| {
+                let after_min = expectation
+                    .min_version
+                    .as_deref()
+                    .is_none_or(|min| current >= semver::Version::parse(min).unwrap());
+                let before_max = expectation
+                    .max_version_exclusive
+                    .as_deref()
+                    .is_none_or(|max| current < semver::Version::parse(max).unwrap());
+                after_min && before_max
+            })
+            .unwrap()
+    }
+
+    fn observed_vector_screens(screens: &[Screen]) -> Vec<btc_test_vectors::Screen> {
+        screens
+            .iter()
+            .map(|screen| match screen {
+                Screen::Confirm {
+                    title,
+                    body,
+                    longtouch,
+                } => btc_test_vectors::Screen::Confirm {
+                    title: title.clone(),
+                    body: body.clone(),
+                    longtouch: *longtouch,
+                },
+                Screen::TotalFee {
+                    total,
+                    fee,
+                    longtouch,
+                } => btc_test_vectors::Screen::TransactionFee {
+                    amount: total.clone(),
+                    fee: fee.clone(),
+                    longtouch: *longtouch,
+                },
+                Screen::Swap { title, from, to } => btc_test_vectors::Screen::Swap {
+                    title: title.clone(),
+                    from: from.clone(),
+                    to: to.clone(),
+                },
+                Screen::Recipient { recipient, amount } => {
+                    btc_test_vectors::Screen::TransactionAddress {
+                        amount: amount.clone(),
+                        address: recipient.clone(),
+                    }
+                }
+                Screen::Status { title, success } => {
+                    let (title, body) = title.split_once('\n').unwrap();
+                    assert_eq!(*success, body == "confirmed");
+                    btc_test_vectors::Screen::Status {
+                        title: title.into(),
+                        body: body.into(),
+                    }
+                }
+                _ => panic!("unexpected screen in transaction vector: {screen:?}"),
+            })
+            .collect()
+    }
+
+    fn assert_vector_observations(
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+        observations: &VectorObservations,
+    ) {
+        assert!(
+            observations.pending_request.is_none(),
+            "transaction vector '{}' ended with an unanswered request",
+            vector.id
+        );
+
+        let expected_prevtx_inputs = if vector.expected_needs_prevtxs {
+            (0..request.inputs.len()).collect()
+        } else {
+            BTreeSet::new()
+        };
+        assert_eq!(
+            observations.prevtx_inputs, expected_prevtx_inputs,
+            "unexpected previous-transaction requests for vector '{}'",
+            vector.id
+        );
+
+        let expected_antiklepto_inputs: BTreeSet<_> = vector
+            .expected_signatures
+            .iter()
+            .filter(|signature| signature.kind == btc_test_vectors::SignatureKind::Ecdsa)
+            .map(|signature| signature.input_index)
+            .collect();
+        assert_eq!(
+            observations.antiklepto_inputs, expected_antiklepto_inputs,
+            "unexpected anti-klepto requests for vector '{}'",
+            vector.id
+        );
+
+        let expected_signature_inputs: BTreeSet<_> = vector
+            .expected_signatures
+            .iter()
+            .map(|signature| signature.input_index)
+            .collect();
+        assert_eq!(
+            observations
+                .signatures
+                .keys()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            expected_signature_inputs,
+            "unexpected signature inputs for vector '{}'",
+            vector.id
+        );
+        for expected in &vector.expected_signatures {
+            let signature = &observations.signatures[&expected.input_index];
+            match expected.kind {
+                btc_test_vectors::SignatureKind::Ecdsa => {
+                    bitcoin::secp256k1::ecdsa::Signature::from_compact(signature).unwrap();
+                    assert_eq!(expected.sighash, btc_test_vectors::Sighash::All);
+                }
+                btc_test_vectors::SignatureKind::TaprootKey
+                | btc_test_vectors::SignatureKind::TaprootScript => {
+                    bitcoin::secp256k1::schnorr::Signature::from_slice(signature).unwrap();
+                    assert_eq!(expected.sighash, btc_test_vectors::Sighash::Default);
+                }
+            }
+        }
+
+        let generated_outputs = observations
+            .generated_outputs
+            .iter()
+            .map(|(index, output)| (*index, hex::encode(output)))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            generated_outputs, vector.expected_generated_outputs,
+            "unexpected generated outputs for vector '{}'",
+            vector.id
+        );
+
+        assert_vector_signature_fixture(vector, observations);
+    }
+
+    fn assert_vector_signature_fixture(
+        vector: &btc_test_vectors::TestVector,
+        observations: &VectorObservations,
+    ) {
+        // Pin exact bytes only for representative signing paths. The assertions above cover the
+        // signature kind, input, sighash and anti-klepto exchange for every vector.
+        // The ECDSA fixture proves that its deterministic host nonce affected the signature;
+        // keystore::tests::test_secp256k1_antiklepto_protocol verifies the host-side check.
+        let expected = match vector.id.as_str() {
+            "high-fee-rounding" => hex!(
+                "fe00a74372509991256c691a98e42792ee8eddb2cd57f34af37fd0f1490716b11e15c53bafa7897912c11749955c5b0b2922dc136a32270637606970cb5bf27e"
+            ),
+            "policy-tr-keyspend-with-script-tree" => hex!(
+                "8ea290ef0b90388bc23380e7e017f4c412f84d106f6f55c38bd4e658932c371da64ea2e75147c3dde8bfbc0f124930ebb681a0bc34c4943d89fdcb9dc5de0a5f"
+            ),
+            "policy-tr-unspendable-internal-key-complex" => hex!(
+                "8e9c801a430d7b5b48cd8c37ae42ff150bca17abb0ee6bb4543cf144e5b96ed9a359b3e30c672d75698b99b36a20a0930c754576242c1f95dbc9fa74d93d5ae8"
+            ),
+            _ => return,
+        };
+        assert_eq!(
+            observations.signatures[&0].as_slice(),
+            expected.as_slice(),
+            "signature fixture changed for vector '{}'",
+            vector.id
+        );
+    }
+
+    async fn assert_vector_pubkeys(
+        hal: &mut TestingHal<'_>,
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+    ) {
+        for expected in &vector.expected_signatures {
+            let input = &request.inputs[expected.input_index];
+            let keypath = keypath_components(&input.keypath);
+            let xpub = crate::keystore::get_xpub(hal, &keypath, crate::keystore::Compute::Once)
+                .await
+                .unwrap();
+            let pubkey = bitcoin::secp256k1::PublicKey::from_slice(xpub.public_key()).unwrap();
+            let actual_pubkey = match expected.kind {
+                btc_test_vectors::SignatureKind::Ecdsa => hex::encode(pubkey.serialize()),
+                btc_test_vectors::SignatureKind::TaprootKey
+                | btc_test_vectors::SignatureKind::TaprootScript => {
+                    hex::encode(pubkey.x_only_public_key().0.serialize())
+                }
+            };
+            assert_eq!(
+                Some(actual_pubkey.as_str()),
+                expected.pubkey.as_deref(),
+                "unexpected pubkey for input {} of vector '{}'",
+                expected.input_index,
+                vector.id
+            );
+
+            if let Some(expected_bip352_pubkey) = &input.bip352_pubkey {
+                let bip352_pubkey = match expected.kind {
+                    btc_test_vectors::SignatureKind::Ecdsa => pubkey.serialize().to_vec(),
+                    btc_test_vectors::SignatureKind::TaprootKey
+                    | btc_test_vectors::SignatureKind::TaprootScript => {
+                        // Taproot silent-payment inputs use the tweaked key-spend private key.
+                        pubkey
+                            .x_only_public_key()
+                            .0
+                            .tap_tweak(SECP256K1, None)
+                            .0
+                            .serialize()
+                            .to_vec()
+                    }
+                };
+                assert_eq!(
+                    bip352_pubkey.as_slice(),
+                    expected_bip352_pubkey.as_slice(),
+                    "unexpected BIP352 pubkey for input {} of vector '{}'",
+                    expected.input_index,
+                    vector.id
+                );
+            }
+        }
+    }
+
+    #[async_test::test]
+    async fn test_transaction_vectors() {
+        let vectors = btc_test_vectors::test_vectors();
+
+        for vector in &vectors.vectors {
+            let sign_request = btc_test_vectors::derive_sign_request(vector).unwrap();
+            let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(vector_transaction(
+                vector,
+                &sign_request,
+            )));
+            let observations =
+                alloc::rc::Rc::new(core::cell::RefCell::new(VectorObservations::default()));
+            *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() = {
+                let transaction = transaction.clone();
+                let observations = observations.clone();
+                Some(Box::new(move |response: Response| {
+                    observations.borrow_mut().observe(&response);
+                    Ok(transaction.borrow().make_host_request(response))
+                }))
+            };
+
+            mock_unlocked_using_mnemonic(&vectors.simulator_seed, "");
+            let mut mock_hal = TestingHal::new();
+            register_vector_configs(&mut mock_hal, vector);
+            let expectation = current_vector_expectation(vector);
+            let result = process(&mut mock_hal, &vector_init_request(vector, &sign_request)).await;
+            assert_eq!(
+                observed_vector_screens(&mock_hal.ui.screens).as_slice(),
+                expectation.screens.as_slice(),
+                "unexpected screens for transaction vector '{}'",
+                vector.id
+            );
+
+            match expectation.outcome {
+                btc_test_vectors::Outcome::Success => {
+                    let response = result.unwrap_or_else(|error| {
+                        panic!("transaction vector '{}' failed: {error:?}", vector.id)
+                    });
+                    observations.borrow_mut().observe(&response);
+                    assert_vector_observations(vector, &sign_request, &observations.borrow());
+                    assert_vector_pubkeys(&mut mock_hal, vector, &sign_request).await;
+                }
+                btc_test_vectors::Outcome::InvalidInput => {
+                    let error = result.expect_err(&format!(
+                        "transaction vector '{}' unexpectedly succeeded",
+                        vector.id
+                    ));
+                    assert_eq!(
+                        error,
+                        Error::InvalidInput,
+                        "unexpected error for transaction vector '{}'",
+                        vector.id
+                    );
+                }
+                btc_test_vectors::Outcome::Unsupported => panic!(
+                    "transaction vector '{}' is unsupported by this firmware version",
+                    vector.id
+                ),
+            }
+        }
+    }
+
     #[async_test::test]
     pub async fn test_sign_init_fail() {
         *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() = None;
@@ -1993,153 +2659,6 @@ mod tests {
         }
     }
 
-    #[async_test::test]
-    pub async fn test_process() {
-        static mut UI_COUNTER: u32 = 0;
-        static mut PREVTX_REQUESTED: u32 = 0;
-
-        for (coin, format_unit) in [
-            (pb::BtcCoin::Btc, FormatUnit::Default),
-            (pb::BtcCoin::Btc, FormatUnit::Sat),
-            (pb::BtcCoin::Ltc, FormatUnit::Default),
-        ] {
-            unsafe {
-                PREVTX_REQUESTED = 0;
-            }
-
-            let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(coin)));
-
-            let tx = transaction.clone();
-            *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-                Some(Box::new(move |response: Response| {
-                    let next = extract_next(&response);
-                    if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                        unsafe { PREVTX_REQUESTED += 1 }
-                    }
-                    Ok(tx.borrow().make_host_request(response))
-                }));
-
-            mock_unlocked();
-            let mut init_request = transaction.borrow().init_request();
-            init_request.format_unit = format_unit as _;
-
-            let mut mock_hal = TestingHal::new();
-            let result = process(&mut mock_hal, &init_request).await;
-
-            assert_eq!(
-                mock_hal.ui.screens,
-                vec![
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "1.00000000 BTC".into(),
-                                FormatUnit::Sat => "100000000 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "LLnC CHbS zfwW quEd aS5T F2Yt 7uz5 Qb1S Z1".into(),
-                            amount: "1.00000000 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "12.34567890 BTC".into(),
-                                FormatUnit::Sat => "1234567890 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "MB1e 6aUe L3Zj 4s4H 2ZqF BHaa Hd7k vvzT co".into(),
-                            amount: "12.34567890 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "bc1q xven xven xven xven xven xven xven xven 2ymj t8".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "0.00006000 BTC".into(),
-                                FormatUnit::Sat => "6000 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "ltc1 qxve nxve nxve nxve nxve nxve nxve nxve nwcp knh".into(),
-                            amount: "0.00006000 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "0.00007000 BTC".into(),
-                                FormatUnit::Sat => "7000 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "ltc1 qg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z qwr7 k5s".into(),
-                            amount: "0.00007000 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    Screen::Confirm {
-                        title: "Warning".into(),
-                        body: "There are 2\nchange outputs.\nProceed?".into(),
-                        longtouch: false,
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => match format_unit {
-                            FormatUnit::Default => Screen::TotalFee {
-                                total: "13.39999900 BTC".into(),
-                                fee: "0.05419010 BTC".into(),
-                                longtouch: true,
-                            },
-                            FormatUnit::Sat => Screen::TotalFee {
-                                total: "1339999900 sat".into(),
-                                fee: "5419010 sat".into(),
-                                longtouch: true,
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::TotalFee {
-                            total: "13.39999900 LTC".into(),
-                            fee: "0.05419010 LTC".into(),
-                            longtouch: true,
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    Screen::Status {
-                        title: "Transaction\nconfirmed".into(),
-                        success: true,
-                    },
-                ],
-            );
-            match result {
-                Ok(Response::BtcSignNext(next)) => {
-                    assert!(next.has_signature);
-                    match coin {
-                        pb::BtcCoin::Btc => {
-                            assert_eq!(
-                                next.signature,
-                                hex!(
-                                    "2e084a0a5f9babb35df6ec3a89720bcfc088d4ba6aee47973c55fec3b3ddaa6007c7b11c8b5a1a6820ca74a85aeb4cf545c1b3375370f44f24d53d61fe676e4c"
-                                )
-                            );
-                        }
-                        _ => {}
-                    }
-                }
-                _ => panic!("wrong result"),
-            }
-            assert_eq!(
-                unsafe { PREVTX_REQUESTED },
-                transaction.borrow().inputs.len() as u32
-            );
-        }
-    }
-
     /// Test that receiving an unexpected message from the host results in an invalid state error.
     #[async_test::test]
     pub async fn test_invalid_state() {
@@ -2160,154 +2679,6 @@ mod tests {
         let result = process(&mut TestingHal::new(), &init_request).await;
         assert_eq!(result, Err(Error::InvalidState));
         assert_eq!(unsafe { COUNTER }, 2);
-    }
-
-    /// Test signing if all inputs are of type P2WPKH-P2SH.
-    #[async_test::test]
-    pub async fn test_script_type_p2wpkh_p2sh() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        for input in transaction.borrow_mut().inputs.iter_mut() {
-            input.input.keypath[0] = 49 + HARDENED;
-        }
-        for output in transaction.borrow_mut().outputs.iter_mut() {
-            if output.ours {
-                output.keypath[0] = 49 + HARDENED;
-            }
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let mut init_request = transaction.borrow().init_request();
-        init_request.script_configs[0] = pb::BtcScriptConfigWithKeypath {
-            script_config: Some(pb::BtcScriptConfig {
-                config: Some(pb::btc_script_config::Config::SimpleType(
-                    SimpleType::P2wpkhP2sh as _,
-                )),
-            }),
-            keypath: vec![49 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-        };
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "3a4618f6163c1d553bebc2c6ac08866d9f027ca663eea743658bb0581c4233a432984ccaeb52044f70474794c55446a5d823e1fb969a39132f7da230d2dd3375"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    /// Test signing if all inputs are of type P2TR.
-    #[async_test::test]
-    pub async fn test_script_type_p2tr() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        for input in transaction.borrow_mut().inputs.iter_mut() {
-            input.input.keypath[0] = 86 + HARDENED;
-        }
-        for output in transaction.borrow_mut().outputs.iter_mut() {
-            if output.ours {
-                output.keypath[0] = 86 + HARDENED;
-            }
-        }
-
-        let tx = transaction.clone();
-        // Check that previous transactions are not streamed, as all inputs are taproot.
-        static mut PREVTX_REQUESTED: bool = false;
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED = true }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        mock_unlocked();
-        let mut init_request = transaction.borrow().init_request();
-        init_request.script_configs[0] = pb::BtcScriptConfigWithKeypath {
-            script_config: Some(pb::BtcScriptConfig {
-                config: Some(pb::btc_script_config::Config::SimpleType(
-                    SimpleType::P2tr as _,
-                )),
-            }),
-            keypath: vec![86 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-        };
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "87f00346f53b11e03175eaf5254e3aec432bfd9585465c83fb483e8ddaf0893b0460d764711b4adf5865419d06116abc174b1578372e11fcd41cd2db18c306a7"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert!(unsafe { !PREVTX_REQUESTED });
-    }
-
-    /// Test signing if with mixed inputs, one of them being taproot. Previous transactions of all
-    /// inputs should be streamed in this case.
-    #[async_test::test]
-    pub async fn test_script_type_p2tr_mixed() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().inputs[0].input.script_config_index = 1;
-        transaction.borrow_mut().inputs[0].input.keypath[0] = 86 + HARDENED;
-
-        let tx = transaction.clone();
-        // Check that previous transactions are streamed, as not all input are taproot.
-        static mut PREVTX_REQUESTED: u32 = 0;
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED += 1 }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        mock_unlocked();
-        let mut init_request = transaction.borrow().init_request();
-        init_request
-            .script_configs
-            .push(pb::BtcScriptConfigWithKeypath {
-                script_config: Some(pb::BtcScriptConfig {
-                    config: Some(pb::btc_script_config::Config::SimpleType(
-                        SimpleType::P2tr as _,
-                    )),
-                }),
-                keypath: vec![86 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-            });
-        assert!(process(&mut TestingHal::new(), &init_request).await.is_ok());
-        assert_eq!(
-            unsafe { PREVTX_REQUESTED },
-            transaction.borrow().inputs.len() as u32
-        );
-    }
-
-    /// Test signing UTXOs with high keypath address indices. Even though we don't support verifying
-    /// receive addresses at these indices (to mitigate ransom attacks), we should still be able to
-    /// spend them.
-    #[async_test::test]
-    pub async fn test_spend_high_address_index() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().inputs[0].input.keypath[4] = 100000;
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        assert!(result.is_ok());
     }
 
     /// Test invalid input cases.
@@ -2419,29 +2790,6 @@ mod tests {
         }
     }
 
-    /// Test signing with mixed input types.
-    #[async_test::test]
-    pub async fn test_mixed_inputs() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().inputs[0].input.script_config_index = 1;
-        transaction.borrow_mut().inputs[0].input.keypath[0] = 49 + HARDENED;
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let mut init_request = transaction.borrow().init_request();
-        init_request
-            .script_configs
-            .push(pb::BtcScriptConfigWithKeypath {
-                script_config: Some(pb::BtcScriptConfig {
-                    config: Some(pb::btc_script_config::Config::SimpleType(
-                        SimpleType::P2wpkhP2sh as _,
-                    )),
-                }),
-                keypath: vec![49 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-            });
-        assert!(process(&mut TestingHal::new(), &init_request).await.is_ok());
-    }
-
     #[async_test::test]
     async fn test_user_aborts() {
         let transaction =
@@ -2458,370 +2806,6 @@ mod tests {
                 process(&mut mock_hal, &init_request).await,
                 Err(Error::UserAbort)
             );
-        }
-    }
-
-    /// Check workflow when a locktime applies.
-    #[async_test::test]
-    async fn test_locktime() {
-        struct Test {
-            coin: pb::BtcCoin,
-            locktime: u32,
-            sequence: u32,
-            // If None: no user confirmation expected.
-            // If Some: confirmation body.
-            confirm: Option<&'static str>,
-        }
-        for test_case in &[
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 0,
-                sequence: 0xffffffff,
-                confirm: None,
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 0,
-                sequence: 0xffffffff - 1,
-                confirm: None,
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 0,
-                sequence: 0xffffffff - 2,
-                confirm: None,
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 1,
-                sequence: 0xffffffff - 1,
-                confirm: Some("Locktime on block:\n1\nTransaction is not RBF"),
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 10,
-                sequence: 0xffffffff - 1,
-                confirm: Some("Locktime on block:\n10\nTransaction is not RBF"),
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 10,
-                sequence: 0xffffffff - 2,
-                confirm: Some("Locktime on block:\n10\nTransaction is RBF"),
-            },
-            Test {
-                coin: pb::BtcCoin::Ltc,
-                locktime: 10,
-                sequence: 0xffffffff - 1,
-                confirm: Some("Locktime on block:\n10\n"),
-            },
-            Test {
-                coin: pb::BtcCoin::Ltc,
-                locktime: 10,
-                sequence: 0xffffffff - 2,
-                confirm: Some("Locktime on block:\n10\n"),
-            },
-        ] {
-            let transaction =
-                alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(test_case.coin)));
-            transaction.borrow_mut().inputs[0].input.sequence = test_case.sequence;
-            mock_host_responder(transaction.clone());
-
-            mock_unlocked();
-
-            let mut init_request = transaction.borrow().init_request();
-            init_request.locktime = test_case.locktime;
-
-            let mut mock_hal = TestingHal::new();
-            let result = process(&mut mock_hal, &init_request).await;
-            let mut found_locktime = false;
-            for screen in mock_hal.ui.screens.iter() {
-                match screen {
-                    Screen::Confirm { title, body, .. } if body.contains("Locktime") => {
-                        found_locktime = true;
-                        if let Some(confirm_str) = test_case.confirm {
-                            assert_eq!(title.as_str(), "");
-                            assert_eq!(body.as_str(), confirm_str);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            assert_eq!(found_locktime, test_case.confirm.is_some());
-            assert!(result.is_ok());
-        }
-    }
-
-    // Test a transaction with an unusually high fee.
-    #[async_test::test]
-    async fn test_high_fee_warning() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().outputs[1].value = 1034567890;
-        // One more confirmation for the high fee warning.
-        transaction.borrow_mut().total_confirmations += 1;
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-        let total_confirmations = transaction.borrow().total_confirmations;
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert!(mock_hal.ui.screens.contains(&Screen::TotalFee {
-            total: "13.39999900 BTC".into(),
-            fee: "2.05419010 BTC".into(),
-            longtouch: false
-        }));
-        assert!(
-            mock_hal
-                .ui
-                .contains_confirm("High fee", "The fee is 18.1%\nthe send amount.\nProceed?")
-        );
-        assert_eq!(
-            mock_hal.ui.screens.len() as u32,
-            total_confirmations + 1 // plus status screen
-        );
-    }
-
-    // Test a P2TR output. It is not part of the default test transaction because Taproot is not
-    // active on Litecoin yet.
-    #[async_test::test]
-    async fn test_p2tr_output() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().outputs[0].r#type = pb::BtcOutputType::P2tr as _;
-        transaction.borrow_mut().outputs[0].payload =
-            hex!("a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c").to_vec();
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-
-        let mut mock_hal = TestingHal::new();
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert_eq!(
-            mock_hal.ui.screens[0],
-            Screen::Recipient {
-                recipient:
-                    "bc1p 5cyx nuxm euwu vkwf em96 lqzs zd02 n6xd cjrs 20ca c6yq jjwu dpxq kedr cr"
-                        .into(),
-                amount: "1.00000000 BTC".into(),
-            }
-        );
-
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "8f1e0e8f98d36db1196264f1a300fae317f1508d2c489fbbd660e048c4529c612f59576c86a26ffa476d97351e469ef6ed2784aecb71053a5166775ccb4d7b9b"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_silent_payment_output() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        // Make an input a P2TR input to verify the right (tweaked) private key is used in the
-        // derivation of the silent payment output.
-        transaction.borrow_mut().inputs[0].input.script_config_index = 1;
-        transaction.borrow_mut().inputs[0].input.keypath[0] = 86 + HARDENED;
-
-        // Make first output a silent payment output. type and payload
-        // are ignored.
-        transaction.borrow_mut().outputs[0].r#type = pb::BtcOutputType::Unknown as _;
-        transaction.borrow_mut().outputs[0].payload = vec![];
-        transaction.borrow_mut().outputs[0].silent_payment =
-            Some(pb::btc_sign_output_request::SilentPayment {
-                address: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv".into(),
-            });
-        let tx = transaction.clone();
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-
-                if NextType::try_from(next.r#type).unwrap() == NextType::Output && next.index == 1 {
-                    assert_eq!(
-                        next.generated_output_pkscript,
-                        hex!(
-                            "51207b9101d60c6461ff3e18f0832e7f1e952084205062d7e0b7b08812c264cfe713"
-                        )
-                    );
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-        mock_unlocked();
-
-        let mut init_request = transaction.borrow().init_request();
-        init_request
-            .script_configs
-            .push(pb::BtcScriptConfigWithKeypath {
-                script_config: Some(pb::BtcScriptConfig {
-                    config: Some(pb::btc_script_config::Config::SimpleType(
-                        pb::btc_script_config::SimpleType::P2tr as _,
-                    )),
-                }),
-                keypath: vec![86 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-            });
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens[0],
-            Screen::Recipient {
-                recipient: "sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv".into(),
-                amount: "1.00000000 BTC".into(),
-            }
-        );
-    }
-
-    #[async_test::test]
-    async fn test_silent_payment_rejects_ours_output() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        {
-            let mut tx = transaction.borrow_mut();
-            let silent_payment_output_index = 5;
-            assert!(tx.outputs[silent_payment_output_index].ours);
-            // A receive-branch self-transfer is not change, but it is still marked as ours and
-            // must not carry a silent payment address.
-            tx.outputs[silent_payment_output_index].keypath[3] = 0;
-            tx.outputs[silent_payment_output_index].silent_payment =
-                Some(pb::btc_sign_output_request::SilentPayment {
-                    address: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv".into(),
-                });
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    // Test an output that is sending to the same account, but is not a change output by keypath.
-    #[async_test::test]
-    async fn test_self_send_non_change_output_same_account() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().outputs[5].keypath[3] = 0;
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-
-        let mut mock_hal = TestingHal::new();
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert_eq!(
-            mock_hal.ui.screens[4],
-            Screen::Recipient {
-                recipient: "This BitBox (same account): bc1q nu4x 8dlr x6de ty47 gehf 4uhk 5tj3 q7yh ywgr y6".into(),
-                amount: "0.00000100 BTC".into(),
-            }
-        );
-        assert!(mock_hal.ui.screens.contains(&Screen::TotalFee {
-            total: "13.40000000 BTC".into(),
-            fee: "0.05419010 BTC".into(),
-            longtouch: true,
-        }));
-
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "e115d7d2d2b7ef068e7b89de83ec791744d46b8bae8a5931a73ef644c0db01cf2f2e2a02797a29a181fe74ea1f5d2bcaba4d70e0e7742412a680fd62957a90f7"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    // Test an output that is sending to another account of our keystore.
-    #[async_test::test]
-    async fn test_self_send_different_account() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        const DIFFERENT_ACCOUNT: u32 = 20 + HARDENED;
-        transaction.borrow_mut().outputs[5].keypath[2] = DIFFERENT_ACCOUNT;
-        transaction.borrow_mut().outputs[5].keypath[3] = 0;
-        transaction.borrow_mut().outputs[5].output_script_config_index = Some(0);
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let coin = transaction.borrow().coin;
-        let mut init_request = transaction.borrow().init_request();
-        init_request.output_script_configs = vec![pb::BtcScriptConfigWithKeypath {
-            script_config: Some(pb::BtcScriptConfig {
-                config: Some(pb::btc_script_config::Config::SimpleType(
-                    SimpleType::P2wpkh as _,
-                )),
-            }),
-            keypath: vec![
-                84 + HARDENED,
-                super::super::params::get(coin).bip44_coin,
-                DIFFERENT_ACCOUNT,
-            ],
-        }];
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens[4],
-            Screen::Recipient {
-                recipient: "This BitBox (account #21): bc1q r9t2 u35g zrtz nzv6 n99f 2dj3 7j9m sfff v78c v2".into(),
-                amount: "0.00000100 BTC".into(),
-            }
-        );
-    }
-
-    /// Exercise the antiklepto protocol
-    #[async_test::test]
-    async fn test_antiklepto() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        let host_nonce = hex!("abababababababababababababababababababababababababababababababab");
-        // The host nonce commitment value does not impact this test, but an invalid commitment
-        // would fail the antiklepto signature check on the host. The host check is skipped here and
-        // tested in keystore::tests::test_secp256k1_antiklepto_protocol. That the host nonce was included in the sig is
-        // tested by the signature fixture test below.
-        let host_nonce_commitment = pb::AntiKleptoHostNonceCommitment {
-            commitment: bitbox_secp256k1::ecdsa_anti_exfil_host_commit(SECP256K1, &host_nonce)
-                .unwrap(),
-        };
-        transaction.borrow_mut().inputs[1].host_nonce = Some(host_nonce.to_vec());
-        transaction.borrow_mut().inputs[1]
-            .input
-            .host_nonce_commitment = Some(host_nonce_commitment);
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        match result {
-            Ok(Response::Btc(pb::BtcResponse {
-                response: Some(pb::btc_response::Response::SignNext(next)),
-            })) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "2e6de654626ee912bf2e0cf5a56749891aa98956d40e29e38b8a644d5c62cfcc44e7729284ff30f9248cd70a5457b0e2324e7c473f6600432acdc8d92fb16766"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
         }
     }
 
@@ -2967,986 +2951,6 @@ mod tests {
         assert_eq!(result, Err(Error::InvalidInput));
     }
 
-    #[async_test::test]
-    async fn test_multisig_p2wsh() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-        mock_host_responder(transaction.clone());
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        // Hash of the multisig configuration as computed by `btc_common_multisig_hash_sorted()`.
-        let multisig_hash =
-            hex!("89751d19e4e26fbeee2fd2c4f56ab7ae5be6dc46482e81241f4accfbc0a1584e");
-        let mut mock_hal = TestingHal::new();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&multisig_hash, "test multisig account name")
-            .unwrap();
-
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 1,
-                                xpubs: vec![
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/2'
-                                    parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap(),
-                                    // dumb rough room report huge dry sudden hamster wait foot crew
-                                    // obvious / 48'/1'/0'/2'
-                                    parse_xpub("xpub6ERxBysTYfQyY4USv6c6J1HNVv9hpZFN9LHVPu47Ac4rK8fLy6NnAeeAHyEsMvG4G66ay5aFZii2VM7wT3KxLKX8Q8keZPd67kRGmrD1WJj").unwrap(),
-                                ],
-                                our_xpub_index: 0,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wsh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        2 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "1bee37e9123fd37fb8be2dd253ea810a021302e14962f46eeea979d96ffb4c6769d007de360f50e1de378de48e7a9fc79c47245b360daf27647529c92e86b203"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "1-of-2\nBTC Testnet multisig".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "test multisig account name".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "tb1q txyq ynfx wsk8 f5gu 8v5g 8e6h s3nj tglk ywhv yztk 6v8z nvx5 kdds mhuv e2".into(),
-                    amount: "0.00090000 TBTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Locktime on block:\n1663289\nTransaction is not RBF".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "0.00090175 TBTC".into(),
-                    fee: "0.00000175 TBTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    /// If the multisig has not been registered before, signing fails.
-    #[async_test::test]
-    async fn test_multisig_not_registered() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-        mock_host_responder(transaction.clone());
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 1,
-                                xpubs: vec![
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/2'
-                                    parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap(),
-                                    // dumb rough room report huge dry sudden hamster wait foot crew
-                                    // obvious / 48'/1'/0'/2'
-                                    parse_xpub("xpub6ERxBysTYfQyY4USv6c6J1HNVv9hpZFN9LHVPu47Ac4rK8fLy6NnAeeAHyEsMvG4G66ay5aFZii2VM7wT3KxLKX8Q8keZPd67kRGmrD1WJj").unwrap(),
-                                ],
-                                our_xpub_index: 0,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wsh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        2 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_multisig_p2wsh_p2sh() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-        for input in transaction.borrow_mut().inputs.iter_mut() {
-            input.input.keypath[3] = 1 + HARDENED;
-        }
-        for output in transaction.borrow_mut().outputs.iter_mut() {
-            if output.ours {
-                output.keypath[3] = 1 + HARDENED;
-            }
-        }
-
-        mock_host_responder(transaction.clone());
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        // Hash of the multisig configuration as computed by `btc_common_multisig_hash_sorted()`.
-        let multisig_hash =
-            hex!("a0a982a6f5ba9286ee45cd140fd763d43443d685a89bc60772553cc5418fccc4");
-        let mut mock_hal = TestingHal::new();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&multisig_hash, "test multisig account name")
-            .unwrap();
-
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 1,
-                                xpubs: vec![
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/1'
-                                    parse_xpub("xpub6EMfjyGVUvwhn1H2BwoVysVJi9cX78eyNTkoM3d26NHW4Zd75zrAcikT3dmoii4eZPwobzK4pMBYrLmE2y918UayfqBQFr6HpVze5mQHGyu").unwrap(),
-                                    // dumb rough room report huge dry sudden hamster wait foot crew
-                                    // obvious / 48'/1'/0'/1'
-                                    parse_xpub("xpub6ERxBysTYfQyV5NYAV6WZVj1dfTzESVGkWUiqERomNKCA6nCA8qX4qSLX2RRGNqckn3ps9B9sdfDkpg11nsJwCjXYXSZvkTED2Jx8jFpB9M").unwrap(),
-                                ],
-                                our_xpub_index: 0,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wshP2sh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        1 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "a72342869a29b02433faae2ac5c49f033effd3a6b60623878ef7bf8b14dee2a03a76511b37baf15e707507f48b10cdf5a8f30b0ada4da22a38a5476f69911d8e"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_multisig_large() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        // Hash of the multisig configuration as computed by `btc_common_multisig_hash_sorted()`.
-        let multisig_hash =
-            hex!("9dfc0652e2a305c8b9949620f98ee14650302e385f23941bc607cc35fd7a7781");
-        let mut mock_hal = TestingHal::new();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&multisig_hash, "test multisig account name")
-            .unwrap();
-
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 7,
-                                xpubs: vec![
-                                    parse_xpub("xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ").unwrap(),
-                                    parse_xpub("xpub6EQcxF2jFkYGn89AwoQJEEJkYMbRjED9AZgt7bkxQA5BLhZEoaQpUHcADbB5GxcMrTdDSGmjP7M3u462Q9otyE2PPam66P5KFLWitPVfYz9").unwrap(),
-                                    parse_xpub("xpub6EP4EycVS5dq1PN7ZqsxBtptkYhfLvLGokZjnB3fvPshMiAohh6E5TaJjAafZWoPRjo6uiZxhtDXLgCuk81ooQgwrsnEdfSWSfa4VUtX8nu").unwrap(),
-                                    parse_xpub("xpub6Eszd4BGGmHShcGtys5gbvV2zrBtW1gaorKf9YuvV4L3bePw7XePyyb2DKswZ5AhFfkcQwjQsiJEUTKhfRstRdHZUjQnJ2RJoQqL8g7FS4b").unwrap(),
-                                    parse_xpub("xpub6Df3nbvH6P3FTvjgKaZcSuydyEofK545U4Bb15JY8R9MtFkKrhYrc3bpEF6fHtNM7xQ1qHwsVpS56TJWUjbKcmRwPkQr17ovV2RaVSJaBq3").unwrap(),
-                                    parse_xpub("xpub6FQQ62gUYzS9wnHWHMPLWrpVnzS8xAf8XvfW1xzXEXTkTCtBrfbeww2zNeCgm3PbueMoq8opQvQDzp5Yf9EtiqVd7d1ASDoWSC1m7g1KHza").unwrap(),
-                                    parse_xpub("xpub6EQNZUUAzJAoFAVVetYUrFVrf7mLyYsnHiQihkA3KPhoRHx7m6SgKBYV4z5Rd9CvUc11ACN8Ap5Wxigt6GYRPUqXGFfm3833ezJpjAmvJKt").unwrap(),
-                                    parse_xpub("xpub6EGZy7cizYn2zUf9NT4qJ3Kr1ZrxdzPRcv2CwAnB1BTGWw7n9ZgDYvwmzzJXM6V7AgZ6CL3DrARZk5DzM9o8tz2RVTeC7QoHh9SxbW3b7Pw").unwrap(),
-                                    parse_xpub("xpub6DaV7oCAkm4HJQMoProrrKYq1RvcgpStgYUCzLRaaeJSBSy9WBRFMNnQyAWJUYy9myUFRTvogq1C2f7x4A2yhtYgr7gL6eZXv2eJvzU12pe").unwrap(),
-                                    parse_xpub("xpub6FFVRbdHt5DgHqR69KuWXRVDp93e1xKxv8rRLwhhCGnWaoF1ecnfdxpg2Nf1pvJTgT1UYg28CVt7YbUXFJL86vi9FaPN9QGtWLeCmf9dA24").unwrap(),
-                                    parse_xpub("xpub6FNywxebMjvSSginZrk7DfNmAHvPJAy3j6pJ9FmUQCoh4FKPzNymdHnkA1z77Ke4GK7g5GkdrBhpyXfWTbZkH6Yo1t4v524wDwF8SAKny9J").unwrap(),
-                                    parse_xpub("xpub6F1V9y6gXejomurTy2hN1UDCJidYahVkqtQJSZLYmcPcPDWkxGgWTrrLnCrCkGESSUSq6GpVVQx9kejPV97BEa9F85utABNL9r6xyPZFiDm").unwrap(),
-                                    parse_xpub("xpub6ECHc4kmTC2tQg2ZoAoazwyag9C4V6yFsZEhjwMJixdVNsUibot6uEvsZY38ZLVqWCtyc9gbzFEwHQLHCT8EiDDKSNNsFAB8NQYRgkiAQwu").unwrap(),
-                                    parse_xpub("xpub6F7CaxXzBCtvXwpRi61KYyhBRkgT1856ujHV5AbJK6ySCUYoDruBH6Pnsi6eHkDiuKuAJ2tSc9x3emP7aax9Dc3u7nP7RCQXEjLKihQu6w1").unwrap(),
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/2'
-                                    parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap(),
-                                ],
-                                our_xpub_index: 14,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wsh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        2 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "dbed8b1aefbdcfd7f3e6d9dff5ec83c5ed77cad7278b06c5f4d33072f300c2d613d166171c54d202415b5344a92d4f6f9b36ac314dc93e18bdcf6135de4d11bf"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_policy() {
-        let mut mock_hal = TestingHal::new();
-
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        // Check that previous transactions are streamed, as not all inputs are taproot.
-        static mut PREVTX_REQUESTED: bool = false;
-        let tx = transaction.clone();
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED = true }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "wsh(multi(2,@0/**,@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut mock_hal,
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let hash = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "5736b8eec7594ad906daf8d3fac64d58aed35fc50726b0ed6d5fb1c8019fcab0606ced7d09bc9a75fadf5ba45cc95dc15fb6796997466739a9f6383bd159dae4"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "BTC Testnet\npolicy with\n2 keys".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Name".into(),
-                    body: "test policy account name".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Show policy\ndetails?".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Policy".into(),
-                    body: "wsh(multi(2,@0/**,@1/**))".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 1/2".into(),
-                    body: "This device: [93531fa9/48'/1'/0'/3']tpubDEjJGD6BCCuA7VHrbk3gMeQ5HocbZ4eSQ121DcvCkC8xaeRFjyoJC9iVrSz1bWfNwAY5K2Vfz5bnHR3y4RrqVpkc5ikz4trfhSyosZPrcnk".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 2/2".into(),
-                    body: "tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "tb1q txyq ynfx wsk8 f5gu 8v5g 8e6h s3nj tglk ywhv yztk 6v8z nvx5 kdds mhuv e2".into(),
-                    amount: "0.00090000 TBTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Locktime on block:\n1663289\nTransaction is not RBF".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "0.00090175 TBTC".into(),
-                    fee: "0.00000175 TBTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-        assert!(unsafe { PREVTX_REQUESTED });
-    }
-
-    /// Same as `test_policy()`, but for a tr() Taproot policy.
-    /// We check that the previous transactions are not streamed as they are not needed for Taproot.
-    #[async_test::test]
-    async fn test_policy_tr() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-
-        let tx = transaction.clone();
-        // Check that previous transactions are not streamed, as all inputs are taproot.
-        static mut PREVTX_REQUESTED: bool = false;
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED = true }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "tr(@0/**,pk(@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "d2816fd56495bac5815283381775e0a0dec837a5d646a0e5602c2451ed173ffae16d10bfe391458aa9499dd908fe6ab669ef571f8a78e98ea8de27d82013a76d"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert!(unsafe { !PREVTX_REQUESTED });
-    }
-
-    // Tests that unspendable internal Taproot keys are displayed as such.
-    #[async_test::test]
-    async fn test_policy_tr_unspendable_internal_key() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-
-        mock_host_responder(transaction.clone());
-
-        let policy_str = "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})";
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: policy_str.into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubD6NzVbkrYhZ4WNrreqKvZr3qeJR7meg2BgaGP9upLkt7bp5SY6AAhY8vaN8ThfCjVcK6ZzE6kZbinszppNoGKvypeTmhyQ6uvUptXEXqknv").unwrap()),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: hex!("ffd63c8d").to_vec(),
-                    keypath: vec![48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 2 + HARDENED],
-                    xpub: Some(parse_xpub("tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N").unwrap()),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "BTC Testnet\npolicy with\n3 keys".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Name".into(),
-                    body: "test policy account name".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Show policy\ndetails?".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Policy".into(),
-                    body: policy_str.into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 1/3".into(),
-                    body: "Provably unspendable: tpubD6NzVbkrYhZ4WNrreqKvZr3qeJR7meg2BgaGP9upLkt7bp5SY6AAhY8vaN8ThfCjVcK6ZzE6kZbinszppNoGKvypeTmhyQ6uvUptXEXqknv".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 2/3".into(),
-                    body: "[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 3/3".into(),
-                    body: "This device: [93531fa9/48'/1'/0'/3']tpubDEjJGD6BCCuA7VHrbk3gMeQ5HocbZ4eSQ121DcvCkC8xaeRFjyoJC9iVrSz1bWfNwAY5K2Vfz5bnHR3y4RrqVpkc5ikz4trfhSyosZPrcnk".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "tb1q txyq ynfx wsk8 f5gu 8v5g 8e6h s3nj tglk ywhv yztk 6v8z nvx5 kdds mhuv e2".into(),
-                    amount: "0.00090000 TBTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Locktime on block:\n1663289\nTransaction is not RBF".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "0.00090175 TBTC".into(),
-                    fee: "0.00000175 TBTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    /// Test that a policy with derivations other than `/**` work.
-    #[async_test::test]
-    async fn test_policy_different_multipath_derivations() {
-        let policy_str = "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))";
-
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        transaction.borrow_mut().inputs[0].input.keypath[4] = 10; // receive path at /10/*
-        transaction.borrow_mut().outputs[0].keypath[4] = 11; // change path at /11/*
-
-        mock_host_responder(transaction.clone());
-
-        static mut UI_COUNTER: u32 = 0;
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: policy_str.into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "1c6b5465859db7dbd88f174d07a9df416d6dfa1e742903989584cd72e989d141485ad9d712df2852a6500e06856404959c010d5254353d11ab3167377ed4ee88"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_policy_wrong_account_keypath() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        mock_host_responder(transaction.clone());
-
-        static mut UI_COUNTER: u32 = 0;
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-        let wrong_keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 4 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "wsh(multi(2,@0/**,@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, wrong_keypath_account);
-        assert_eq!(
-            process(&mut mock_hal, &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    /// Avoid change keypaths with a too high address index.
-    #[async_test::test]
-    async fn test_policy_wrong_change_keypath() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        transaction.borrow_mut().outputs[0].keypath[5] = 10000; // Too high change address index.
-        mock_host_responder(transaction.clone());
-
-        static mut UI_COUNTER: u32 = 0;
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "wsh(multi(2,@0/**,@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        assert_eq!(
-            process(&mut mock_hal, &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    pub async fn test_payment_request() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        // Attach second output to a payment request.
-        {
-            let mut tx = transaction.borrow_mut();
-            // An additional confirmation for the text memo.
-            tx.total_confirmations += 3;
-            let payment_request_output_index = 1;
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::TextMemo(memo::TextMemo {
-                        note: "Test memo line1\nTest memo line2".into(),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
-            );
-            tx.payment_request = Some(payment_request);
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert!(result.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Recipient {
-                    recipient: "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH".into(),
-                    amount: "1.00000000 BTC".into(),
-                },
-                // Payment request
-                Screen::Recipient {
-                    recipient: "Test Merchant".into(),
-                    amount: "12.34567890 BTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Memo from\n\nTest Merchant".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Memo 1/2".into(),
-                    body: "Test memo line1".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Memo 2/2".into(),
-                    body: "Test memo line2".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "bc1q xven xven xven xven xven xven xven xven 2ymj t8".into(),
-                    amount: "0.00006000 BTC".into(),
-                },
-                Screen::Recipient {
-                    recipient: "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4".into(),
-                    amount: "0.00007000 BTC".into(),
-                },
-                Screen::Confirm {
-                    title: "Warning".into(),
-                    body: "There are 2\nchange outputs.\nProceed?".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "13.39999900 BTC".into(),
-                    fee: "0.05419010 BTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    #[async_test::test]
-    pub async fn test_payment_request_rejects_ours_output() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        {
-            let mut tx = transaction.borrow_mut();
-            let payment_request_output_index = 5;
-            assert!(tx.outputs[payment_request_output_index].ours);
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::TextMemo(memo::TextMemo {
-                        note: "Test memo".into(),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "bc1qnu4x8dlrx6dety47gehf4uhk5tj3q7yhywgry6",
-            );
-            tx.payment_request = Some(payment_request);
-            // A receive-branch self-transfer is not change, but it is still marked as ours and
-            // must not belong to a payment request.
-            tx.outputs[payment_request_output_index].keypath[3] = 0;
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
     #[cfg(feature = "app-ethereum")]
     #[test]
     pub fn test_validate_swap_source_account() {
@@ -4020,241 +3024,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "app-ethereum")]
-    #[async_test::test]
-    pub async fn test_swap_payment_request() {
-        // End-to-end swap signing: swap screens appear, then the regular BTC confirmations continue.
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.total_confirmations += 1;
-            let payment_request_output_index = 1;
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::CoinPurchaseMemo(memo::CoinPurchaseMemo {
-                        coin_type: 60,
-                        amount: "0.25 ETH".into(),
-                        address: "0x773A77b9D32589be03f9132AF759e294f7851be9".into(),
-                        address_derivation: Some(memo::coin_purchase_memo::AddressDerivation::Eth(
-                            memo::coin_purchase_memo::EthAddressDerivation {
-                                keypath: vec![44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                            },
-                        )),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
-            );
-            tx.payment_request = Some(payment_request);
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert!(result.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Recipient {
-                    recipient: "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH".into(),
-                    amount: "1.00000000 BTC".into(),
-                },
-                Screen::Recipient {
-                    recipient: "Test Merchant".into(),
-                    amount: "12.34567890 BTC".into(),
-                },
-                Screen::Swap {
-                    title: "Swap".into(),
-                    from: "12.34567890 BTC".into(),
-                    to: "0.25 ETH".into(),
-                },
-                Screen::Recipient {
-                    recipient: "bc1q xven xven xven xven xven xven xven xven 2ymj t8".into(),
-                    amount: "0.00006000 BTC".into(),
-                },
-                Screen::Recipient {
-                    recipient: "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4".into(),
-                    amount: "0.00007000 BTC".into(),
-                },
-                Screen::Confirm {
-                    title: "Warning".into(),
-                    body: "There are 2\nchange outputs.\nProceed?".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "13.39999900 BTC".into(),
-                    fee: "0.05419010 BTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    #[cfg(feature = "app-ethereum")]
-    #[async_test::test]
-    pub async fn test_swap_payment_request_unsupported_source_coin() {
-        // Swap UI is restricted to BTC/LTC source accounts; other BTC-like coins must fail early.
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(
-            pb::BtcCoin::Tbtc,
-        )));
-
-        {
-            let mut tx = transaction.borrow_mut();
-            let payment_request_output_index = 1;
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::CoinPurchaseMemo(memo::CoinPurchaseMemo {
-                        coin_type: 60,
-                        amount: "0.25 ETH".into(),
-                        address: "0x773A77b9D32589be03f9132AF759e294f7851be9".into(),
-                        address_derivation: Some(memo::coin_purchase_memo::AddressDerivation::Eth(
-                            memo::coin_purchase_memo::EthAddressDerivation {
-                                keypath: vec![44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                            },
-                        )),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "2MvdL2uD2Ubr4Zx8e6CQqNQEHjQ75sGH1NN",
-            );
-            tx.payment_request = Some(payment_request);
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        // Attach OP_RETURN output
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 0,
-                payload: b"hello world".to_vec(),
-                ..Default::default()
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "f49c71b89ec3510ebebae9aff9f967ad9bb6cc0c4cddbdf851f97e47e9922646622459e522b0751fa246e49a8e48417344a5384a9f68c1c85cd03804b35e1e1e"
-                    ),
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-
-        assert!(mock_hal.ui.contains_confirm("OP_RETURN", "hello world"));
-    }
-
-    #[async_test::test]
-    async fn test_op_return_nonascii() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        // Attach OP_RETURN output
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 0,
-                payload: vec![1, 2, 3, 4, 5],
-                ..Default::default()
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert!(result.is_ok());
-
-        assert!(
-            mock_hal
-                .ui
-                .contains_confirm("OP_RETURN\ndata (hex)", "0102030405")
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return_fail_nonzero_value() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        // Attach OP_RETURN output
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 100,
-                payload: b"hello world".to_vec(),
-                ..Default::default()
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        assert_eq!(
-            process(&mut mock_hal, &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
     #[async_test::test]
     async fn test_op_return_rejects_ours_output() {
         let transaction =
@@ -4268,57 +3037,6 @@ mod tests {
             tx.outputs[output_index].value = 0;
             tx.outputs[output_index].payload = b"hello world".to_vec();
             tx.outputs[output_index].keypath[3] = 0;
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return_rejects_silent_payment_output() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs[0].r#type = pb::BtcOutputType::OpReturn as _;
-            tx.outputs[0].value = 0;
-            tx.outputs[0].payload = b"hello world".to_vec();
-            tx.outputs[0].silent_payment = Some(pb::btc_sign_output_request::SilentPayment {
-                address: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv".into(),
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return_rejects_payment_request_output() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 0,
-                payload: b"hello world".to_vec(),
-                payment_request_index: Some(0),
-                ..Default::default()
-            });
         }
 
         mock_host_responder(transaction.clone());

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -1383,6 +1383,7 @@ mod tests {
     use alloc::collections::{BTreeMap, BTreeSet};
     use bitbox_test_vectors::btc_transaction as btc_test_vectors;
     use hex_lit::hex;
+    use miniscript::psbt::PsbtExt;
     use pb::btc_payment_request_request::{Memo, memo};
     use util::bip32::HARDENED;
 
@@ -2390,6 +2391,88 @@ mod tests {
         );
     }
 
+    /// Adds firmware responses to the vector PSBT and checks that the transaction, including its
+    /// signatures, is valid.
+    fn assert_vector_transaction_valid(
+        vector: &btc_test_vectors::TestVector,
+        observations: &VectorObservations,
+    ) {
+        let serialized = hex::decode(&vector.psbt.transaction).unwrap_or_else(|error| {
+            panic!(
+                "transaction vector '{}' contains invalid PSBT hex: {error}",
+                vector.id
+            )
+        });
+        let mut psbt = bitcoin::psbt::Psbt::deserialize(&serialized).unwrap_or_else(|error| {
+            panic!(
+                "transaction vector '{}' contains an invalid PSBT: {error}",
+                vector.id
+            )
+        });
+
+        for (index, pkscript) in &observations.generated_outputs {
+            psbt.unsigned_tx.output[*index].script_pubkey =
+                bitcoin::ScriptBuf::from_bytes(pkscript.clone());
+        }
+
+        for expected in &vector.expected_signatures {
+            let signature = &observations.signatures[&expected.input_index];
+            let input = &mut psbt.inputs[expected.input_index];
+            match expected.kind {
+                btc_test_vectors::SignatureKind::Ecdsa => {
+                    let pubkey = expected
+                        .pubkey
+                        .as_deref()
+                        .unwrap()
+                        .parse::<bitcoin::PublicKey>()
+                        .unwrap();
+                    let signature = bitcoin::ecdsa::Signature::sighash_all(
+                        bitcoin::secp256k1::ecdsa::Signature::from_compact(signature).unwrap(),
+                    );
+                    assert!(input.partial_sigs.insert(pubkey, signature).is_none());
+                }
+                btc_test_vectors::SignatureKind::TaprootKey => {
+                    assert!(input.tap_key_sig.is_none());
+                    input.tap_key_sig =
+                        Some(bitcoin::taproot::Signature::from_slice(signature).unwrap());
+                }
+                btc_test_vectors::SignatureKind::TaprootScript => {
+                    let pubkey = expected
+                        .pubkey
+                        .as_deref()
+                        .unwrap()
+                        .parse::<bitcoin::secp256k1::XOnlyPublicKey>()
+                        .unwrap();
+                    let leaf_hash = bitcoin::TapLeafHash::from_slice(
+                        &hex::decode(expected.leaf_hash.as_deref().unwrap()).unwrap(),
+                    )
+                    .unwrap();
+                    let signature = bitcoin::taproot::Signature::from_slice(signature).unwrap();
+                    assert!(
+                        input
+                            .tap_script_sigs
+                            .insert((pubkey, leaf_hash), signature)
+                            .is_none()
+                    );
+                }
+            }
+        }
+
+        let secp = bitcoin::secp256k1::Secp256k1::verification_only();
+        psbt.finalize_mut(&secp).unwrap_or_else(|errors| {
+            panic!(
+                "transaction vector '{}' failed PSBT finalization: {errors:?}",
+                vector.id
+            )
+        });
+        miniscript::psbt::interpreter_check(&psbt, &secp).unwrap_or_else(|error| {
+            panic!(
+                "transaction vector '{}' failed script verification: {error:?}",
+                vector.id
+            )
+        });
+    }
+
     async fn assert_vector_pubkeys(
         hal: &mut TestingHal<'_>,
         vector: &btc_test_vectors::TestVector,
@@ -2482,7 +2565,11 @@ mod tests {
                         panic!("transaction vector '{}' failed: {error:?}", vector.id)
                     });
                     observations.borrow_mut().observe(&response);
-                    assert_vector_observations(vector, &sign_request, &observations.borrow());
+                    {
+                        let observations = observations.borrow();
+                        assert_vector_observations(vector, &sign_request, &observations);
+                        assert_vector_transaction_valid(vector, &observations);
+                    }
                     assert_vector_pubkeys(&mut mock_hal, vector, &sign_request).await;
                 }
                 btc_test_vectors::Outcome::InvalidInput => {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -1364,6 +1364,7 @@ mod tests {
     use alloc::collections::{BTreeMap, BTreeSet};
     use bitbox_test_vectors::btc_transaction as btc_test_vectors;
     use hex_lit::hex;
+    use miniscript::psbt::PsbtExt;
     use pb::btc_payment_request_request::{Memo, memo};
     use util::bip32::HARDENED;
 
@@ -2291,6 +2292,88 @@ mod tests {
         );
     }
 
+    /// Adds firmware responses to the vector PSBT and checks that the transaction, including its
+    /// signatures, is valid.
+    fn assert_vector_transaction_valid(
+        vector: &btc_test_vectors::TestVector,
+        observations: &VectorObservations,
+    ) {
+        let serialized = hex::decode(&vector.psbt.transaction).unwrap_or_else(|error| {
+            panic!(
+                "transaction vector '{}' contains invalid PSBT hex: {error}",
+                vector.id
+            )
+        });
+        let mut psbt = bitcoin::psbt::Psbt::deserialize(&serialized).unwrap_or_else(|error| {
+            panic!(
+                "transaction vector '{}' contains an invalid PSBT: {error}",
+                vector.id
+            )
+        });
+
+        for (index, pkscript) in &observations.generated_outputs {
+            psbt.unsigned_tx.output[*index].script_pubkey =
+                bitcoin::ScriptBuf::from_bytes(pkscript.clone());
+        }
+
+        for expected in &vector.expected_signatures {
+            let signature = &observations.signatures[&expected.input_index];
+            let input = &mut psbt.inputs[expected.input_index];
+            match expected.kind {
+                btc_test_vectors::SignatureKind::Ecdsa => {
+                    let pubkey = expected
+                        .pubkey
+                        .as_deref()
+                        .unwrap()
+                        .parse::<bitcoin::PublicKey>()
+                        .unwrap();
+                    let signature = bitcoin::ecdsa::Signature::sighash_all(
+                        bitcoin::secp256k1::ecdsa::Signature::from_compact(signature).unwrap(),
+                    );
+                    assert!(input.partial_sigs.insert(pubkey, signature).is_none());
+                }
+                btc_test_vectors::SignatureKind::TaprootKey => {
+                    assert!(input.tap_key_sig.is_none());
+                    input.tap_key_sig =
+                        Some(bitcoin::taproot::Signature::from_slice(signature).unwrap());
+                }
+                btc_test_vectors::SignatureKind::TaprootScript => {
+                    let pubkey = expected
+                        .pubkey
+                        .as_deref()
+                        .unwrap()
+                        .parse::<bitcoin::secp256k1::XOnlyPublicKey>()
+                        .unwrap();
+                    let leaf_hash = bitcoin::TapLeafHash::from_slice(
+                        &hex::decode(expected.leaf_hash.as_deref().unwrap()).unwrap(),
+                    )
+                    .unwrap();
+                    let signature = bitcoin::taproot::Signature::from_slice(signature).unwrap();
+                    assert!(
+                        input
+                            .tap_script_sigs
+                            .insert((pubkey, leaf_hash), signature)
+                            .is_none()
+                    );
+                }
+            }
+        }
+
+        let secp = bitcoin::secp256k1::Secp256k1::verification_only();
+        psbt.finalize_mut(&secp).unwrap_or_else(|errors| {
+            panic!(
+                "transaction vector '{}' failed PSBT finalization: {errors:?}",
+                vector.id
+            )
+        });
+        miniscript::psbt::interpreter_check(&psbt, &secp).unwrap_or_else(|error| {
+            panic!(
+                "transaction vector '{}' failed script verification: {error:?}",
+                vector.id
+            )
+        });
+    }
+
     async fn assert_vector_pubkeys(
         hal: &mut TestingHal<'_>,
         vector: &btc_test_vectors::TestVector,
@@ -2383,7 +2466,11 @@ mod tests {
                         panic!("transaction vector '{}' failed: {error:?}", vector.id)
                     });
                     observations.borrow_mut().observe(&response);
-                    assert_vector_observations(vector, &sign_request, &observations.borrow());
+                    {
+                        let observations = observations.borrow();
+                        assert_vector_observations(vector, &sign_request, &observations);
+                        assert_vector_transaction_valid(vector, &observations);
+                    }
                     assert_vector_pubkeys(&mut mock_hal, vector, &sign_request).await;
                 }
                 btc_test_vectors::Outcome::InvalidInput => {

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -1380,6 +1380,8 @@ mod tests {
     use crate::hal::{Memory, testing::TestingHal};
     use crate::keystore::testing::{mock_unlocked, mock_unlocked_using_mnemonic};
     use alloc::boxed::Box;
+    use alloc::collections::{BTreeMap, BTreeSet};
+    use bitbox_test_vectors::btc_transaction as btc_test_vectors;
     use hex_lit::hex;
     use pb::btc_payment_request_request::{Memo, memo};
     use util::bip32::HARDENED;
@@ -1839,6 +1841,670 @@ mod tests {
             }));
     }
 
+    fn keypath_components(keypath: &bitcoin::bip32::DerivationPath) -> Vec<u32> {
+        keypath.as_ref().iter().copied().map(u32::from).collect()
+    }
+
+    fn vector_keypath(keypath: &str) -> Vec<u32> {
+        keypath_components(&keypath.parse().unwrap())
+    }
+
+    fn vector_coin(coin: btc_test_vectors::Coin) -> pb::BtcCoin {
+        match coin {
+            btc_test_vectors::Coin::Btc => pb::BtcCoin::Btc,
+            btc_test_vectors::Coin::Tbtc => pb::BtcCoin::Tbtc,
+            btc_test_vectors::Coin::Ltc => pb::BtcCoin::Ltc,
+        }
+    }
+
+    fn vector_script_config(config: &btc_test_vectors::ScriptConfig) -> pb::BtcScriptConfig {
+        use btc_test_vectors::ScriptConfig;
+
+        let config = match config {
+            ScriptConfig::Simple { script_type } => {
+                let simple_type = match script_type {
+                    btc_test_vectors::SimpleType::P2wpkh => SimpleType::P2wpkh,
+                    btc_test_vectors::SimpleType::P2wpkhP2sh => SimpleType::P2wpkhP2sh,
+                    btc_test_vectors::SimpleType::P2tr => SimpleType::P2tr,
+                };
+                pb::btc_script_config::Config::SimpleType(simple_type as _)
+            }
+            ScriptConfig::Multisig {
+                threshold,
+                xpubs,
+                our_xpub_index,
+                script_type,
+            } => {
+                let script_type = match script_type {
+                    btc_test_vectors::MultisigScriptType::P2wsh => {
+                        pb::btc_script_config::multisig::ScriptType::P2wsh
+                    }
+                    btc_test_vectors::MultisigScriptType::P2wshP2sh => {
+                        pb::btc_script_config::multisig::ScriptType::P2wshP2sh
+                    }
+                };
+                pb::btc_script_config::Config::Multisig(pb::btc_script_config::Multisig {
+                    threshold: *threshold,
+                    xpubs: xpubs.iter().map(|xpub| parse_xpub(xpub).unwrap()).collect(),
+                    our_xpub_index: *our_xpub_index,
+                    script_type: script_type as _,
+                })
+            }
+            ScriptConfig::Policy { policy, keys } => {
+                pb::btc_script_config::Config::Policy(pb::btc_script_config::Policy {
+                    policy: policy.clone(),
+                    keys: keys
+                        .iter()
+                        .map(|key| pb::KeyOriginInfo {
+                            root_fingerprint: key
+                                .root_fingerprint
+                                .as_deref()
+                                .map(hex::decode)
+                                .transpose()
+                                .unwrap()
+                                .unwrap_or_default(),
+                            keypath: key
+                                .keypath
+                                .as_deref()
+                                .map(vector_keypath)
+                                .unwrap_or_default(),
+                            xpub: Some(parse_xpub(&key.xpub).unwrap()),
+                        })
+                        .collect(),
+                })
+            }
+        };
+        pb::BtcScriptConfig {
+            config: Some(config),
+        }
+    }
+
+    fn vector_script_config_with_keypath(
+        config: &btc_test_vectors::ScriptConfigWithKeypath,
+    ) -> pb::BtcScriptConfigWithKeypath {
+        pb::BtcScriptConfigWithKeypath {
+            script_config: Some(vector_script_config(&config.script_config)),
+            keypath: vector_keypath(&config.keypath),
+        }
+    }
+
+    fn vector_prevtx(
+        input: &btc_test_vectors::FirmwareInput,
+    ) -> (
+        u32,
+        Vec<pb::BtcPrevTxInputRequest>,
+        Vec<pb::BtcPrevTxOutputRequest>,
+        u32,
+    ) {
+        let Some(prev_tx) = input.prev_tx.as_ref() else {
+            return (0, vec![], vec![], 0);
+        };
+        let inputs = prev_tx
+            .input
+            .iter()
+            .map(|input| pb::BtcPrevTxInputRequest {
+                prev_out_hash: input.previous_output.txid.to_byte_array().to_vec(),
+                prev_out_index: input.previous_output.vout,
+                signature_script: input.script_sig.as_bytes().to_vec(),
+                sequence: input.sequence.0,
+            })
+            .collect();
+        let outputs = prev_tx
+            .output
+            .iter()
+            .map(|output| pb::BtcPrevTxOutputRequest {
+                value: output.value.to_sat(),
+                pubkey_script: output.script_pubkey.as_bytes().to_vec(),
+            })
+            .collect();
+        (
+            u32::try_from(prev_tx.version.0).unwrap(),
+            inputs,
+            outputs,
+            prev_tx.lock_time.to_consensus_u32(),
+        )
+    }
+
+    fn vector_input(
+        vector: &btc_test_vectors::TestVector,
+        input_index: usize,
+        input: &btc_test_vectors::FirmwareInput,
+    ) -> TxInput {
+        let signature = vector
+            .expected_signatures
+            .iter()
+            .find(|signature| signature.input_index == input_index);
+        let host_nonce = signature
+            .is_some_and(|signature| signature.kind == btc_test_vectors::SignatureKind::Ecdsa)
+            .then(|| vec![u8::try_from(input_index + 1).unwrap(); 32]);
+        let host_nonce_commitment =
+            host_nonce
+                .as_ref()
+                .map(|host_nonce| pb::AntiKleptoHostNonceCommitment {
+                    commitment: bitbox_secp256k1::ecdsa_anti_exfil_host_commit(
+                        SECP256K1, host_nonce,
+                    )
+                    .unwrap(),
+                });
+        let (prevtx_version, prevtx_inputs, prevtx_outputs, prevtx_locktime) = vector_prevtx(input);
+
+        TxInput {
+            input: pb::BtcSignInputRequest {
+                prev_out_hash: input.prev_out_hash.to_byte_array().to_vec(),
+                prev_out_index: input.prev_out_index,
+                prev_out_value: input.prev_out_value,
+                sequence: input.sequence,
+                keypath: keypath_components(&input.keypath),
+                script_config_index: input.script_config_index,
+                host_nonce_commitment,
+            },
+            prevtx_version,
+            prevtx_inputs,
+            prevtx_outputs,
+            prevtx_locktime,
+            host_nonce,
+        }
+    }
+
+    fn vector_output(output: &btc_test_vectors::FirmwareOutput) -> pb::BtcSignOutputRequest {
+        let output_type = match output.output_type {
+            btc_test_vectors::OutputType::Unknown => pb::BtcOutputType::Unknown,
+            btc_test_vectors::OutputType::P2pkh => pb::BtcOutputType::P2pkh,
+            btc_test_vectors::OutputType::P2sh => pb::BtcOutputType::P2sh,
+            btc_test_vectors::OutputType::P2wpkh => pb::BtcOutputType::P2wpkh,
+            btc_test_vectors::OutputType::P2wsh => pb::BtcOutputType::P2wsh,
+            btc_test_vectors::OutputType::P2tr => pb::BtcOutputType::P2tr,
+            btc_test_vectors::OutputType::OpReturn => pb::BtcOutputType::OpReturn,
+        };
+        pb::BtcSignOutputRequest {
+            ours: output.ours,
+            r#type: output_type as _,
+            value: output.value,
+            payload: output.payload.clone(),
+            keypath: output
+                .keypath
+                .as_ref()
+                .map(keypath_components)
+                .unwrap_or_default(),
+            script_config_index: output.script_config_index,
+            payment_request_index: output.payment_request_index,
+            silent_payment: output.silent_payment_address.as_ref().map(|address| {
+                pb::btc_sign_output_request::SilentPayment {
+                    address: address.clone(),
+                }
+            }),
+            output_script_config_index: output.output_script_config_index,
+        }
+    }
+
+    fn vector_payment_request(
+        request: &btc_test_vectors::PaymentRequest,
+    ) -> pb::BtcPaymentRequestRequest {
+        pb::BtcPaymentRequestRequest {
+            recipient_name: request.recipient_name.clone(),
+            memos: request
+                .memos
+                .iter()
+                .map(|memo| match memo {
+                    btc_test_vectors::PaymentRequestMemo::Text { note } => Memo {
+                        memo: Some(memo::Memo::TextMemo(memo::TextMemo { note: note.clone() })),
+                    },
+                    btc_test_vectors::PaymentRequestMemo::CoinPurchase {
+                        coin_type,
+                        amount,
+                        address,
+                        address_keypath,
+                    } => Memo {
+                        memo: Some(memo::Memo::CoinPurchaseMemo(memo::CoinPurchaseMemo {
+                            coin_type: *coin_type,
+                            amount: amount.clone(),
+                            address: address.clone(),
+                            address_derivation: Some(
+                                memo::coin_purchase_memo::AddressDerivation::Eth(
+                                    memo::coin_purchase_memo::EthAddressDerivation {
+                                        keypath: vector_keypath(address_keypath),
+                                    },
+                                ),
+                            ),
+                        })),
+                    },
+                })
+                .collect(),
+            nonce: hex::decode(&request.nonce).unwrap(),
+            total_amount: request.total_amount,
+            signature: hex::decode(&request.signature).unwrap(),
+        }
+    }
+
+    fn vector_transaction(
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+    ) -> Transaction {
+        Transaction {
+            coin: vector_coin(vector.coin),
+            total_confirmations: 0,
+            version: request.version,
+            inputs: request
+                .inputs
+                .iter()
+                .enumerate()
+                .map(|(index, input)| vector_input(vector, index, input))
+                .collect(),
+            outputs: request.outputs.iter().map(vector_output).collect(),
+            locktime: request.locktime,
+            payment_request: request.payment_requests.first().map(vector_payment_request),
+        }
+    }
+
+    fn vector_init_request(
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+    ) -> pb::BtcSignInitRequest {
+        pb::BtcSignInitRequest {
+            coin: vector_coin(vector.coin) as _,
+            script_configs: request
+                .script_configs
+                .iter()
+                .map(vector_script_config_with_keypath)
+                .collect(),
+            output_script_configs: request
+                .output_script_configs
+                .iter()
+                .map(vector_script_config_with_keypath)
+                .collect(),
+            version: request.version,
+            num_inputs: request.inputs.len() as _,
+            num_outputs: request.outputs.len() as _,
+            locktime: request.locktime,
+            format_unit: match request.format_unit {
+                btc_test_vectors::FormatUnit::Default => FormatUnit::Default,
+                btc_test_vectors::FormatUnit::Sat => FormatUnit::Sat,
+            } as _,
+            contains_silent_payment_outputs: request
+                .outputs
+                .iter()
+                .any(|output| output.silent_payment_address.is_some()),
+        }
+    }
+
+    fn register_vector_configs(hal: &mut TestingHal<'_>, vector: &btc_test_vectors::TestVector) {
+        let coin = vector_coin(vector.coin);
+        for registration in &vector.registrations {
+            let config = vector_script_config(&registration.script_config);
+            match config.config.as_ref().unwrap() {
+                pb::btc_script_config::Config::Multisig(multisig) => {
+                    let keypath = vector_keypath(registration.keypath.as_deref().unwrap());
+                    let hash = super::super::multisig::get_hash(
+                        coin,
+                        multisig,
+                        super::super::multisig::SortXpubs::Yes,
+                        &keypath,
+                    )
+                    .unwrap();
+                    hal.memory
+                        .multisig_set_by_hash(&hash, &registration.name)
+                        .unwrap();
+                }
+                pb::btc_script_config::Config::Policy(policy) => {
+                    let hash = super::super::policies::get_hash(coin, policy).unwrap();
+                    hal.memory
+                        .multisig_set_by_hash(&hash, &registration.name)
+                        .unwrap();
+                }
+                pb::btc_script_config::Config::SimpleType(_) => {
+                    panic!("simple script configs cannot be registered")
+                }
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct VectorObservations {
+        pending_request: Option<(NextType, usize)>,
+        prevtx_inputs: BTreeSet<usize>,
+        antiklepto_inputs: BTreeSet<usize>,
+        signatures: BTreeMap<usize, Vec<u8>>,
+        generated_outputs: BTreeMap<usize, Vec<u8>>,
+    }
+
+    impl VectorObservations {
+        fn observe(&mut self, response: &Response) {
+            let next = extract_next(response);
+            if let Some((request_type, index)) = self.pending_request.take() {
+                if next.has_signature {
+                    assert!(matches!(
+                        request_type,
+                        NextType::Input | NextType::HostNonce
+                    ));
+                    assert!(
+                        self.signatures
+                            .insert(index, next.signature.clone())
+                            .is_none()
+                    );
+                }
+                if !next.generated_output_pkscript.is_empty() {
+                    assert_eq!(request_type, NextType::Output);
+                    assert!(!next.silent_payment_dleq_proof.is_empty());
+                    assert!(
+                        self.generated_outputs
+                            .insert(index, next.generated_output_pkscript.clone())
+                            .is_none()
+                    );
+                } else {
+                    assert!(next.silent_payment_dleq_proof.is_empty());
+                }
+            }
+
+            let request_type = NextType::try_from(next.r#type).unwrap();
+            match request_type {
+                NextType::PrevtxInit => {
+                    self.prevtx_inputs.insert(next.index as usize);
+                }
+                NextType::HostNonce => {
+                    assert!(next.anti_klepto_signer_commitment.is_some());
+                    self.antiklepto_inputs.insert(next.index as usize);
+                }
+                _ => assert!(next.anti_klepto_signer_commitment.is_none()),
+            }
+            if request_type != NextType::Done {
+                self.pending_request = Some((request_type, next.index as usize));
+            }
+        }
+    }
+
+    fn current_vector_expectation(
+        vector: &btc_test_vectors::TestVector,
+    ) -> &btc_test_vectors::VersionExpectation {
+        let current = semver::Version::parse(
+            crate::version::FIRMWARE_VERSION_SHORT
+                .strip_prefix('v')
+                .unwrap(),
+        )
+        .unwrap();
+        vector
+            .expectations
+            .iter()
+            .find(|expectation| {
+                let after_min = expectation
+                    .min_version
+                    .as_deref()
+                    .is_none_or(|min| current >= semver::Version::parse(min).unwrap());
+                let before_max = expectation
+                    .max_version_exclusive
+                    .as_deref()
+                    .is_none_or(|max| current < semver::Version::parse(max).unwrap());
+                after_min && before_max
+            })
+            .unwrap()
+    }
+
+    fn observed_vector_screens(screens: &[Screen]) -> Vec<btc_test_vectors::Screen> {
+        screens
+            .iter()
+            .map(|screen| match screen {
+                Screen::Confirm {
+                    title,
+                    body,
+                    longtouch,
+                } => btc_test_vectors::Screen::Confirm {
+                    title: title.clone(),
+                    body: body.clone(),
+                    longtouch: *longtouch,
+                },
+                Screen::TotalFee {
+                    total,
+                    fee,
+                    longtouch,
+                } => btc_test_vectors::Screen::TransactionFee {
+                    amount: total.clone(),
+                    fee: fee.clone(),
+                    longtouch: *longtouch,
+                },
+                Screen::Swap { title, from, to } => btc_test_vectors::Screen::Swap {
+                    title: title.clone(),
+                    from: from.clone(),
+                    to: to.clone(),
+                },
+                Screen::Recipient { recipient, amount } => {
+                    btc_test_vectors::Screen::TransactionAddress {
+                        amount: amount.clone(),
+                        address: recipient.clone(),
+                    }
+                }
+                Screen::Status { title, success } => {
+                    let (title, body) = title.split_once('\n').unwrap();
+                    assert_eq!(*success, body == "confirmed");
+                    btc_test_vectors::Screen::Status {
+                        title: title.into(),
+                        body: body.into(),
+                    }
+                }
+                _ => panic!("unexpected screen in transaction vector: {screen:?}"),
+            })
+            .collect()
+    }
+
+    fn assert_vector_observations(
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+        observations: &VectorObservations,
+    ) {
+        assert!(
+            observations.pending_request.is_none(),
+            "transaction vector '{}' ended with an unanswered request",
+            vector.id
+        );
+
+        let expected_prevtx_inputs = if vector.expected_needs_prevtxs {
+            (0..request.inputs.len()).collect()
+        } else {
+            BTreeSet::new()
+        };
+        assert_eq!(
+            observations.prevtx_inputs, expected_prevtx_inputs,
+            "unexpected previous-transaction requests for vector '{}'",
+            vector.id
+        );
+
+        let expected_antiklepto_inputs: BTreeSet<_> = vector
+            .expected_signatures
+            .iter()
+            .filter(|signature| signature.kind == btc_test_vectors::SignatureKind::Ecdsa)
+            .map(|signature| signature.input_index)
+            .collect();
+        assert_eq!(
+            observations.antiklepto_inputs, expected_antiklepto_inputs,
+            "unexpected anti-klepto requests for vector '{}'",
+            vector.id
+        );
+
+        let expected_signature_inputs: BTreeSet<_> = vector
+            .expected_signatures
+            .iter()
+            .map(|signature| signature.input_index)
+            .collect();
+        assert_eq!(
+            observations
+                .signatures
+                .keys()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            expected_signature_inputs,
+            "unexpected signature inputs for vector '{}'",
+            vector.id
+        );
+        for expected in &vector.expected_signatures {
+            let signature = &observations.signatures[&expected.input_index];
+            match expected.kind {
+                btc_test_vectors::SignatureKind::Ecdsa => {
+                    bitcoin::secp256k1::ecdsa::Signature::from_compact(signature).unwrap();
+                    assert_eq!(expected.sighash, btc_test_vectors::Sighash::All);
+                }
+                btc_test_vectors::SignatureKind::TaprootKey
+                | btc_test_vectors::SignatureKind::TaprootScript => {
+                    bitcoin::secp256k1::schnorr::Signature::from_slice(signature).unwrap();
+                    assert_eq!(expected.sighash, btc_test_vectors::Sighash::Default);
+                }
+            }
+        }
+
+        let generated_outputs = observations
+            .generated_outputs
+            .iter()
+            .map(|(index, output)| (*index, hex::encode(output)))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            generated_outputs, vector.expected_generated_outputs,
+            "unexpected generated outputs for vector '{}'",
+            vector.id
+        );
+
+        assert_vector_signature_fixture(vector, observations);
+    }
+
+    fn assert_vector_signature_fixture(
+        vector: &btc_test_vectors::TestVector,
+        observations: &VectorObservations,
+    ) {
+        // Pin exact bytes only for representative signing paths. The assertions above cover the
+        // signature kind, input, sighash and anti-klepto exchange for every vector.
+        // The ECDSA fixture proves that its deterministic host nonce affected the signature;
+        // keystore::tests::test_secp256k1_antiklepto_protocol verifies the host-side check.
+        let expected = match vector.id.as_str() {
+            "high-fee-rounding" => hex!(
+                "fe00a74372509991256c691a98e42792ee8eddb2cd57f34af37fd0f1490716b11e15c53bafa7897912c11749955c5b0b2922dc136a32270637606970cb5bf27e"
+            ),
+            "policy-tr-keyspend-with-script-tree" => hex!(
+                "8ea290ef0b90388bc23380e7e017f4c412f84d106f6f55c38bd4e658932c371da64ea2e75147c3dde8bfbc0f124930ebb681a0bc34c4943d89fdcb9dc5de0a5f"
+            ),
+            "policy-tr-unspendable-internal-key-complex" => hex!(
+                "8e9c801a430d7b5b48cd8c37ae42ff150bca17abb0ee6bb4543cf144e5b96ed9a359b3e30c672d75698b99b36a20a0930c754576242c1f95dbc9fa74d93d5ae8"
+            ),
+            _ => return,
+        };
+        assert_eq!(
+            observations.signatures[&0].as_slice(),
+            expected.as_slice(),
+            "signature fixture changed for vector '{}'",
+            vector.id
+        );
+    }
+
+    async fn assert_vector_pubkeys(
+        hal: &mut TestingHal<'_>,
+        vector: &btc_test_vectors::TestVector,
+        request: &btc_test_vectors::FirmwareSignRequest,
+    ) {
+        for expected in &vector.expected_signatures {
+            let input = &request.inputs[expected.input_index];
+            let keypath = keypath_components(&input.keypath);
+            let xpub = crate::keystore::get_xpub(hal, &keypath, crate::keystore::Compute::Once)
+                .await
+                .unwrap();
+            let pubkey = bitcoin::secp256k1::PublicKey::from_slice(xpub.public_key()).unwrap();
+            let actual_pubkey = match expected.kind {
+                btc_test_vectors::SignatureKind::Ecdsa => hex::encode(pubkey.serialize()),
+                btc_test_vectors::SignatureKind::TaprootKey
+                | btc_test_vectors::SignatureKind::TaprootScript => {
+                    hex::encode(pubkey.x_only_public_key().0.serialize())
+                }
+            };
+            assert_eq!(
+                Some(actual_pubkey.as_str()),
+                expected.pubkey.as_deref(),
+                "unexpected pubkey for input {} of vector '{}'",
+                expected.input_index,
+                vector.id
+            );
+
+            if let Some(expected_bip352_pubkey) = &input.bip352_pubkey {
+                let bip352_pubkey = match expected.kind {
+                    btc_test_vectors::SignatureKind::Ecdsa => pubkey.serialize().to_vec(),
+                    btc_test_vectors::SignatureKind::TaprootKey
+                    | btc_test_vectors::SignatureKind::TaprootScript => {
+                        // Taproot silent-payment inputs use the tweaked key-spend private key.
+                        pubkey
+                            .x_only_public_key()
+                            .0
+                            .tap_tweak(SECP256K1, None)
+                            .0
+                            .serialize()
+                            .to_vec()
+                    }
+                };
+                assert_eq!(
+                    bip352_pubkey.as_slice(),
+                    expected_bip352_pubkey.as_slice(),
+                    "unexpected BIP352 pubkey for input {} of vector '{}'",
+                    expected.input_index,
+                    vector.id
+                );
+            }
+        }
+    }
+
+    #[async_test::test]
+    async fn test_transaction_vectors() {
+        let vectors = btc_test_vectors::test_vectors();
+
+        for vector in &vectors.vectors {
+            let sign_request = btc_test_vectors::derive_sign_request(vector).unwrap();
+            let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(vector_transaction(
+                vector,
+                &sign_request,
+            )));
+            let observations =
+                alloc::rc::Rc::new(core::cell::RefCell::new(VectorObservations::default()));
+            *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() = {
+                let transaction = transaction.clone();
+                let observations = observations.clone();
+                Some(Box::new(move |response: Response| {
+                    observations.borrow_mut().observe(&response);
+                    Ok(transaction.borrow().make_host_request(response))
+                }))
+            };
+
+            mock_unlocked_using_mnemonic(&vectors.simulator_seed, "");
+            let mut mock_hal = TestingHal::new();
+            register_vector_configs(&mut mock_hal, vector);
+            let expectation = current_vector_expectation(vector);
+            let result = process(&mut mock_hal, &vector_init_request(vector, &sign_request)).await;
+            assert_eq!(
+                observed_vector_screens(&mock_hal.ui.screens).as_slice(),
+                expectation.screens.as_slice(),
+                "unexpected screens for transaction vector '{}'",
+                vector.id
+            );
+
+            match expectation.outcome {
+                btc_test_vectors::Outcome::Success => {
+                    let response = result.unwrap_or_else(|error| {
+                        panic!("transaction vector '{}' failed: {error:?}", vector.id)
+                    });
+                    observations.borrow_mut().observe(&response);
+                    assert_vector_observations(vector, &sign_request, &observations.borrow());
+                    assert_vector_pubkeys(&mut mock_hal, vector, &sign_request).await;
+                }
+                btc_test_vectors::Outcome::InvalidInput => {
+                    let error = result.expect_err(&format!(
+                        "transaction vector '{}' unexpectedly succeeded",
+                        vector.id
+                    ));
+                    assert_eq!(
+                        error,
+                        Error::InvalidInput,
+                        "unexpected error for transaction vector '{}'",
+                        vector.id
+                    );
+                }
+                btc_test_vectors::Outcome::Unsupported => panic!(
+                    "transaction vector '{}' is unsupported by this firmware version",
+                    vector.id
+                ),
+            }
+        }
+    }
+
     #[async_test::test]
     pub async fn test_sign_init_fail() {
         *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() = None;
@@ -2092,153 +2758,6 @@ mod tests {
         }
     }
 
-    #[async_test::test]
-    pub async fn test_process() {
-        static mut UI_COUNTER: u32 = 0;
-        static mut PREVTX_REQUESTED: u32 = 0;
-
-        for (coin, format_unit) in [
-            (pb::BtcCoin::Btc, FormatUnit::Default),
-            (pb::BtcCoin::Btc, FormatUnit::Sat),
-            (pb::BtcCoin::Ltc, FormatUnit::Default),
-        ] {
-            unsafe {
-                PREVTX_REQUESTED = 0;
-            }
-
-            mock_unlocked();
-            let transaction = new_transaction(coin).await;
-
-            let tx = transaction.clone();
-            *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-                Some(Box::new(move |response: Response| {
-                    let next = extract_next(&response);
-                    if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                        unsafe { PREVTX_REQUESTED += 1 }
-                    }
-                    Ok(tx.borrow().make_host_request(response))
-                }));
-
-            let mut init_request = transaction.borrow().init_request();
-            init_request.format_unit = format_unit as _;
-
-            let mut mock_hal = TestingHal::new();
-            let result = process(&mut mock_hal, &init_request).await;
-
-            assert_eq!(
-                mock_hal.ui.screens,
-                vec![
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "1.00000000 BTC".into(),
-                                FormatUnit::Sat => "100000000 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "LLnC CHbS zfwW quEd aS5T F2Yt 7uz5 Qb1S Z1".into(),
-                            amount: "1.00000000 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "34oV nh4g NviJ GMnN vgqu MeLA xvXJ uaRV MZ".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "12.34567890 BTC".into(),
-                                FormatUnit::Sat => "1234567890 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "MB1e 6aUe L3Zj 4s4H 2ZqF BHaa Hd7k vvzT co".into(),
-                            amount: "12.34567890 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "bc1q xven xven xven xven xven xven xven xven 2ymj t8".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "0.00006000 BTC".into(),
-                                FormatUnit::Sat => "6000 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "ltc1 qxve nxve nxve nxve nxve nxve nxve nxve nwcp knh".into(),
-                            amount: "0.00006000 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => Screen::Recipient {
-                            recipient: "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4".into(),
-                            amount: match format_unit {
-                                FormatUnit::Default => "0.00007000 BTC".into(),
-                                FormatUnit::Sat => "7000 sat".into(),
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::Recipient {
-                            recipient: "ltc1 qg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z yg3z qwr7 k5s".into(),
-                            amount: "0.00007000 LTC".into(),
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    Screen::Confirm {
-                        title: "Warning".into(),
-                        body: "There are 2\nchange outputs.\nProceed?".into(),
-                        longtouch: false,
-                    },
-                    match coin {
-                        pb::BtcCoin::Btc => match format_unit {
-                            FormatUnit::Default => Screen::TotalFee {
-                                total: "13.39999900 BTC".into(),
-                                fee: "0.05419010 BTC".into(),
-                                longtouch: true,
-                            },
-                            FormatUnit::Sat => Screen::TotalFee {
-                                total: "1339999900 sat".into(),
-                                fee: "5419010 sat".into(),
-                                longtouch: true,
-                            },
-                        },
-                        pb::BtcCoin::Ltc => Screen::TotalFee {
-                            total: "13.39999900 LTC".into(),
-                            fee: "0.05419010 LTC".into(),
-                            longtouch: true,
-                        },
-                        _ => panic!("unexpected coin"),
-                    },
-                    Screen::Status {
-                        title: "Transaction\nconfirmed".into(),
-                        success: true,
-                    },
-                ],
-            );
-            match result {
-                Ok(Response::BtcSignNext(next)) => {
-                    assert!(next.has_signature);
-                    match coin {
-                        pb::BtcCoin::Btc => {
-                            assert_eq!(
-                                next.signature,
-                                hex!(
-                                    "2738445c66add4a23ba457ddd678bc9ea3dab27030fa6a73b31c1aac7893c9aa0dd848ab8d27ff660a1f23213e0156937c9d46c261a3f809beae93760d2bce72"
-                                )
-                            );
-                        }
-                        _ => {}
-                    }
-                }
-                _ => panic!("wrong result"),
-            }
-            assert_eq!(
-                unsafe { PREVTX_REQUESTED },
-                transaction.borrow().inputs.len() as u32
-            );
-        }
-    }
-
     /// Test that receiving an unexpected message from the host results in an invalid state error.
     #[async_test::test]
     pub async fn test_invalid_state() {
@@ -2258,155 +2777,6 @@ mod tests {
         let result = process(&mut TestingHal::new(), &init_request).await;
         assert_eq!(result, Err(Error::InvalidState));
         assert_eq!(unsafe { COUNTER }, 2);
-    }
-
-    /// Test signing if all inputs are of type P2WPKH-P2SH.
-    #[async_test::test]
-    pub async fn test_script_type_p2wpkh_p2sh() {
-        mock_unlocked();
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        for input in transaction.borrow_mut().inputs.iter_mut() {
-            input.input.keypath[0] = 49 + HARDENED;
-        }
-        for output in transaction.borrow_mut().outputs.iter_mut() {
-            if output.ours {
-                output.keypath[0] = 49 + HARDENED;
-            }
-        }
-        let mut init_request = transaction.borrow().init_request();
-        init_request.script_configs[0] = pb::BtcScriptConfigWithKeypath {
-            script_config: Some(pb::BtcScriptConfig {
-                config: Some(pb::btc_script_config::Config::SimpleType(
-                    SimpleType::P2wpkhP2sh as _,
-                )),
-            }),
-            keypath: vec![49 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-        };
-        set_prevout_scripts(&mut TestingHal::new(), &transaction, &init_request).await;
-        mock_host_responder(transaction.clone());
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "157bca77b0af6618659c78bf4d7a758ac520e6088a7e648f5fb44fefeecca54c0dcc128a6a1141b2786e8618f12ecd618e81f87205fe456de4ce3d368e89d936"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    /// Test signing if all inputs are of type P2TR.
-    #[async_test::test]
-    pub async fn test_script_type_p2tr() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        for input in transaction.borrow_mut().inputs.iter_mut() {
-            input.input.keypath[0] = 86 + HARDENED;
-        }
-        for output in transaction.borrow_mut().outputs.iter_mut() {
-            if output.ours {
-                output.keypath[0] = 86 + HARDENED;
-            }
-        }
-
-        let tx = transaction.clone();
-        // Check that previous transactions are not streamed, as all inputs are taproot.
-        static mut PREVTX_REQUESTED: bool = false;
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED = true }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        let mut init_request = transaction.borrow().init_request();
-        init_request.script_configs[0] = pb::BtcScriptConfigWithKeypath {
-            script_config: Some(pb::BtcScriptConfig {
-                config: Some(pb::btc_script_config::Config::SimpleType(
-                    SimpleType::P2tr as _,
-                )),
-            }),
-            keypath: vec![86 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-        };
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "c62342dc6a5e438b18cfc6b58d07394ec3dd4bb1687d520ac2576b219e2e45987e922a8d488a4ae058cda1a40e64835de2c2c796fa5ad579659fa7e3106b1a57"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert!(unsafe { !PREVTX_REQUESTED });
-    }
-
-    /// Test signing if with mixed inputs, one of them being taproot. Previous transactions of all
-    /// inputs should be streamed in this case.
-    #[async_test::test]
-    pub async fn test_script_type_p2tr_mixed() {
-        mock_unlocked();
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().inputs[0].input.script_config_index = 1;
-        transaction.borrow_mut().inputs[0].input.keypath[0] = 86 + HARDENED;
-
-        let mut init_request = transaction.borrow().init_request();
-        init_request
-            .script_configs
-            .push(pb::BtcScriptConfigWithKeypath {
-                script_config: Some(pb::BtcScriptConfig {
-                    config: Some(pb::btc_script_config::Config::SimpleType(
-                        SimpleType::P2tr as _,
-                    )),
-                }),
-                keypath: vec![86 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-            });
-        set_prevout_scripts(&mut TestingHal::new(), &transaction, &init_request).await;
-
-        let tx = transaction.clone();
-        // Check that previous transactions are streamed, as not all input are taproot.
-        static mut PREVTX_REQUESTED: u32 = 0;
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED += 1 }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        assert!(process(&mut TestingHal::new(), &init_request).await.is_ok());
-        assert_eq!(
-            unsafe { PREVTX_REQUESTED },
-            transaction.borrow().inputs.len() as u32
-        );
-    }
-
-    /// Test signing UTXOs with high keypath address indices. Even though we don't support verifying
-    /// receive addresses at these indices (to mitigate ransom attacks), we should still be able to
-    /// spend them.
-    #[async_test::test]
-    pub async fn test_spend_high_address_index() {
-        mock_unlocked();
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().inputs[0].input.keypath[4] = 100000;
-        let init_request = transaction.borrow().init_request();
-        set_prevout_scripts(&mut TestingHal::new(), &transaction, &init_request).await;
-        mock_host_responder(transaction.clone());
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        assert!(result.is_ok());
     }
 
     /// Test invalid input cases.
@@ -2527,333 +2897,6 @@ mod tests {
         }
     }
 
-    /// Test signing with mixed input types.
-    #[async_test::test]
-    pub async fn test_mixed_inputs() {
-        mock_unlocked();
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        transaction.borrow_mut().inputs[0].input.script_config_index = 1;
-        transaction.borrow_mut().inputs[0].input.keypath[0] = 49 + HARDENED;
-        let mut init_request = transaction.borrow().init_request();
-        init_request
-            .script_configs
-            .push(pb::BtcScriptConfigWithKeypath {
-                script_config: Some(pb::BtcScriptConfig {
-                    config: Some(pb::btc_script_config::Config::SimpleType(
-                        SimpleType::P2wpkhP2sh as _,
-                    )),
-                }),
-                keypath: vec![49 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-            });
-        set_prevout_scripts(&mut TestingHal::new(), &transaction, &init_request).await;
-        mock_host_responder(transaction.clone());
-        assert!(process(&mut TestingHal::new(), &init_request).await.is_ok());
-    }
-
-    #[async_test::test]
-    async fn test_user_aborts() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        mock_host_responder(transaction.clone());
-        // We go through all possible user confirmations and abort one of them at a time.
-        let total_confirmations = transaction.borrow().total_confirmations;
-        for counter in 0..total_confirmations {
-            let mut mock_hal = TestingHal::new();
-            mock_hal.ui.abort_nth(counter as usize);
-            mock_unlocked();
-            let init_request = transaction.borrow().init_request();
-            assert_eq!(
-                process(&mut mock_hal, &init_request).await,
-                Err(Error::UserAbort)
-            );
-        }
-    }
-
-    /// Check workflow when a locktime applies.
-    #[async_test::test]
-    async fn test_locktime() {
-        struct Test {
-            coin: pb::BtcCoin,
-            locktime: u32,
-            sequence: u32,
-            // If None: no user confirmation expected.
-            // If Some: confirmation body.
-            confirm: Option<&'static str>,
-        }
-        for test_case in &[
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 0,
-                sequence: 0xffffffff,
-                confirm: None,
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 0,
-                sequence: 0xffffffff - 1,
-                confirm: None,
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 0,
-                sequence: 0xffffffff - 2,
-                confirm: None,
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 1,
-                sequence: 0xffffffff - 1,
-                confirm: Some("Locktime on block:\n1\nTransaction is not RBF"),
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 10,
-                sequence: 0xffffffff - 1,
-                confirm: Some("Locktime on block:\n10\nTransaction is not RBF"),
-            },
-            Test {
-                coin: pb::BtcCoin::Btc,
-                locktime: 10,
-                sequence: 0xffffffff - 2,
-                confirm: Some("Locktime on block:\n10\nTransaction is RBF"),
-            },
-            Test {
-                coin: pb::BtcCoin::Ltc,
-                locktime: 10,
-                sequence: 0xffffffff - 1,
-                confirm: Some("Locktime on block:\n10\n"),
-            },
-            Test {
-                coin: pb::BtcCoin::Ltc,
-                locktime: 10,
-                sequence: 0xffffffff - 2,
-                confirm: Some("Locktime on block:\n10\n"),
-            },
-        ] {
-            mock_unlocked();
-            let transaction = new_transaction(test_case.coin).await;
-            transaction.borrow_mut().inputs[0].input.sequence = test_case.sequence;
-            mock_host_responder(transaction.clone());
-
-            let mut init_request = transaction.borrow().init_request();
-            init_request.locktime = test_case.locktime;
-
-            let mut mock_hal = TestingHal::new();
-            let result = process(&mut mock_hal, &init_request).await;
-            let mut found_locktime = false;
-            for screen in mock_hal.ui.screens.iter() {
-                match screen {
-                    Screen::Confirm { title, body, .. } if body.contains("Locktime") => {
-                        found_locktime = true;
-                        if let Some(confirm_str) = test_case.confirm {
-                            assert_eq!(title.as_str(), "");
-                            assert_eq!(body.as_str(), confirm_str);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            assert_eq!(found_locktime, test_case.confirm.is_some());
-            assert!(result.is_ok());
-        }
-    }
-
-    // Test a transaction with an unusually high fee.
-    #[async_test::test]
-    async fn test_high_fee_warning() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        transaction.borrow_mut().outputs[1].value = 1034567890;
-        // One more confirmation for the high fee warning.
-        transaction.borrow_mut().total_confirmations += 1;
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-        let total_confirmations = transaction.borrow().total_confirmations;
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert!(mock_hal.ui.screens.contains(&Screen::TotalFee {
-            total: "13.39999900 BTC".into(),
-            fee: "2.05419010 BTC".into(),
-            longtouch: false
-        }));
-        assert!(
-            mock_hal
-                .ui
-                .contains_confirm("High fee", "The fee is 18.1%\nthe send amount.\nProceed?")
-        );
-        assert_eq!(
-            mock_hal.ui.screens.len() as u32,
-            total_confirmations + 1 // plus status screen
-        );
-    }
-
-    #[async_test::test]
-    async fn test_high_fee_warning_total_inputs() {
-        for with_op_return in [false, true] {
-            let transaction =
-                alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-            {
-                let mut tx = transaction.borrow_mut();
-                tx.outputs.retain(|output| output.ours);
-                if with_op_return {
-                    tx.outputs.push(pb::BtcSignOutputRequest {
-                        r#type: pb::BtcOutputType::OpReturn as _,
-                        payload: b"metadata".to_vec(),
-                        ..Default::default()
-                    });
-                }
-            }
-            mock_host_responder(transaction.clone());
-            mock_unlocked();
-            let init_request = transaction.borrow().init_request();
-
-            let mut mock_hal = TestingHal::new();
-            assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-            assert!(mock_hal.ui.screens.contains(&Screen::TotalFee {
-                total: "13.39999900 BTC".into(),
-                fee: "13.39999900 BTC".into(),
-                longtouch: false,
-            }));
-            assert!(
-                mock_hal
-                    .ui
-                    .contains_confirm("High fee", "The fee is 66.0%\nof all inputs.\nProceed?")
-            );
-            assert_eq!(
-                mock_hal.ui.contains_confirm("OP_RETURN", "metadata"),
-                with_op_return
-            );
-        }
-    }
-
-    #[async_test::test]
-    async fn test_no_high_fee_warning_total_inputs_below_threshold() {
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.retain(|output| output.ours);
-            tx.outputs.truncate(1);
-            tx.outputs[0].value = 2_000_000_000;
-        }
-        mock_host_responder(transaction.clone());
-        mock_unlocked();
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert!(mock_hal.ui.screens.contains(&Screen::TotalFee {
-            total: "0.30000000 BTC".into(),
-            fee: "0.30000000 BTC".into(),
-            longtouch: true,
-        }));
-        assert!(!mock_hal.ui.screens.iter().any(|screen| {
-            matches!(screen, Screen::Confirm { title, .. } if title == "High fee")
-        }));
-    }
-
-    // Test a P2TR output. It is not part of the default test transaction because Taproot is not
-    // active on Litecoin yet.
-    #[async_test::test]
-    async fn test_p2tr_output() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        transaction.borrow_mut().outputs[0].r#type = pb::BtcOutputType::P2tr as _;
-        transaction.borrow_mut().outputs[0].payload =
-            hex!("a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c").to_vec();
-        mock_host_responder(transaction.clone());
-
-        let mut mock_hal = TestingHal::new();
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert_eq!(
-            mock_hal.ui.screens[0],
-            Screen::Recipient {
-                recipient:
-                    "bc1p 5cyx nuxm euwu vkwf em96 lqzs zd02 n6xd cjrs 20ca c6yq jjwu dpxq kedr cr"
-                        .into(),
-                amount: "1.00000000 BTC".into(),
-            }
-        );
-
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "63d8442f327c59f50baacfa64726d01d6325042e9c79a03be14504a52cfbb1cc0e9a0b7ce419b6448e280bab107abb969b5eb4c149399f23e3c479d37e99ac31"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_silent_payment_output() {
-        mock_unlocked();
-        let transaction =
-            alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new(pb::BtcCoin::Btc)));
-
-        // Make an input a P2TR input to verify the right (tweaked) private key is used in the
-        // derivation of the silent payment output.
-        transaction.borrow_mut().inputs[0].input.script_config_index = 1;
-        transaction.borrow_mut().inputs[0].input.keypath[0] = 86 + HARDENED;
-
-        // Make first output a silent payment output. type and payload
-        // are ignored.
-        transaction.borrow_mut().outputs[0].r#type = pb::BtcOutputType::Unknown as _;
-        transaction.borrow_mut().outputs[0].payload = vec![];
-        transaction.borrow_mut().outputs[0].silent_payment =
-            Some(pb::btc_sign_output_request::SilentPayment {
-                address: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv".into(),
-            });
-        let mut init_request = transaction.borrow().init_request();
-        init_request
-            .script_configs
-            .push(pb::BtcScriptConfigWithKeypath {
-                script_config: Some(pb::BtcScriptConfig {
-                    config: Some(pb::btc_script_config::Config::SimpleType(
-                        pb::btc_script_config::SimpleType::P2tr as _,
-                    )),
-                }),
-                keypath: vec![86 + HARDENED, 0 + HARDENED, 10 + HARDENED],
-            });
-        set_prevout_scripts(&mut TestingHal::new(), &transaction, &init_request).await;
-        let tx = transaction.clone();
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-
-                if NextType::try_from(next.r#type).unwrap() == NextType::Output && next.index == 1 {
-                    assert_eq!(
-                        next.generated_output_pkscript,
-                        hex!(
-                            "5120d93dcc0bfa6bd3f53dff16446ed4a6687272fd00966d462c269e4ec11ed98f9e"
-                        )
-                    );
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens[0],
-            Screen::Recipient {
-                recipient: "sp1q qgst e7k9 hx0q ftg6 qmwl kqtw uy6c ycya vzmz j85c 6qdf hjdp djtd gqju exzk 6mur w56s uy3e 0rd2 cgqv ycxt tddw svgx e2us fpxu mr70 xc9p kqwv".into(),
-                amount: "1.00000000 BTC".into(),
-            }
-        );
-    }
-
     #[async_test::test]
     async fn test_silent_payment_rejects_input_keypath_mismatch() {
         for (simple_type, purpose) in [
@@ -2913,141 +2956,21 @@ mod tests {
     }
 
     #[async_test::test]
-    async fn test_silent_payment_rejects_ours_output() {
+    async fn test_user_aborts() {
         mock_unlocked();
         let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        {
-            let mut tx = transaction.borrow_mut();
-            let silent_payment_output_index = 5;
-            assert!(tx.outputs[silent_payment_output_index].ours);
-            // A receive-branch self-transfer is not change, but it is still marked as ours and
-            // must not carry a silent payment address.
-            tx.outputs[silent_payment_output_index].keypath[3] = 0;
-            tx.outputs[silent_payment_output_index].silent_payment =
-                Some(pb::btc_sign_output_request::SilentPayment {
-                    address: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv".into(),
-                });
-        }
-
         mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    // Test an output that is sending to the same account, but is not a change output by keypath.
-    #[async_test::test]
-    async fn test_self_send_non_change_output_same_account() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        transaction.borrow_mut().outputs[5].keypath[3] = 0;
-        mock_host_responder(transaction.clone());
-
-        let mut mock_hal = TestingHal::new();
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert_eq!(
-            mock_hal.ui.screens[4],
-            Screen::Recipient {
-                recipient: "This BitBox (same account): bc1q nu4x 8dlr x6de ty47 gehf 4uhk 5tj3 q7yh ywgr y6".into(),
-                amount: "0.00000100 BTC".into(),
-            }
-        );
-        assert!(mock_hal.ui.screens.contains(&Screen::TotalFee {
-            total: "13.40000000 BTC".into(),
-            fee: "0.05419010 BTC".into(),
-            longtouch: true,
-        }));
-
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "1d4cab467bb114fd62fa803407d514980e5b18f45a66a34d31078129627d2e892894a8035b67781bae22bd8b326c3c2de7555b0bd9509a2d0adb4971ca34ae1e"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    // Test an output that is sending to another account of our keystore.
-    #[async_test::test]
-    async fn test_self_send_different_account() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        const DIFFERENT_ACCOUNT: u32 = 20 + HARDENED;
-        transaction.borrow_mut().outputs[5].keypath[2] = DIFFERENT_ACCOUNT;
-        transaction.borrow_mut().outputs[5].keypath[3] = 0;
-        transaction.borrow_mut().outputs[5].output_script_config_index = Some(0);
-        mock_host_responder(transaction.clone());
-        let coin = transaction.borrow().coin;
-        let mut init_request = transaction.borrow().init_request();
-        init_request.output_script_configs = vec![pb::BtcScriptConfigWithKeypath {
-            script_config: Some(pb::BtcScriptConfig {
-                config: Some(pb::btc_script_config::Config::SimpleType(
-                    SimpleType::P2wpkh as _,
-                )),
-            }),
-            keypath: vec![
-                84 + HARDENED,
-                super::super::params::get(coin).bip44_coin,
-                DIFFERENT_ACCOUNT,
-            ],
-        }];
-
-        let mut mock_hal = TestingHal::new();
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens[4],
-            Screen::Recipient {
-                recipient: "This BitBox (account #21): bc1q r9t2 u35g zrtz nzv6 n99f 2dj3 7j9m sfff v78c v2".into(),
-                amount: "0.00000100 BTC".into(),
-            }
-        );
-    }
-
-    /// Exercise the antiklepto protocol
-    #[async_test::test]
-    async fn test_antiklepto() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-        let host_nonce = hex!("abababababababababababababababababababababababababababababababab");
-        // The host nonce commitment value does not impact this test, but an invalid commitment
-        // would fail the antiklepto signature check on the host. The host check is skipped here and
-        // tested in keystore::tests::test_secp256k1_antiklepto_protocol. That the host nonce was included in the sig is
-        // tested by the signature fixture test below.
-        let host_nonce_commitment = pb::AntiKleptoHostNonceCommitment {
-            commitment: bitbox_secp256k1::ecdsa_anti_exfil_host_commit(SECP256K1, &host_nonce)
-                .unwrap(),
-        };
-        transaction.borrow_mut().inputs[1].host_nonce = Some(host_nonce.to_vec());
-        transaction.borrow_mut().inputs[1]
-            .input
-            .host_nonce_commitment = Some(host_nonce_commitment);
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-        let result = process(&mut TestingHal::new(), &init_request).await;
-        match result {
-            Ok(Response::Btc(pb::BtcResponse {
-                response: Some(pb::btc_response::Response::SignNext(next)),
-            })) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "07b9c8df1b71fc841d5a379a9f568faffc4f7311e74a7ab3ec1f8f1b0d1e8b1234ded6bacb2532b653f0c1f3039fd348a86d1663db763b7e2c445fe9988c3f60"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
+        // We go through all possible user confirmations and abort one of them at a time.
+        let total_confirmations = transaction.borrow().total_confirmations;
+        for counter in 0..total_confirmations {
+            let mut mock_hal = TestingHal::new();
+            mock_hal.ui.abort_nth(counter as usize);
+            mock_unlocked();
+            let init_request = transaction.borrow().init_request();
+            assert_eq!(
+                process(&mut mock_hal, &init_request).await,
+                Err(Error::UserAbort)
+            );
         }
     }
 
@@ -3189,989 +3112,6 @@ mod tests {
         assert_eq!(result, Err(Error::InvalidInput));
     }
 
-    #[async_test::test]
-    async fn test_multisig_p2wsh() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-        mock_host_responder(transaction.clone());
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        // Hash of the multisig configuration as computed by `btc_common_multisig_hash_sorted()`.
-        let multisig_hash =
-            hex!("89751d19e4e26fbeee2fd2c4f56ab7ae5be6dc46482e81241f4accfbc0a1584e");
-        let mut mock_hal = TestingHal::new();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&multisig_hash, "test multisig account name")
-            .unwrap();
-
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 1,
-                                xpubs: vec![
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/2'
-                                    parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap(),
-                                    // dumb rough room report huge dry sudden hamster wait foot crew
-                                    // obvious / 48'/1'/0'/2'
-                                    parse_xpub("xpub6ERxBysTYfQyY4USv6c6J1HNVv9hpZFN9LHVPu47Ac4rK8fLy6NnAeeAHyEsMvG4G66ay5aFZii2VM7wT3KxLKX8Q8keZPd67kRGmrD1WJj").unwrap(),
-                                ],
-                                our_xpub_index: 0,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wsh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        2 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-
-        set_prevout_scripts(&mut mock_hal, &transaction, &init_request).await;
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "5f4ff35de020fdf55813f1bab8eda330440199329c02fbb9aa58292fda61c35873c44c9328d29e3f6f6a1dd20d6863aa0ad956cb8bcfbe3b023f16b99d4b89ee"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "1-of-2\nBTC Testnet multisig".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "test multisig account name".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "tb1q txyq ynfx wsk8 f5gu 8v5g 8e6h s3nj tglk ywhv yztk 6v8z nvx5 kdds mhuv e2".into(),
-                    amount: "0.00090000 TBTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Locktime on block:\n1663289\nTransaction is not RBF".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "0.00090175 TBTC".into(),
-                    fee: "0.00000175 TBTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    /// If the multisig has not been registered before, signing fails.
-    #[async_test::test]
-    async fn test_multisig_not_registered() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-        mock_host_responder(transaction.clone());
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 1,
-                                xpubs: vec![
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/2'
-                                    parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap(),
-                                    // dumb rough room report huge dry sudden hamster wait foot crew
-                                    // obvious / 48'/1'/0'/2'
-                                    parse_xpub("xpub6ERxBysTYfQyY4USv6c6J1HNVv9hpZFN9LHVPu47Ac4rK8fLy6NnAeeAHyEsMvG4G66ay5aFZii2VM7wT3KxLKX8Q8keZPd67kRGmrD1WJj").unwrap(),
-                                ],
-                                our_xpub_index: 0,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wsh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        2 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_multisig_p2wsh_p2sh() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-        for input in transaction.borrow_mut().inputs.iter_mut() {
-            input.input.keypath[3] = 1 + HARDENED;
-        }
-        for output in transaction.borrow_mut().outputs.iter_mut() {
-            if output.ours {
-                output.keypath[3] = 1 + HARDENED;
-            }
-        }
-
-        mock_host_responder(transaction.clone());
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        // Hash of the multisig configuration as computed by `btc_common_multisig_hash_sorted()`.
-        let multisig_hash =
-            hex!("a0a982a6f5ba9286ee45cd140fd763d43443d685a89bc60772553cc5418fccc4");
-        let mut mock_hal = TestingHal::new();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&multisig_hash, "test multisig account name")
-            .unwrap();
-
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 1,
-                                xpubs: vec![
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/1'
-                                    parse_xpub("xpub6EMfjyGVUvwhn1H2BwoVysVJi9cX78eyNTkoM3d26NHW4Zd75zrAcikT3dmoii4eZPwobzK4pMBYrLmE2y918UayfqBQFr6HpVze5mQHGyu").unwrap(),
-                                    // dumb rough room report huge dry sudden hamster wait foot crew
-                                    // obvious / 48'/1'/0'/1'
-                                    parse_xpub("xpub6ERxBysTYfQyV5NYAV6WZVj1dfTzESVGkWUiqERomNKCA6nCA8qX4qSLX2RRGNqckn3ps9B9sdfDkpg11nsJwCjXYXSZvkTED2Jx8jFpB9M").unwrap(),
-                                ],
-                                our_xpub_index: 0,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wshP2sh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        1 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-        set_prevout_scripts(&mut mock_hal, &transaction, &init_request).await;
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "e80ddbc806ba13e34239af24668267e6aae4a8522f56a9ee2c94496088da614614ddd85f80f15d87fed85086dce56521b3c32fc7f809483cdd1a75c36bb43bde"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_multisig_large() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_multisig()));
-
-        mock_host_responder(transaction.clone());
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        // Hash of the multisig configuration as computed by `btc_common_multisig_hash_sorted()`.
-        let multisig_hash =
-            hex!("9dfc0652e2a305c8b9949620f98ee14650302e385f23941bc607cc35fd7a7781");
-        let mut mock_hal = TestingHal::new();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&multisig_hash, "test multisig account name")
-            .unwrap();
-
-        let init_request = {
-            let tx = transaction.borrow();
-            pb::BtcSignInitRequest {
-                coin: tx.coin as _,
-                script_configs: vec![pb::BtcScriptConfigWithKeypath {
-                    script_config: Some(pb::BtcScriptConfig {
-                        config: Some(pb::btc_script_config::Config::Multisig(
-                            pb::btc_script_config::Multisig {
-                                threshold: 7,
-                                xpubs: vec![
-                                    parse_xpub("xpub6Eu7xJRyXRCi4eLYhJPnfZVjgAQtM7qFaEZwUhvgxGf4enEZMxevGzWvZTawCj9USP2MFTEhKQAwnqHwoaPHetTLqGuvq5r5uaLKyGx5QDZ").unwrap(),
-                                    parse_xpub("xpub6EQcxF2jFkYGn89AwoQJEEJkYMbRjED9AZgt7bkxQA5BLhZEoaQpUHcADbB5GxcMrTdDSGmjP7M3u462Q9otyE2PPam66P5KFLWitPVfYz9").unwrap(),
-                                    parse_xpub("xpub6EP4EycVS5dq1PN7ZqsxBtptkYhfLvLGokZjnB3fvPshMiAohh6E5TaJjAafZWoPRjo6uiZxhtDXLgCuk81ooQgwrsnEdfSWSfa4VUtX8nu").unwrap(),
-                                    parse_xpub("xpub6Eszd4BGGmHShcGtys5gbvV2zrBtW1gaorKf9YuvV4L3bePw7XePyyb2DKswZ5AhFfkcQwjQsiJEUTKhfRstRdHZUjQnJ2RJoQqL8g7FS4b").unwrap(),
-                                    parse_xpub("xpub6Df3nbvH6P3FTvjgKaZcSuydyEofK545U4Bb15JY8R9MtFkKrhYrc3bpEF6fHtNM7xQ1qHwsVpS56TJWUjbKcmRwPkQr17ovV2RaVSJaBq3").unwrap(),
-                                    parse_xpub("xpub6FQQ62gUYzS9wnHWHMPLWrpVnzS8xAf8XvfW1xzXEXTkTCtBrfbeww2zNeCgm3PbueMoq8opQvQDzp5Yf9EtiqVd7d1ASDoWSC1m7g1KHza").unwrap(),
-                                    parse_xpub("xpub6EQNZUUAzJAoFAVVetYUrFVrf7mLyYsnHiQihkA3KPhoRHx7m6SgKBYV4z5Rd9CvUc11ACN8Ap5Wxigt6GYRPUqXGFfm3833ezJpjAmvJKt").unwrap(),
-                                    parse_xpub("xpub6EGZy7cizYn2zUf9NT4qJ3Kr1ZrxdzPRcv2CwAnB1BTGWw7n9ZgDYvwmzzJXM6V7AgZ6CL3DrARZk5DzM9o8tz2RVTeC7QoHh9SxbW3b7Pw").unwrap(),
-                                    parse_xpub("xpub6DaV7oCAkm4HJQMoProrrKYq1RvcgpStgYUCzLRaaeJSBSy9WBRFMNnQyAWJUYy9myUFRTvogq1C2f7x4A2yhtYgr7gL6eZXv2eJvzU12pe").unwrap(),
-                                    parse_xpub("xpub6FFVRbdHt5DgHqR69KuWXRVDp93e1xKxv8rRLwhhCGnWaoF1ecnfdxpg2Nf1pvJTgT1UYg28CVt7YbUXFJL86vi9FaPN9QGtWLeCmf9dA24").unwrap(),
-                                    parse_xpub("xpub6FNywxebMjvSSginZrk7DfNmAHvPJAy3j6pJ9FmUQCoh4FKPzNymdHnkA1z77Ke4GK7g5GkdrBhpyXfWTbZkH6Yo1t4v524wDwF8SAKny9J").unwrap(),
-                                    parse_xpub("xpub6F1V9y6gXejomurTy2hN1UDCJidYahVkqtQJSZLYmcPcPDWkxGgWTrrLnCrCkGESSUSq6GpVVQx9kejPV97BEa9F85utABNL9r6xyPZFiDm").unwrap(),
-                                    parse_xpub("xpub6ECHc4kmTC2tQg2ZoAoazwyag9C4V6yFsZEhjwMJixdVNsUibot6uEvsZY38ZLVqWCtyc9gbzFEwHQLHCT8EiDDKSNNsFAB8NQYRgkiAQwu").unwrap(),
-                                    parse_xpub("xpub6F7CaxXzBCtvXwpRi61KYyhBRkgT1856ujHV5AbJK6ySCUYoDruBH6Pnsi6eHkDiuKuAJ2tSc9x3emP7aax9Dc3u7nP7RCQXEjLKihQu6w1").unwrap(),
-                                    // sudden tenant fault inject concert weather maid people chunk
-                                    // youth stumble grit / 48'/1'/0'/2'
-                                    parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap(),
-                                ],
-                                our_xpub_index: 14,
-                                script_type: pb::btc_script_config::multisig::ScriptType::P2wsh
-                                    as _,
-                            },
-                        )),
-                    }),
-                    keypath: vec![
-                        48 + HARDENED,
-                        super::super::params::get(tx.coin).bip44_coin,
-                        0 + HARDENED,
-                        2 + HARDENED,
-                    ],
-                }],
-                output_script_configs: vec![],
-                version: tx.version,
-                num_inputs: tx.inputs.len() as _,
-                num_outputs: tx.outputs.len() as _,
-                locktime: tx.locktime,
-                format_unit: FormatUnit::Default as _,
-                contains_silent_payment_outputs: false,
-            }
-        };
-        set_prevout_scripts(&mut mock_hal, &transaction, &init_request).await;
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "b6fc8262c84c39a8ea9ec9e59378f5290838835909f20ab6f9ae9eb4c35ad3fb06a05407f1297694d26976f3d1ae5e8bad0130dc3fd2d7ca02e653d9f5aeeb03"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_policy() {
-        let mut mock_hal = TestingHal::new();
-
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        // Check that previous transactions are streamed, as not all inputs are taproot.
-        static mut PREVTX_REQUESTED: bool = false;
-        let tx = transaction.clone();
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED = true }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "wsh(multi(2,@0/**,@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut mock_hal,
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let hash = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        set_prevout_scripts(&mut mock_hal, &transaction, &init_request).await;
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "bef93371f3c8fdf8c844a09b0bf0a3414767f68ba87d07ff3441a03c681cab887c337e3a982ecfdc84a8c15f0ebf50ae4ae92772f56431142fbe21ee8878a96c"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "BTC Testnet\npolicy with\n2 keys".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Name".into(),
-                    body: "test policy account name".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Show policy\ndetails?".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Policy".into(),
-                    body: "wsh(multi(2,@0/**,@1/**))".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 1/2".into(),
-                    body: "This device: [93531fa9/48'/1'/0'/3']tpubDEjJGD6BCCuA7VHrbk3gMeQ5HocbZ4eSQ121DcvCkC8xaeRFjyoJC9iVrSz1bWfNwAY5K2Vfz5bnHR3y4RrqVpkc5ikz4trfhSyosZPrcnk".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 2/2".into(),
-                    body: "tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "tb1q txyq ynfx wsk8 f5gu 8v5g 8e6h s3nj tglk ywhv yztk 6v8z nvx5 kdds mhuv e2".into(),
-                    amount: "0.00090000 TBTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Locktime on block:\n1663289\nTransaction is not RBF".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "0.00090175 TBTC".into(),
-                    fee: "0.00000175 TBTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-        assert!(unsafe { PREVTX_REQUESTED });
-    }
-
-    /// Same as `test_policy()`, but for a tr() Taproot policy.
-    /// We check that the previous transactions are not streamed as they are not needed for Taproot.
-    #[async_test::test]
-    async fn test_policy_tr() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-
-        let tx = transaction.clone();
-        // Check that previous transactions are not streamed, as all inputs are taproot.
-        static mut PREVTX_REQUESTED: bool = false;
-        *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() =
-            Some(Box::new(move |response: Response| {
-                let next = extract_next(&response);
-                if NextType::try_from(next.r#type).unwrap() == NextType::PrevtxInit {
-                    unsafe { PREVTX_REQUESTED = true }
-                }
-                Ok(tx.borrow().make_host_request(response))
-            }));
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "tr(@0/**,pk(@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "d2816fd56495bac5815283381775e0a0dec837a5d646a0e5602c2451ed173ffae16d10bfe391458aa9499dd908fe6ab669ef571f8a78e98ea8de27d82013a76d"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-        assert!(unsafe { !PREVTX_REQUESTED });
-    }
-
-    // Tests that unspendable internal Taproot keys are displayed as such.
-    #[async_test::test]
-    async fn test_policy_tr_unspendable_internal_key() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-
-        mock_host_responder(transaction.clone());
-
-        let policy_str = "tr(@0/<0;1>/*,{and_v(v:multi_a(1,@1/<2;3>/*,@2/<2;3>/*),older(2)),multi_a(2,@1/<0;1>/*,@2/<0;1>/*)})";
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: policy_str.into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubD6NzVbkrYhZ4WNrreqKvZr3qeJR7meg2BgaGP9upLkt7bp5SY6AAhY8vaN8ThfCjVcK6ZzE6kZbinszppNoGKvypeTmhyQ6uvUptXEXqknv").unwrap()),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: hex!("ffd63c8d").to_vec(),
-                    keypath: vec![48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 2 + HARDENED],
-                    xpub: Some(parse_xpub("tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N").unwrap()),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        assert!(process(&mut mock_hal, &init_request).await.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Confirm {
-                    title: "Spend from".into(),
-                    body: "BTC Testnet\npolicy with\n3 keys".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Name".into(),
-                    body: "test policy account name".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Show policy\ndetails?".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Policy".into(),
-                    body: policy_str.into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 1/3".into(),
-                    body: "Provably unspendable: tpubD6NzVbkrYhZ4WNrreqKvZr3qeJR7meg2BgaGP9upLkt7bp5SY6AAhY8vaN8ThfCjVcK6ZzE6kZbinszppNoGKvypeTmhyQ6uvUptXEXqknv".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 2/3".into(),
-                    body: "[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Key 3/3".into(),
-                    body: "This device: [93531fa9/48'/1'/0'/3']tpubDEjJGD6BCCuA7VHrbk3gMeQ5HocbZ4eSQ121DcvCkC8xaeRFjyoJC9iVrSz1bWfNwAY5K2Vfz5bnHR3y4RrqVpkc5ikz4trfhSyosZPrcnk".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "tb1q txyq ynfx wsk8 f5gu 8v5g 8e6h s3nj tglk ywhv yztk 6v8z nvx5 kdds mhuv e2".into(),
-                    amount: "0.00090000 TBTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Locktime on block:\n1663289\nTransaction is not RBF".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "0.00090175 TBTC".into(),
-                    fee: "0.00000175 TBTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    /// Test that a policy with derivations other than `/**` work.
-    #[async_test::test]
-    async fn test_policy_different_multipath_derivations() {
-        let policy_str = "wsh(multi(2,@0/<10;11>/*,@1/<20;21>/*))";
-
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        transaction.borrow_mut().inputs[0].input.keypath[4] = 10; // receive path at /10/*
-        transaction.borrow_mut().outputs[0].keypath[4] = 11; // change path at /11/*
-
-        mock_host_responder(transaction.clone());
-
-        static mut UI_COUNTER: u32 = 0;
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: policy_str.into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        set_prevout_scripts(&mut mock_hal, &transaction, &init_request).await;
-        let result = process(&mut mock_hal, &init_request).await;
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "2454a136a45a0af77632475a901bad2324123ed65cf9c9ec3ba2847a65e749b0718a0d1968b524739bee4e38aa119924733ee09d016093b32b6861eb57ba0e5f"
-                    )
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-    }
-
-    #[async_test::test]
-    async fn test_policy_wrong_account_keypath() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        mock_host_responder(transaction.clone());
-
-        static mut UI_COUNTER: u32 = 0;
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-        let wrong_keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 4 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "wsh(multi(2,@0/**,@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, wrong_keypath_account);
-        assert_eq!(
-            process(&mut mock_hal, &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    /// Avoid change keypaths with a too high address index.
-    #[async_test::test]
-    async fn test_policy_wrong_change_keypath() {
-        let transaction = alloc::rc::Rc::new(core::cell::RefCell::new(Transaction::new_policy()));
-        transaction.borrow_mut().outputs[0].keypath[5] = 10000; // Too high change address index.
-        mock_host_responder(transaction.clone());
-
-        static mut UI_COUNTER: u32 = 0;
-
-        mock_unlocked_using_mnemonic(
-            "sudden tenant fault inject concert weather maid people chunk youth stumble grit",
-            "",
-        );
-
-        let keypath_account = &[48 + HARDENED, 1 + HARDENED, 0 + HARDENED, 3 + HARDENED];
-
-        let policy = pb::btc_script_config::Policy {
-            policy: "wsh(multi(2,@0/**,@1/**))".into(),
-            keys: vec![
-                pb::KeyOriginInfo {
-                    root_fingerprint: crate::keystore::root_fingerprint().unwrap(),
-                    keypath: keypath_account.to_vec(),
-                    xpub: Some(
-                        crate::keystore::get_xpub(
-                            &mut TestingHal::new(),
-                            keypath_account,
-                            crate::keystore::Compute::Once,
-                        )
-                        .await
-                        .unwrap()
-                        .into(),
-                    ),
-                },
-                pb::KeyOriginInfo {
-                    root_fingerprint: vec![],
-                    keypath: vec![],
-                    xpub: Some(parse_xpub("tpubDFGkUYFfEhAALSXQ9VNssUq71HWYLWLK7sAEqFyqJBQxQ4uGSBW1RSBkoVfijE6iEHZFs2kZrVzzV1nZCSEXYKudtsfEWcWKVXvjjLeRyd8").unwrap()),
-                },
-            ],
-        };
-
-        // Register policy.
-        let mut mock_hal = TestingHal::new();
-        let hash_vec = super::super::policies::get_hash(pb::BtcCoin::Tbtc, &policy).unwrap();
-        let hash32: [u8; 32] = hash_vec.as_slice().try_into().unwrap();
-        mock_hal
-            .memory
-            .multisig_set_by_hash(&hash32, "test policy account name")
-            .unwrap();
-
-        let init_request = transaction
-            .borrow()
-            .init_request_policy(policy, keypath_account);
-        assert_eq!(
-            process(&mut mock_hal, &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    pub async fn test_payment_request() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        // Attach second output to a payment request.
-        {
-            let mut tx = transaction.borrow_mut();
-            // An additional confirmation for the text memo.
-            tx.total_confirmations += 3;
-            let payment_request_output_index = 1;
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::TextMemo(memo::TextMemo {
-                        note: "Test memo line1\nTest memo line2".into(),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
-            );
-            tx.payment_request = Some(payment_request);
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert!(result.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Recipient {
-                    recipient: "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH".into(),
-                    amount: "1.00000000 BTC".into(),
-                },
-                // Payment request
-                Screen::Recipient {
-                    recipient: "Test Merchant".into(),
-                    amount: "12.34567890 BTC".into(),
-                },
-                Screen::Confirm {
-                    title: "".into(),
-                    body: "Memo from\n\nTest Merchant".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Memo 1/2".into(),
-                    body: "Test memo line1".into(),
-                    longtouch: false,
-                },
-                Screen::Confirm {
-                    title: "Memo 2/2".into(),
-                    body: "Test memo line2".into(),
-                    longtouch: false,
-                },
-                Screen::Recipient {
-                    recipient: "bc1q xven xven xven xven xven xven xven xven 2ymj t8".into(),
-                    amount: "0.00006000 BTC".into(),
-                },
-                Screen::Recipient {
-                    recipient: "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4".into(),
-                    amount: "0.00007000 BTC".into(),
-                },
-                Screen::Confirm {
-                    title: "Warning".into(),
-                    body: "There are 2\nchange outputs.\nProceed?".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "13.39999900 BTC".into(),
-                    fee: "0.05419010 BTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    #[async_test::test]
-    pub async fn test_payment_request_rejects_ours_output() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        {
-            let mut tx = transaction.borrow_mut();
-            let payment_request_output_index = 5;
-            assert!(tx.outputs[payment_request_output_index].ours);
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::TextMemo(memo::TextMemo {
-                        note: "Test memo".into(),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "bc1qnu4x8dlrx6dety47gehf4uhk5tj3q7yhywgry6",
-            );
-            tx.payment_request = Some(payment_request);
-            // A receive-branch self-transfer is not change, but it is still marked as ours and
-            // must not belong to a payment request.
-            tx.outputs[payment_request_output_index].keypath[3] = 0;
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
     #[cfg(feature = "app-ethereum")]
     #[test]
     pub fn test_validate_swap_source_account() {
@@ -4245,237 +3185,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "app-ethereum")]
-    #[async_test::test]
-    pub async fn test_swap_payment_request() {
-        // End-to-end swap signing: swap screens appear, then the regular BTC confirmations continue.
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.total_confirmations += 1;
-            let payment_request_output_index = 1;
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::CoinPurchaseMemo(memo::CoinPurchaseMemo {
-                        coin_type: 60,
-                        amount: "0.25 ETH".into(),
-                        address: "0x773A77b9D32589be03f9132AF759e294f7851be9".into(),
-                        address_derivation: Some(memo::coin_purchase_memo::AddressDerivation::Eth(
-                            memo::coin_purchase_memo::EthAddressDerivation {
-                                keypath: vec![44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                            },
-                        )),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "34oVnh4gNviJGMnNvgquMeLAxvXJuaRVMZ",
-            );
-            tx.payment_request = Some(payment_request);
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert!(result.is_ok());
-
-        assert_eq!(
-            mock_hal.ui.screens,
-            vec![
-                Screen::Recipient {
-                    recipient: "12ZE w5Hc v1hT b6YU QJ69 y1V7 uhco Dz92 PH".into(),
-                    amount: "1.00000000 BTC".into(),
-                },
-                Screen::Recipient {
-                    recipient: "Test Merchant".into(),
-                    amount: "12.34567890 BTC".into(),
-                },
-                Screen::Swap {
-                    title: "Swap".into(),
-                    from: "12.34567890 BTC".into(),
-                    to: "0.25 ETH".into(),
-                },
-                Screen::Recipient {
-                    recipient: "bc1q xven xven xven xven xven xven xven xven 2ymj t8".into(),
-                    amount: "0.00006000 BTC".into(),
-                },
-                Screen::Recipient {
-                    recipient: "bc1q g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zy g3zq d8sx w4".into(),
-                    amount: "0.00007000 BTC".into(),
-                },
-                Screen::Confirm {
-                    title: "Warning".into(),
-                    body: "There are 2\nchange outputs.\nProceed?".into(),
-                    longtouch: false,
-                },
-                Screen::TotalFee {
-                    total: "13.39999900 BTC".into(),
-                    fee: "0.05419010 BTC".into(),
-                    longtouch: true,
-                },
-                Screen::Status {
-                    title: "Transaction\nconfirmed".into(),
-                    success: true
-                },
-            ]
-        );
-    }
-
-    #[cfg(feature = "app-ethereum")]
-    #[async_test::test]
-    pub async fn test_swap_payment_request_unsupported_source_coin() {
-        // Swap UI is restricted to BTC/LTC source accounts; other BTC-like coins must fail early.
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Tbtc).await;
-
-        {
-            let mut tx = transaction.borrow_mut();
-            let payment_request_output_index = 1;
-            let output_value = tx.outputs[payment_request_output_index].value;
-            let mut payment_request = pb::BtcPaymentRequestRequest {
-                recipient_name: "Test Merchant".into(),
-                memos: vec![Memo {
-                    memo: Some(memo::Memo::CoinPurchaseMemo(memo::CoinPurchaseMemo {
-                        coin_type: 60,
-                        amount: "0.25 ETH".into(),
-                        address: "0x773A77b9D32589be03f9132AF759e294f7851be9".into(),
-                        address_derivation: Some(memo::coin_purchase_memo::AddressDerivation::Eth(
-                            memo::coin_purchase_memo::EthAddressDerivation {
-                                keypath: vec![44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                            },
-                        )),
-                    })),
-                }],
-                nonce: vec![],
-                total_amount: output_value,
-                signature: vec![],
-            };
-            payment_request::tst_sign_payment_request_btc(
-                tx.coin,
-                &mut payment_request,
-                output_value,
-                "2MvdL2uD2Ubr4Zx8e6CQqNQEHjQ75sGH1NN",
-            );
-            tx.payment_request = Some(payment_request);
-            tx.outputs[payment_request_output_index].payment_request_index = Some(0);
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        // Attach OP_RETURN output
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 0,
-                payload: b"hello world".to_vec(),
-                ..Default::default()
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-
-        match result {
-            Ok(Response::BtcSignNext(next)) => {
-                assert!(next.has_signature);
-                assert_eq!(
-                    next.signature,
-                    hex!(
-                        "6c3c1156a5ce8c3382d81f1858649c9f595d4e251df361c90b7498f3907d756c7aded53e9eb668c81b50607b35e04127cd6eabd3dc4e36538bae283d89900ad0"
-                    ),
-                );
-            }
-            _ => panic!("wrong result"),
-        }
-
-        assert!(mock_hal.ui.contains_confirm("OP_RETURN", "hello world"));
-    }
-
-    #[async_test::test]
-    async fn test_op_return_nonascii() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        // Attach OP_RETURN output
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 0,
-                payload: vec![1, 2, 3, 4, 5],
-                ..Default::default()
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        let result = process(&mut mock_hal, &init_request).await;
-        assert!(result.is_ok());
-
-        assert!(
-            mock_hal
-                .ui
-                .contains_confirm("OP_RETURN\ndata (hex)", "0102030405")
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return_fail_nonzero_value() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        // Attach OP_RETURN output
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 100,
-                payload: b"hello world".to_vec(),
-                ..Default::default()
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        let mut mock_hal = TestingHal::new();
-        assert_eq!(
-            process(&mut mock_hal, &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
     #[async_test::test]
     async fn test_op_return_rejects_ours_output() {
         mock_unlocked();
@@ -4489,55 +3198,6 @@ mod tests {
             tx.outputs[output_index].value = 0;
             tx.outputs[output_index].payload = b"hello world".to_vec();
             tx.outputs[output_index].keypath[3] = 0;
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return_rejects_silent_payment_output() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs[0].r#type = pb::BtcOutputType::OpReturn as _;
-            tx.outputs[0].value = 0;
-            tx.outputs[0].payload = b"hello world".to_vec();
-            tx.outputs[0].silent_payment = Some(pb::btc_sign_output_request::SilentPayment {
-                address: "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv".into(),
-            });
-        }
-
-        mock_host_responder(transaction.clone());
-        let init_request = transaction.borrow().init_request();
-
-        assert_eq!(
-            process(&mut TestingHal::new(), &init_request).await,
-            Err(Error::InvalidInput)
-        );
-    }
-
-    #[async_test::test]
-    async fn test_op_return_rejects_payment_request_output() {
-        mock_unlocked();
-        let transaction = new_transaction(pb::BtcCoin::Btc).await;
-
-        {
-            let mut tx = transaction.borrow_mut();
-            tx.outputs.push(pb::BtcSignOutputRequest {
-                r#type: pb::BtcOutputType::OpReturn as _,
-                value: 0,
-                payload: b"hello world".to_vec(),
-                payment_request_index: Some(0),
-                ..Default::default()
-            });
         }
 
         mock_host_responder(transaction.clone());

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "firmware": "v9.26.5",
+  "firmware": "v9.27.0",
   "bootloader": "v1.2.2",
   "stage0": 1
 }


### PR DESCRIPTION
Add a readable source of Bitcoin transaction signing vectors, authored
as PSBTs with the metadata needed by signing APIs. Derive firmware
requests in memory, exercise them in signtx.rs, and remove overlapping
bespoke tests.

Advance the development firmware version to v9.27.0 and add versioned
coverage for the all-change fee confirmation flow introduced there.
Older simulator entries are skipped only where their stdout omitted
address and fee screens; genuine older behavior remains versioned.

For successful vectors, populate the PSBT with the firmware responses
and check that the completed transaction and its signatures are valid.

The generated fixtures are meant to be consumed by client libraries so
firmware and clients can cover the same transactions and versioned
expectations without repo-specific vector sources. They will also be
useful when adding the Bitcoin API to the new bitbox-api-ts library.

Keep the generated JSON synchronized with its Rust source through a
drift test.