### PR TITLE
Show EIP-712 primary type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 ## Firmware
 
 ### [Unreleased]
+- Ethereum: display the EIP-712 message type before signing
 
 ### v9.27.0
 - Display long transaction and swap amounts in full instead of truncating them

--- a/src/rust/bitbox02-rust/src/hww/api/ethereum/sign_typed_msg.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/ethereum/sign_typed_msg.rs
@@ -734,6 +734,18 @@ pub async fn process(
     )
     .await?;
 
+    confirm::confirm_value(
+        hal,
+        &ConfirmParams {
+            title: "Message type",
+            body: &request.primary_type,
+            scrollable: true,
+            accept_is_nextarrow: true,
+            ..Default::default()
+        },
+    )
+    .await?;
+
     let sighash: [u8; 32] = eip712_sighash(
         hal,
         &request.types,
@@ -1709,6 +1721,78 @@ mod tests {
 
         assert_eq!(result, Err(Error::InvalidInput));
         assert!(mock_hal.ui.screens.is_empty());
+    }
+
+    #[async_test::test]
+    async fn test_process_displays_primary_type() {
+        async fn run(primary_type: &'static str) -> Vec<Screen> {
+            mock_unlocked();
+            let typed_msg = alloc::rc::Rc::new(TypedMessage::new(
+                vec![
+                    StructType {
+                        name: DOMAIN_TYPE_NAME.into(),
+                        members: vec![mk_member("chainId", mk_sized_type(DataType::Uint, 32))],
+                    },
+                    StructType {
+                        name: "Authorize".into(),
+                        members: vec![mk_member("amount", mk_sized_type(DataType::Uint, 32))],
+                    },
+                    StructType {
+                        name: "Revoke".into(),
+                        members: vec![mk_member("amount", mk_sized_type(DataType::Uint, 32))],
+                    },
+                ],
+                primary_type,
+                Object::Struct(vec![Object::BigUint(BigUint::from(1u32))]),
+                Object::Struct(vec![Object::BigUint(BigUint::from(42u32))]),
+            ));
+            {
+                let typed_msg = typed_msg.clone();
+                *crate::hww::MOCK_NEXT_REQUEST.0.borrow_mut() = Some(Box::new(move |response| {
+                    Ok(typed_msg.handle_host_response(&response).unwrap())
+                }));
+            }
+
+            let mut mock_hal = TestingHal::new();
+            let result = process(
+                &mut mock_hal,
+                &pb::EthSignTypedMessageRequest {
+                    chain_id: 1,
+                    keypath: vec![44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
+                    types: typed_msg.types.clone(),
+                    primary_type: primary_type.into(),
+                    host_nonce_commitment: None,
+                },
+            )
+            .await;
+
+            assert!(matches!(result, Ok(Response::Sign(_))));
+            mock_hal.ui.screens
+        }
+
+        let mut authorize_screens = run("Authorize").await;
+        let mut revoke_screens = run("Revoke").await;
+
+        assert_eq!(
+            authorize_screens[1],
+            Screen::Confirm {
+                title: "Message type".into(),
+                body: "Authorize".into(),
+                longtouch: false,
+            }
+        );
+        assert_eq!(
+            revoke_screens[1],
+            Screen::Confirm {
+                title: "Message type".into(),
+                body: "Revoke".into(),
+                longtouch: false,
+            }
+        );
+
+        authorize_screens.remove(1);
+        revoke_screens.remove(1);
+        assert_eq!(authorize_screens, revoke_screens);
     }
 
     /// Test computation of the domain separator, which is `hashStruct(domain)`.
@@ -2725,6 +2809,11 @@ mod tests {
                 expected_screens.push(Screen::Confirm {
                     title: "Ethereum".into(),
                     body: address.clone(),
+                    longtouch: false,
+                });
+                expected_screens.push(Screen::Confirm {
+                    title: "Message type".into(),
+                    body: tc.primary_type.clone(),
                     longtouch: false,
                 });
                 expected_screens.extend(tc.expected_screens.iter().map(|(title, body)| {


### PR DESCRIPTION
Add a Message type confirmation before traversing typed data so the device
transcript binds the host-selected primary type.

Cover same-shaped requests with distinct primary types, update the end-to-end
signing screen expectation, and record the change in the firmware changelog.