### PR TITLE
keystore: zeroize derived encryption keys

### DIFF
--- a/src/rust/bitbox-aes/src/lib.rs
+++ b/src/rust/bitbox-aes/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256};
+use zeroize::Zeroizing;
 
 // AES block size.
 const BLOCK_SIZE: usize = 16;
@@ -64,8 +65,8 @@ fn decrypt(key: &[u8; 32], cipher: &[u8]) -> Result<zeroize::Zeroizing<Vec<u8>>,
     Ok(result)
 }
 
-fn sha512(buf: &[u8]) -> [u8; 64] {
-    bitcoin::hashes::sha512::Hash::hash(buf).to_byte_array()
+fn sha512(buf: &[u8]) -> Zeroizing<[u8; 64]> {
+    Zeroizing::new(bitcoin::hashes::sha512::Hash::hash(buf).to_byte_array())
 }
 
 fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
@@ -76,7 +77,7 @@ fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
 }
 
 pub fn encrypt_with_hmac(iv: &[u8; 16], key: &[u8], plain: &[u8]) -> Vec<u8> {
-    let hash: [u8; 64] = sha512(key);
+    let hash = sha512(key);
     let (encryption_key, authentication_key) = hash.split_at(32);
     let mut cipher = encrypt(iv, encryption_key.try_into().unwrap(), plain);
     let mac: [u8; 32] = hmac_sha256(authentication_key, &cipher);
@@ -85,7 +86,7 @@ pub fn encrypt_with_hmac(iv: &[u8; 16], key: &[u8], plain: &[u8]) -> Vec<u8> {
 }
 
 pub fn decrypt_with_hmac(key: &[u8], cipher: &[u8]) -> Result<zeroize::Zeroizing<Vec<u8>>, ()> {
-    let hash: [u8; 64] = sha512(key);
+    let hash = sha512(key);
     let (encryption_key, authentication_key) = hash.split_at(32);
     if cipher.len() < 32 {
         return Err(());

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -764,7 +764,8 @@ pub async fn stretch_retained_seed_encryption_key(
 
     let mut engine = HmacEngine::<sha256::Hash>::new(salted_out.as_slice());
     engine.input(kdf.as_slice());
-    let stretched = Hmac::<sha256::Hash>::from_engine(engine).to_byte_array();
+    let stretched =
+        zeroize::Zeroizing::new(Hmac::<sha256::Hash>::from_engine(engine).to_byte_array());
 
     Ok(zeroize::Zeroizing::new(stretched.to_vec()))
 }


### PR DESCRIPTION
The final retained-seed encryption key was first stored in a plain stack
array before being copied into a Zeroizing vector. Its SHA-512 expansion
into the AES and HMAC keys was likewise stored in a plain array.

Wrap both derived-key arrays in Zeroizing so their storage is wiped on
every return path. Retained ciphertext and the unstretched KDF input are
intentionally unchanged because they cannot decrypt the seed without the
secure-chip KDF.
