### PR TITLE
bb03: bound and scroll confirmation bodies

### DIFF
--- a/src/rust/bitbox-hal/src/ui.rs
+++ b/src/rust/bitbox-hal/src/ui.rs
@@ -3,6 +3,11 @@
 use alloc::string::String;
 use core::time::Duration;
 
+/// Maximum confirmation body length in bytes that can be displayed without truncation.
+/// Longer bodies are truncated and suffixed with `...`.
+/// Keep this in sync with `src/ui/components/label.h:MAX_LABEL_SIZE`.
+pub const MAX_CONFIRM_BODY_SIZE: usize = 640;
+
 pub struct UserAbort;
 
 #[derive(Copy, Clone, Default)]
@@ -18,7 +23,8 @@ pub struct ConfirmParams<'a> {
     /// The confirmation title of the screen. Max 200 chars, otherwise **panic**.
     pub title: &'a str,
     pub title_autowrap: bool,
-    /// The confirmation body of the screen. Max 200 chars, otherwise **panic**.
+    /// The confirmation body of the screen. UIs truncate bodies longer than
+    /// [`MAX_CONFIRM_BODY_SIZE`].
     pub body: &'a str,
     pub font: Font,
     /// If true, the body is horizontally scrollable.

--- a/src/rust/bitbox02-rust/src/workflow/confirm.rs
+++ b/src/rust/bitbox02-rust/src/workflow/confirm.rs
@@ -3,16 +3,13 @@
 use crate::hal::Ui;
 use crate::hal::ui::{ConfirmParams, UserAbort};
 
-// Keep this in sync with src/ui/components/label.h:MAX_LABEL_SIZE. `MAX_CONFIRM_BODY_SIZE` is the
-// effective confirmation body limit and intentionally matches that UI label size limit.
-pub(crate) const MAX_CONFIRM_BODY_SIZE: usize = 640;
+pub(crate) use crate::hal::ui::MAX_CONFIRM_BODY_SIZE;
 
 pub(crate) const TRUNCATION_WARNING_BODY: &str = "The next value is\ntoo large to display\nin full";
 
 /// Confirm a potentially long value.
 ///
-/// If the value exceeds the UI label limit, the UI will truncate it with `...`, so warn the user
-/// before showing it.
+/// If the value exceeds the target UI's label limit, warn the user before showing it.
 pub(crate) async fn confirm_value(
     hal: &mut impl crate::hal::Hal,
     params: &ConfirmParams<'_>,
@@ -28,4 +25,25 @@ pub(crate) async fn confirm_value(
             .await?;
     }
     hal.ui().confirm(params).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hal::testing::TestingHal;
+
+    #[async_test::test]
+    async fn test_confirm_value() {
+        let body = "a".repeat(MAX_CONFIRM_BODY_SIZE + 1);
+        let params = ConfirmParams {
+            title: "Value",
+            body: &body,
+            ..Default::default()
+        };
+
+        let mut hal = TestingHal::new();
+        assert!(confirm_value(&mut hal, &params).await.is_ok());
+        assert_eq!(hal.ui.screens.len(), 2);
+        assert!(hal.ui.contains_confirm("Warning", TRUNCATION_WARNING_BODY));
+    }
 }

--- a/src/rust/bitbox02/src/ui/types.rs
+++ b/src/rust/bitbox02/src/ui/types.rs
@@ -5,9 +5,10 @@ use alloc::boxed::Box;
 
 pub use bitbox02_sys::trinary_choice_t as TrinaryChoice;
 
-// Taking the constant straight from C, as it's excluding the null terminator.
+// Keep this in sync with src/ui/components/label.h:MAX_LABEL_SIZE.
 #[cfg_attr(any(feature = "testing", feature = "c-unit-testing"), allow(dead_code))]
-pub(crate) const MAX_LABEL_SIZE: usize = bitbox02_sys::MAX_LABEL_SIZE as _;
+pub(crate) const MAX_LABEL_SIZE: usize = bitbox_hal::ui::MAX_CONFIRM_BODY_SIZE;
+const _: () = assert!(MAX_LABEL_SIZE == bitbox02_sys::MAX_LABEL_SIZE as usize);
 
 #[derive(Default)]
 pub enum Font {

--- a/src/rust/bitbox02/src/ui/ui.rs
+++ b/src/rust/bitbox02/src/ui/ui.rs
@@ -228,7 +228,7 @@ pub async fn confirm(params: &ConfirmParams<'_>) -> ConfirmResponse {
 
     // We truncate at a bit higher than MAX_LABEL_SIZE, so the label component will correctly
     // truncate and append '...'.
-    const TRUNCATE_SIZE: usize = bitbox02_sys::MAX_LABEL_SIZE as usize + 1;
+    const TRUNCATE_SIZE: usize = super::types::MAX_LABEL_SIZE + 1;
     let title =
         util::strings::str_to_cstr_vec(util::strings::truncate_str(params.title, TRUNCATE_SIZE))
             .unwrap();

--- a/src/rust/bitbox03/src/ui/confirm.rs
+++ b/src/rust/bitbox03/src/ui/confirm.rs
@@ -1,13 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use bitbox_hal::ui::{ConfirmParams, UserAbort};
+use alloc::string::String;
+use bitbox_hal::ui::{ConfirmParams, MAX_CONFIRM_BODY_SIZE, UserAbort};
 use bitbox_lvgl::{
-    self as lvgl, LabelExt, LvLabel, LvLabelLongMode, LvObj, LvOpacityLevel, ObjExt,
+    self as lvgl, LabelExt, LvLabel, LvLabelLongMode, LvObj, LvObjFlag, LvOpacityLevel, ObjExt,
 };
 use util::futures::completion::Responder;
 
 use super::nav_button::{NavIcon, build_close_button, build_nav_button};
 use super::slide_to_confirm::build_slide_to_confirm;
+
+fn truncate_body(body: &str) -> String {
+    if body.len() <= MAX_CONFIRM_BODY_SIZE {
+        return String::from(body);
+    }
+
+    let mut end = MAX_CONFIRM_BODY_SIZE;
+    while !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = String::from(&body[..end]);
+    truncated.push_str("...");
+    truncated
+}
 
 pub fn build_confirm_screen(
     params: &ConfirmParams<'_>,
@@ -33,15 +48,28 @@ pub fn build_confirm_screen(
         lvgl::LvState::LV_STATE_DEFAULT as u32,
     );
 
-    let body = LvLabel::new(&screen).unwrap();
+    // Keep navigation controls fixed while allowing long confirmation contents to be reviewed.
+    let body_container = LvObj::with_parent(&screen).unwrap();
+    body_container.set_width(380);
+    body_container.set_layout(lvgl::LvLayout::LV_LAYOUT_FLEX);
+    body_container.set_flex_flow(lvgl::LvFlexFlow::LV_FLEX_FLOW_COLUMN);
+    body_container.set_style_flex_grow(1, 0);
+    body_container.set_style_pad_top(0, 0);
+    body_container.set_style_pad_right(0, 0);
+    body_container.set_style_pad_bottom(0, 0);
+    body_container.set_style_pad_left(0, 0);
+    body_container.set_style_border_width(0, 0);
+    body_container.set_style_bg_opa(LvOpacityLevel::LV_OPA_TRANSP as u8, 0);
+    body_container.add_flag(LvObjFlag::LV_OBJ_FLAG_SCROLLABLE);
+
+    let body = LvLabel::new(&body_container).unwrap();
     body.set_width(380);
     body.set_long_mode(LvLabelLongMode::LV_LABEL_LONG_MODE_WRAP);
-    body.set_text(params.body).unwrap();
+    body.set_text(&truncate_body(params.body)).unwrap();
     body.set_style_text_font(
         lvgl::fonts::INTER_REGULAR_32,
         lvgl::LvState::LV_STATE_DEFAULT as u32,
     );
-    body.set_style_flex_grow(1, 0);
 
     if params.longtouch {
         // High-stakes confirmation: the accept action is a slide gesture instead of a tap, and
@@ -84,4 +112,26 @@ pub fn build_confirm_screen(
         .expect("failed to register accept callback");
 
     screen
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_body() {
+        let exact = "a".repeat(MAX_CONFIRM_BODY_SIZE);
+        assert_eq!(truncate_body(&exact), exact);
+
+        let overlong = "a".repeat(MAX_CONFIRM_BODY_SIZE + 1);
+        let mut expected = String::from(&overlong[..MAX_CONFIRM_BODY_SIZE]);
+        expected.push_str("...");
+        assert_eq!(truncate_body(&overlong), expected);
+
+        let mut utf8 = "a".repeat(MAX_CONFIRM_BODY_SIZE - 1);
+        utf8.push('€');
+        let truncated = truncate_body(&utf8);
+        assert_eq!(truncated.len(), MAX_CONFIRM_BODY_SIZE + 2);
+        assert!(truncated.ends_with("..."));
+    }
 }

--- a/src/ui/components/label.h
+++ b/src/ui/components/label.h
@@ -9,7 +9,8 @@
 
 // Max size of text shown (excl. null terminator). The current size of 640 is chosen to be able to
 // show up to 320 bytes of Ethereum tx data in hex format.
-// Keep this in sync with src/rust/bitbox02-rust/src/workflow/confirm.rs:MAX_CONFIRM_BODY_SIZE.
+// Keep this in sync with src/rust/bitbox-hal/src/ui.rs:MAX_CONFIRM_BODY_SIZE.
+// src/rust/bitbox02/src/ui/types.rs:MAX_LABEL_SIZE asserts that both definitions are equal.
 #define MAX_LABEL_SIZE 640
 
 /**


### PR DESCRIPTION
Keep confirmation navigation controls fixed while long bodies scroll
independently.

Use the shared 640-byte confirmation-body limit on both devices and
truncate BB03 bodies at a UTF-8 boundary with an ellipsis. This keeps
the truncation warning aligned with the value actually shown.