### PR TITLE
bb03: fix confirmation body color

### DIFF
--- a/src/rust/bitbox-lvgl-sys/lv_conf.h
+++ b/src/rust/bitbox-lvgl-sys/lv_conf.h
@@ -817,7 +817,7 @@
 #define LV_USE_THEME_DEFAULT 1
 #if LV_USE_THEME_DEFAULT
     /** 0: Light mode; 1: Dark mode */
-    #define LV_THEME_DEFAULT_DARK 0
+    #define LV_THEME_DEFAULT_DARK 1
 
     /** 1: Enable grow on press */
     #define LV_THEME_DEFAULT_GROW 1


### PR DESCRIPTION
BB03 screens use black backgrounds, but LVGL's default light theme assigns dark text to nested containers. Enable the default dark theme so inherited text remains visible across the BB03 UI, including the pairing code.