### PR TITLE
docs: clarify signing fallback behavior

### DIFF
--- a/messages/btc.proto
+++ b/messages/btc.proto
@@ -152,6 +152,8 @@ message BTCSignInputRequest {
   repeated uint32 keypath = 6; // all inputs must be ours.
   // References a script config from BTCSignInitRequest
   uint32 script_config_index = 7;
+  // If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+  // This differs from plain RFC6979 and does not provide anti-klepto protection.
   AntiKleptoHostNonceCommitment host_nonce_commitment = 8;
 }
 
@@ -281,6 +283,8 @@ message BTCSignMessageRequest {
   BTCCoin coin = 1;
   BTCScriptConfigWithKeypath script_config = 2;
   bytes msg = 3;
+  // If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+  // This differs from plain RFC6979 and does not provide anti-klepto protection.
   AntiKleptoHostNonceCommitment host_nonce_commitment = 4;
 }
 

--- a/messages/eth.proto
+++ b/messages/eth.proto
@@ -48,6 +48,8 @@ message ETHSignRequest {
   bytes recipient = 6; // 20 byte recipient
   bytes value = 7; // smallest big endian serialization, max. 32 bytes
   bytes data = 8;
+  // If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+  // This differs from plain RFC6979 and does not provide anti-klepto protection.
   AntiKleptoHostNonceCommitment host_nonce_commitment = 9;
   // If non-zero, `coin` is ignored and `chain_id` is used to identify the network.
   uint64 chain_id = 10;
@@ -67,6 +69,8 @@ message ETHSignEIP1559Request {
   bytes recipient = 7; // 20 byte recipient
   bytes value = 8; // smallest big endian serialization, max. 32 bytes
   bytes data = 9;
+  // If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+  // This differs from plain RFC6979 and does not provide anti-klepto protection.
   AntiKleptoHostNonceCommitment host_nonce_commitment = 10;
   ETHAddressCase address_case = 11;
   // For streaming: if non-zero, data field should be empty and data will be requested in chunks
@@ -88,6 +92,8 @@ message ETHSignMessageRequest {
   ETHCoin coin = 1;
   repeated uint32 keypath = 2;
   bytes msg = 3;
+  // If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+  // This differs from plain RFC6979 and does not provide anti-klepto protection.
   AntiKleptoHostNonceCommitment host_nonce_commitment = 4;
   // If non-zero, `coin` is ignored and `chain_id` is used to identify the network.
   uint64 chain_id = 5;
@@ -131,6 +137,7 @@ message ETHSignTypedMessageRequest {
   repeated uint32 keypath = 2;
   repeated StructType types = 3;
   string primary_type = 4;
+  // If omitted, plain RFC6979 signing is used without anti-klepto protection.
   AntiKleptoHostNonceCommitment host_nonce_commitment = 5;
 }
 

--- a/src/rust/bitbox-proto/src/generated/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox-proto/src/generated/shiftcrypto.bitbox02.rs
@@ -804,6 +804,8 @@ pub struct BtcSignInputRequest {
     /// References a script config from BTCSignInitRequest
     #[prost(uint32, tag = "7")]
     pub script_config_index: u32,
+    /// If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+    /// This differs from plain RFC6979 and does not provide anti-klepto protection.
     #[prost(message, optional, tag = "8")]
     pub host_nonce_commitment: ::core::option::Option<AntiKleptoHostNonceCommitment>,
 }
@@ -1047,6 +1049,8 @@ pub struct BtcSignMessageRequest {
     pub script_config: ::core::option::Option<BtcScriptConfigWithKeypath>,
     #[prost(bytes = "vec", tag = "3")]
     pub msg: ::prost::alloc::vec::Vec<u8>,
+    /// If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+    /// This differs from plain RFC6979 and does not provide anti-klepto protection.
     #[prost(message, optional, tag = "4")]
     pub host_nonce_commitment: ::core::option::Option<AntiKleptoHostNonceCommitment>,
 }
@@ -1564,6 +1568,8 @@ pub struct EthSignRequest {
     pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "8")]
     pub data: ::prost::alloc::vec::Vec<u8>,
+    /// If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+    /// This differs from plain RFC6979 and does not provide anti-klepto protection.
     #[prost(message, optional, tag = "9")]
     pub host_nonce_commitment: ::core::option::Option<AntiKleptoHostNonceCommitment>,
     /// If non-zero, `coin` is ignored and `chain_id` is used to identify the network.
@@ -1603,6 +1609,8 @@ pub struct EthSignEip1559Request {
     pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "9")]
     pub data: ::prost::alloc::vec::Vec<u8>,
+    /// If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+    /// This differs from plain RFC6979 and does not provide anti-klepto protection.
     #[prost(message, optional, tag = "10")]
     pub host_nonce_commitment: ::core::option::Option<AntiKleptoHostNonceCommitment>,
     #[prost(enumeration = "EthAddressCase", tag = "11")]
@@ -1637,6 +1645,8 @@ pub struct EthSignMessageRequest {
     pub keypath: ::prost::alloc::vec::Vec<u32>,
     #[prost(bytes = "vec", tag = "3")]
     pub msg: ::prost::alloc::vec::Vec<u8>,
+    /// If omitted, the signature uses the historical deterministic zero-contribution S2C fallback.
+    /// This differs from plain RFC6979 and does not provide anti-klepto protection.
     #[prost(message, optional, tag = "4")]
     pub host_nonce_commitment: ::core::option::Option<AntiKleptoHostNonceCommitment>,
     /// If non-zero, `coin` is ignored and `chain_id` is used to identify the network.
@@ -1661,6 +1671,7 @@ pub struct EthSignTypedMessageRequest {
     pub types: ::prost::alloc::vec::Vec<eth_sign_typed_message_request::StructType>,
     #[prost(string, tag = "4")]
     pub primary_type: ::prost::alloc::string::String,
+    /// If omitted, plain RFC6979 signing is used without anti-klepto protection.
     #[prost(message, optional, tag = "5")]
     pub host_nonce_commitment: ::core::option::Option<AntiKleptoHostNonceCommitment>,
 }

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signmsg.rs
@@ -112,7 +112,9 @@ pub async fn process(
             super::antiklepto_get_host_nonce(signer_commitment).await?
         }
 
-        // Return signature directly without the anti-klepto protocol, for backwards compatibility.
+        // Return the signature directly without the anti-klepto protocol for backwards
+        // compatibility. Preserve the historical zero-contribution S2C signature; this differs
+        // from plain RFC6979 and does not provide anti-klepto protection.
         None => [0; 32],
     };
 

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/signtx.rs
@@ -1314,7 +1314,9 @@ async fn _process(
                         .try_into()
                         .or(Err(Error::InvalidInput))?
                 }
-                // Return signature directly without the anti-klepto protocol, for backwards compatibility.
+                // Return the signature directly without the anti-klepto protocol for backwards
+                // compatibility. Preserve the historical zero-contribution S2C signature; this
+                // differs from plain RFC6979 and does not provide anti-klepto protection.
                 None => [0; 32],
             };
 

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign.rs
@@ -614,7 +614,9 @@ pub async fn _process(
             super::antiklepto_get_host_nonce(signer_commitment).await?
         }
 
-        // Return signature directly without the anti-klepto protocol, for backwards compatibility.
+        // Return the signature directly without the anti-klepto protocol for backwards
+        // compatibility. Preserve the historical zero-contribution S2C signature; this differs
+        // from plain RFC6979 and does not provide anti-klepto protection.
         None => [0; 32],
     };
     let sign_result = crate::secp256k1::secp256k1_sign(

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/signmsg.rs
@@ -71,7 +71,9 @@ pub async fn process(
             super::antiklepto_get_host_nonce(signer_commitment).await?
         }
 
-        // Return signature directly without the anti-klepto protocol, for backwards compatibility.
+        // Return the signature directly without the anti-klepto protocol for backwards
+        // compatibility. Preserve the historical zero-contribution S2C signature; this differs
+        // from plain RFC6979 and does not provide anti-klepto protection.
         None => [0; 32],
     };
 


### PR DESCRIPTION
Document the historical zero-contribution S2C fallback used by legacy
Bitcoin and Ethereum signing requests when anti-klepto is omitted.

Clarify that EIP-712 instead falls back to plain RFC6979 and that neither
fallback provides anti-klepto protection.

This is and aid to LLMs to not spend time analyzing this in reviews.

The alternative would be to fallback to RFC6979, but it's not worth the effort, considering that virtually all clients use antiklepto - this change could not retroactively change legacy apps.