### PR TITLE
noise: use multi-source entropy for static key

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "bip39",
  "bitbox-aes",
  "bitbox-bytequeue",
+ "bitbox-core-utils",
  "bitbox-framed-serial-link",
  "bitbox-hal",
  "bitbox-noise",

--- a/src/rust/bitbox-noise/src/lib.rs
+++ b/src/rust/bitbox-noise/src/lib.rs
@@ -16,6 +16,6 @@ pub mod testing;
 mod x25519;
 
 pub use noise_xx::{Error, HandshakeHash, HandshakeResult, State};
-pub use x25519::{X25519, genkey};
+pub use x25519::{X25519, genkey, genkey_from_entropy};
 
 pub use noise_rust_crypto::sensitive::Sensitive;

--- a/src/rust/bitbox-noise/src/noise_xx.rs
+++ b/src/rust/bitbox-noise/src/noise_xx.rs
@@ -80,8 +80,8 @@ impl State {
 
     /// Can be called at any time to start waiting for a new communication channel.
     ///
-    /// `static_private_key` is the local static key. It can be generated using
-    /// `genkey()` with a HAL random source and then persisted. `random` is used to generate a
+    /// `static_private_key` is the local static key. It is generated using
+    /// `genkey_from_entropy()` and then persisted. `random` is used to generate a
     /// fresh ephemeral private key for each session.
     pub fn init(&mut self, static_private_key: Sensitive<PrivateKey>, random: &mut impl Random) {
         let ephemeral_private_key = genkey(random);

--- a/src/rust/bitbox-noise/src/x25519.rs
+++ b/src/rust/bitbox-noise/src/x25519.rs
@@ -15,11 +15,14 @@ pub struct X25519;
 pub type PrivateKey = [u8; 32];
 pub type PublicKey = [u8; 32];
 
-/// Generate a fresh x25519 private key by reading 32 random bytes from the HAL and applying
-/// the standard clamping.
-pub fn genkey(random: &mut impl Random) -> Sensitive<PrivateKey> {
+/// Turn 32 bytes of entropy into an x25519 private key by applying the standard clamping.
+///
+/// The caller is responsible for the quality of `entropy`. For long-lived keys, prefer
+/// `bitbox_core_utils::random::random_32_bytes()`, which mixes the MCU TRNG, the secure chip
+/// TRNG and the factory randomness.
+pub fn genkey_from_entropy(entropy: &[u8; 32]) -> Sensitive<PrivateKey> {
     let mut k: Sensitive<PrivateKey> = Sensitive::new();
-    random.mcu_32_bytes(&mut k);
+    k.copy_from_slice(entropy);
 
     // Copied from: https://github.com/sopium/noise-rust/blob/76fb694f06b429879c264087f496958a99710356/noise-rust-crypto/src/lib.rs#L49-L51
     // which in turn copied it from:
@@ -30,6 +33,17 @@ pub fn genkey(random: &mut impl Random) -> Sensitive<PrivateKey> {
     k[31] |= 64;
 
     k
+}
+
+/// Generate a fresh x25519 private key by reading 32 random bytes from the MCU TRNG and applying
+/// the standard clamping.
+///
+/// This is used for per-session ephemeral keys, where a synchronous, cheap source is wanted.
+/// Long-lived keys should be built with `genkey_from_entropy()` instead.
+pub fn genkey(random: &mut impl Random) -> Sensitive<PrivateKey> {
+    let mut entropy: Sensitive<PrivateKey> = Sensitive::new();
+    random.mcu_32_bytes(&mut entropy);
+    genkey_from_entropy(&entropy)
 }
 
 impl noise_protocol::DH for X25519 {
@@ -54,5 +68,59 @@ impl noise_protocol::DH for X25519 {
         let k = x25519_dalek::StaticSecret::from(*k.deref());
         let pk = x25519_dalek::PublicKey::from(*pk);
         Ok(*k.diffie_hellman(&pk).as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::ops::Deref;
+
+    /// RFC 7748 clamping: bottom three bits cleared, top bit cleared, second-highest bit set.
+    fn assert_clamped(k: &[u8; 32]) {
+        assert_eq!(k[0] & 0b0000_0111, 0);
+        assert_eq!(k[31] & 0b1000_0000, 0);
+        assert_eq!(k[31] & 0b0100_0000, 0b0100_0000);
+    }
+
+    #[test]
+    fn test_genkey_from_entropy_clamps() {
+        for entropy in [[0x00u8; 32], [0xffu8; 32], [0xaau8; 32]] {
+            assert_clamped(genkey_from_entropy(&entropy).deref());
+        }
+    }
+
+    #[test]
+    fn test_genkey_from_entropy_preserves_unclamped_bits() {
+        // Only the clamped bits may differ from the supplied entropy.
+        let entropy = [0xffu8; 32];
+        let k = genkey_from_entropy(&entropy);
+        assert_eq!(k[0], 0xff & 248);
+        assert_eq!(k[31], (0xff & 127) | 64);
+        for i in 1..31 {
+            assert_eq!(k[i], entropy[i]);
+        }
+    }
+
+    #[test]
+    fn test_genkey_matches_genkey_from_entropy() {
+        // genkey() must be exactly genkey_from_entropy() over the MCU TRNG, so that the
+        // ephemeral-key path is unchanged by the refactor.
+        struct FixedRandom([u8; 32]);
+        impl Random for FixedRandom {
+            fn factory_randomness(&mut self) -> &'static [u8; 32] {
+                &[0; 32]
+            }
+            fn mcu_32_bytes(&mut self, out: &mut [u8; 32]) {
+                for (o, v) in out.iter_mut().zip(self.0.iter()) {
+                    *o ^= *v;
+                }
+            }
+        }
+
+        let entropy = [0x5au8; 32];
+        let from_genkey = genkey(&mut FixedRandom(entropy));
+        let from_entropy = genkey_from_entropy(&entropy);
+        assert_eq!(from_genkey.deref(), from_entropy.deref());
     }
 }

--- a/src/rust/bitbox02/Cargo.toml
+++ b/src/rust/bitbox02/Cargo.toml
@@ -13,6 +13,7 @@ bitbox02-sys = {path="../bitbox02-sys"}
 bitbox-securechip = { path = "../bitbox-securechip" }
 bitbox-securechip-sys = { path = "../bitbox-securechip-sys" }
 bitbox-noise = { path = "../bitbox-noise" }
+bitbox-core-utils = { path = "../bitbox-core-utils" }
 bitbox-hal = { path = "../bitbox-hal" }
 bitbox-bytequeue = { path = "../bitbox-bytequeue" }
 bitbox-framed-serial-link = { path = "../bitbox-framed-serial-link" }

--- a/src/rust/bitbox02/src/random.rs
+++ b/src/rust/bitbox02/src/random.rs
@@ -33,7 +33,7 @@ pub extern "C" fn rust_noise_generate_static_private_key(
         Ok(entropy) => entropy,
         // Mirrors the C `random_32_bytes()`, which aborts if the securechip cannot provide
         // randomness rather than silently falling back to fewer sources.
-        Err(_) => panic!("securechip randomness unavailable"),
+        Err(e) => panic!("securechip randomness unavailable: {e:?}"),
     };
     let key = bitbox_noise::genkey_from_entropy(&entropy);
     private_key_out.as_mut().copy_from_slice(&key[..]);
@@ -57,8 +57,10 @@ mod tests {
         assert!([0; 32] != result);
     }
 
+    // `genkey()` is the ephemeral-key path; the static key is built with
+    // `genkey_from_entropy()`, whose clamping is covered in `bitbox-noise`.
     #[test]
-    fn test_generate_static_private_key() {
+    fn test_genkey() {
         let mut random = crate::hal::random::BitBox02Random;
         let key = bitbox_noise::genkey(&mut random);
         assert_eq!(key[0] & 0b111, 0);

--- a/src/rust/bitbox02/src/random.rs
+++ b/src/rust/bitbox02/src/random.rs
@@ -23,7 +23,19 @@ pub extern "C" fn rust_noise_generate_static_private_key(
     mut private_key_out: util::bytes::BytesMut,
 ) {
     let mut random = crate::hal::random::BitBox02Random;
-    let key = bitbox_noise::genkey(&mut random);
+    let mut securechip = crate::hal::securechip::BitBox02SecureChip;
+    // Use the same multi-source entropy as other persistent secrets (e.g. the salt root):
+    // sha256(MCU TRNG XOR securechip TRNG XOR factory randomness).
+    let entropy = match util::bb02_async::block_on(bitbox_core_utils::random::random_32_bytes(
+        &mut random,
+        &mut securechip,
+    )) {
+        Ok(entropy) => entropy,
+        // Mirrors the C `random_32_bytes()`, which aborts if the securechip cannot provide
+        // randomness rather than silently falling back to fewer sources.
+        Err(_) => panic!("securechip randomness unavailable"),
+    };
+    let key = bitbox_noise::genkey_from_entropy(&entropy);
     private_key_out.as_mut().copy_from_slice(&key[..]);
 }
 


### PR DESCRIPTION
Hi! I've been reading through the firmware to learn how the entropy paths fit together — the multi-source design in `random_32_bytes()` is a nice piece of work. While doing that I ran into something I couldn't explain to myself, so I thought I'd ask here.

In `memory_reset_hww()`, two persistent secrets are generated a few lines apart:

```c
// Set salt root
_interface_functions->random_32_bytes(chunk.fields.salt_root);

// Set a new noise static private key.
rust_noise_generate_static_private_key(...);
```

The salt root goes through `random_32_bytes()` — MCU TRNG XOR securechip TRNG XOR factory randomness, hashed with SHA-256. The Noise static key goes through `bitbox_noise::genkey()`, which reads `random.mcu_32_bytes()` directly, so it only gets the MCU TRNG.

I genuinely can't tell from the code whether that's deliberate. My best guess at a reason is the sync/async boundary: `random_32_bytes()` is async because the securechip is, while `rust_noise_generate_static_private_key` is a synchronous `extern "C"` entry point. If that's the rationale, please just close this — a one-line comment in `x25519.rs` would save the next reader the same detour, and I'd be happy to send that instead.

In case it wasn't deliberate, here's a patch that lines the two up:

- adds `genkey_from_entropy()`, which only applies the x25519 clamping to caller-supplied entropy
- the static key call site feeds it `random_32_bytes()` output via `block_on`, the same pattern already used in `securechip/imp.rs`
- `genkey()` keeps its current behaviour and is still used for the per-session ephemeral keys in `noise_xx::init()`, where a cheap synchronous source is exactly what you want. It's now a thin wrapper, and `test_genkey_matches_genkey_from_entropy` asserts both paths agree, so the ephemeral path is provably untouched.

This keeps `bitbox-noise` free of async. Two things it does cost, which you may not want: it adds a `bitbox-core-utils` dependency to `bitbox02` (no cycle — `bitbox-core-utils` only depends on `bitbox-hal`), and it makes `memory_reset_hww()` depend on the securechip being available. Very happy to drop this if either is unwelcome.

To be clear about scope: this isn't a security report. The key here is the device↔app pairing identity, not seed-related, and the current code is only weaker if the MCU TRNG itself is degraded. It's a consistency/hardening tidy-up, nothing more.

**Testing**: `cargo test --manifest-path src/rust/Cargo.toml --all-features` passes (full suite, 0 failures). Clippy with the flags from `src/CMakeLists.txt` reports no new lints, and rustfmt is clean on the changed files. I couldn't get the CMake/ARM cross-build working on my machine, so `thumbv7em-none-eabi` will need a CI run — apologies for leaving that to you.

**Two things I'd like your call on**:
1. I used `panic!` when the securechip can't provide randomness, mirroring the C `random_32_bytes()` which aborts. Would a proper `Abort()` be more consistent here?
2. Is making `memory_reset_hww()` securechip-dependent acceptable, or would you rather keep that path free of it?

Thanks for maintaining this in the open — it's been a pleasure to read.

---

*Updated after review from @adam2k — thanks!*

**Why the securechip dependency isn't new**: `salt_root`, generated two lines above this call
site, already goes `random_32_bytes` -> `random_32_bytes_sec` (`src/random.c:49`) ->
`rust_securechip_random` -> `block_on(random())` (`bitbox02/src/securechip/imp.rs:157`) ->
`Abort()` on failure. So `memory_reset_hww()` already cannot complete without a working
securechip, and already nests a `block_on`. This patch adds neither a new dependency nor a new
failure mode.

**No compatibility risk**: the static key is generated only in `memory_reset_hww()` and then
persisted, so existing devices keep their pairing identity.

**C unit tests are unaffected**: `rust_noise_generate_static_private_key` is `--wrap`ped at
`test/unit-test/CMakeLists.txt:51`, so `_test_memory_reset_hww_ble`'s `random_32_bytes` call
counts never reach the new path.
