### PR TITLE
bb03: fix body text color

### DIFF
--- a/src/rust/bitbox03/src/ui/confirm.rs
+++ b/src/rust/bitbox03/src/ui/confirm.rs
@@ -60,6 +60,9 @@ pub fn build_confirm_screen(
     body_container.set_style_pad_left(0, 0);
     body_container.set_style_border_width(0, 0);
     body_container.set_style_bg_opa(LvOpacityLevel::LV_OPA_TRANSP as u8, 0);
+    // The theme's card style sets its own dark grey text color, which would otherwise shadow
+    // the screen's white for the label below.
+    body_container.set_style_text_color(lvgl::color::white(), 0);
     body_container.add_flag(LvObjFlag::LV_OBJ_FLAG_SCROLLABLE);
 
     let body = LvLabel::new(&body_container).unwrap();


### PR DESCRIPTION
Fixes bug introduced by commit 00fe58e00 where body text color is grey.

The scroll container introduced for long confirmation bodies is a plain LvObj, so the default LVGL theme applies its card style to it, which sets a dark grey text color. Label text color is inherited from the nearest ancestor that defines it, so the body label picked up the container's grey instead of the screen's white.

Override the text color on the container, like the commit already did for the card style's background and border.