### PR TITLE
Validate ATECC response lengths

### DIFF
--- a/src/atecc/atecc.c
+++ b/src/atecc/atecc.c
@@ -123,11 +123,19 @@ static ATCA_STATUS _receive(void* iface, uint8_t word_address, uint8_t* rxdata, 
 {
     (void)iface;
     (void)word_address;
-    uint8_t ret = i2c_ecc_read(rxdata, *rxlength);
+    const uint16_t rxdata_capacity = *rxlength;
+    uint8_t ret = i2c_ecc_read(rxdata, rxdata_capacity);
     if (ret) {
         return ATCA_COMM_FAIL;
     }
-    *rxlength = rxdata[0];
+    const uint8_t response_length = rxdata[0];
+    if (response_length > rxdata_capacity) {
+        return ATCA_SMALL_BUFFER;
+    }
+    if (response_length < ATCA_RSP_SIZE_MIN) {
+        return ATCA_RX_FAIL;
+    }
+    *rxlength = response_length;
     return ATCA_SUCCESS;
 }
 

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -29,6 +29,8 @@ else()
   # Tests
 
   set(TEST_LIST
+     atecc
+     "-Wl,--gc-sections"
      bootloader_format
      ""
      cleanup
@@ -88,6 +90,13 @@ else()
     target_include_directories(${EXE} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
+    if(TEST_NAME STREQUAL "atecc")
+      target_compile_options(${EXE} PRIVATE -ffunction-sections -fdata-sections)
+      target_include_directories(${EXE} PRIVATE
+          ${CMAKE_SOURCE_DIR}/external
+          ${CMAKE_SOURCE_DIR}/external/cryptoauthlib/lib
+      )
+    endif()
     if(TEST_NAME STREQUAL "bootloader_format")
       target_sources(${EXE} PRIVATE ${CMAKE_SOURCE_DIR}/src/bootloader/bootloader_format.c)
       target_include_directories(${EXE} PRIVATE

--- a/test/unit-test/test_atecc.c
+++ b/test/unit-test/test_atecc.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+
+#include <stdint.h>
+
+// i2c_ecc.h intentionally hides the hardware interface in test builds. Expose its declarations
+// while including atecc.c below.
+#undef TESTING
+#include <i2c_ecc.h>
+#define TESTING
+
+#include "../../src/atecc/atecc.c"
+
+static uint8_t _read_result;
+static uint8_t _response_length;
+static uint32_t _received_capacity;
+
+uint8_t i2c_ecc_read(uint8_t* rxdata, uint32_t rxlen)
+{
+    _received_capacity = rxlen;
+    rxdata[0] = _response_length;
+    return _read_result;
+}
+
+uint8_t i2c_ecc_write(uint8_t* txdata, uint32_t txlen)
+{
+    (void)txdata;
+    (void)txlen;
+    return 0;
+}
+
+uint8_t i2c_ecc_idle(void)
+{
+    return 0;
+}
+
+uint8_t i2c_ecc_sleep(void)
+{
+    return 0;
+}
+
+uint8_t i2c_ecc_wake(void)
+{
+    return I2C_ECC_WAKE;
+}
+
+static void _test_receive(uint8_t response_length, uint16_t capacity, ATCA_STATUS expected_status)
+{
+    uint8_t response[16] = {0};
+    _read_result = 0;
+    _response_length = response_length;
+    _received_capacity = 0;
+
+    uint16_t length = capacity;
+    assert_int_equal(_receive(NULL, 0, response, &length), expected_status);
+    assert_int_equal(_received_capacity, capacity);
+    if (expected_status == ATCA_SUCCESS) {
+        assert_int_equal(length, response_length);
+    } else {
+        assert_int_equal(length, capacity);
+    }
+}
+
+static void test_receive_valid_length(void** state)
+{
+    (void)state;
+    _test_receive(7, 16, ATCA_SUCCESS);
+}
+
+static void test_receive_oversized_length(void** state)
+{
+    (void)state;
+    _test_receive(8, 7, ATCA_SMALL_BUFFER);
+}
+
+static void test_receive_undersized_length(void** state)
+{
+    (void)state;
+    _test_receive(ATCA_RSP_SIZE_MIN - 1, 16, ATCA_RX_FAIL);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_receive_valid_length),
+        cmocka_unit_test(test_receive_oversized_length),
+        cmocka_unit_test(test_receive_undersized_length),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Preserve the receive buffer capacity and reject malformed ATECC
response counts before CryptoAuthLib can use them for CRC validation.

Match the status codes used by the standard CryptoAuthLib I2C HAL and add
regression tests for undersized and oversized response counts.

Tests:
- ./scripts/dev_exec.sh make firmware
- ./scripts/dev_exec.sh make unit-test
- ./scripts/dev_exec.sh make run-unit-tests