### PR TITLE
factorysetup: fix RTT response endianness

### DIFF
--- a/src/factorysetup.c
+++ b/src/factorysetup.c
@@ -852,8 +852,8 @@ static void _rtt_send(const uint8_t* msg, size_t len)
         Abort("Buffer to send to host too large");
     }
     uint8_t len16[2];
-    len16[0] = (len >> 8) & 0xff;
-    len16[1] = len & 0xff;
+    len16[0] = len & 0xff;
+    len16[1] = (len >> 8) & 0xff;
     rust_rtt_ch1_write(&len16[0], LENSIZE);
     rust_rtt_ch1_write(msg, len);
 }


### PR DESCRIPTION
Commit dff5254d5 ("factory-setup: Remove C implementation of RTT") changed the
response length encoding from a native little-endian uint16_t to manually
assembled big-endian bytes.

This made host clients parse short response lengths as much larger values.
Restore little-endian encoding to match requests and existing clients.