### PR TITLE
ci: Test individual PR commits

### DIFF
--- a/.ci/matrix-from-commit-log
+++ b/.ci/matrix-from-commit-log
@@ -1,13 +1,15 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
+import json
 import subprocess
 import sys
-import json
 
-range = sys.argv[1]
+commits = subprocess.check_output(["git", "rev-list", "--reverse", sys.argv[1]], text=True).split()
 
-commits = subprocess.run(f'git log --format="%H" {range}', shell=True, text=True, capture_output=True)
-commits = commits.stdout.strip().split()
-
-if len(commits) > 0:
-  print(json.dumps({'commit': commits}))
+if commits:
+    total = len(commits)
+    matrix = [
+        {"commit": commit, "height": height, "total": total}
+        for height, commit in enumerate(commits, start=1)
+    ]
+    print(json.dumps({"include": matrix}))

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -24,7 +24,7 @@ jobs:
       base-sha: ${{ github.event.pull_request.base.sha }}
     secrets: inherit
 
-  # Build the firmware on every commit to simplify bisecting the firmware
+  # Build the firmware at every individual PR commit to simplify bisecting.
   generate-matrix:
     runs-on: ubuntu-22.04
     outputs:
@@ -35,26 +35,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      # HEAD~ because  we want to skip the last commit (which is built in job above)
       - name: Create jobs for commits in PR history
         id: set-matrix
         run: |
-          echo matrix=$(.ci/matrix-from-commit-log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}~) >> $GITHUB_OUTPUT
+          echo "matrix=$(.ci/matrix-from-commit-log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})" >> "$GITHUB_OUTPUT"
 
-  # Run this job for every commit in the PR except HEAD.
-  # This job simulates what github does for the PR HEAD commit but for every other commit in the
-  # PR. So for every commit, it creates a merge commit between that commit and the base branch.
-  # Then it runs the CI on that merge commit.
-  # The only caveat is that this file (pr-ci.yml) is already loaded from the PR HEAD merge commit,
-  # and therefore we need to load the `.ci` scripts from the PR HEAD merge commit. The outcome of
-  # that is that changes to the CI is not tested per commit. All commits use the final version.
+  # The full CI above checks the PR merged into its base. This job additionally builds each PR
+  # commit as-is, without the base branch merged in.
   pr-commit-ci:
+    name: Per commit bb02 build (${{ matrix.height }}/${{ matrix.total }})
     runs-on: ubuntu-22.04
-    needs: [ generate-matrix, dev-container ]
+    needs: [generate-matrix, dev-container]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    if: needs.generate-matrix.outputs.matrix != '' && !cancelled()
+    if: needs.generate-matrix.outputs.matrix != ''
     container:
       image: ${{ needs.dev-container.outputs.container-repo}}:${{ needs.dev-container.outputs.container-version }}
       env:
@@ -64,25 +59,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.base.sha }}
+          submodules: recursive
+          ref: ${{ matrix.commit }}
 
       - name: Mark directory as safe
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Create merge commit
-        env:
-          GIT_AUTHOR_NAME: Bot
-          GIT_AUTHOR_EMAIL: bot@bitbox.swiss
-          GIT_COMMITTER_NAME: Bot
-          GIT_COMMITTER_EMAIL: bot@bitbox.swiss
-        run: |
-          git fetch origin ${{ matrix.commit }} ${{ github.event.pull_request.merge_commit_sha }}
-          git merge --no-ff --no-edit ${{ matrix.commit }}
-          git submodule update --init --recursive
-          git log -1 --format="Head %H, Parents %P"
-          # Since the workflow definition is taken from the pull request merge commit, we need to
-          # get the .ci scripts from there as well.
-          git checkout -f ${{ github.event.pull_request.merge_commit_sha }} -- .ci .github
-
-      - name: build firmware
+      - name: Build firmware
         run: make -j$(($(nproc)+1)) firmware


### PR DESCRIPTION
Build each commit directly instead of creating a synthetic merge with the PR base. Include the head commit and label matrix jobs with their position in the PR history.