### PR TITLE
BUILD: document host tools for native builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -104,6 +104,20 @@ brew tap osx-cross/arm
 brew install arm-gcc-bin
 ```
 
+Install [rustup](https://rustup.rs). The toolchain version is pinned by
+`src/rust/rust-toolchain.toml`; rustup will download it automatically once you run `cargo` from
+ within `src/rust` (or after setting a rustup override for the repository).
+
+The build also invokes three tools that are not installed by the brew commands
+above. Install them with the same versions as the container (see the
+[Dockerfile](Dockerfile)):
+
+```sh
+cargo install cbindgen --version 0.29.2 --locked
+cargo install bindgen-cli --version 0.72.1 --locked
+cargo install --path tools/prost-build-proto --locked
+```
+
 ## Contributor instructions
 
 ### Check out the repository


### PR DESCRIPTION
The macOS setup section covers the brew dependencies but not the three tools installed via cargo in the Dockerfile.  Without them, building the simulators natively fails with CBINDGEN-NOTFOUND, "bindgen was not found", and "prost-build-proto: command not found".

Pin the same versions as the container, since the section already warns that version drift from CI causes reproducibility problems.