### PR TITLE
backup: sanitize legacy device names

### DIFF
--- a/src/rust/bitbox02-rust/src/backup.rs
+++ b/src/rust/bitbox02-rust/src/backup.rs
@@ -70,6 +70,19 @@ pub fn id(seed: &[u8]) -> String {
     hex::encode(mac.finalize_reset().into_bytes())
 }
 
+/// Replaces non-printable-ASCII characters in legacy backup names with `?`.
+pub(crate) fn sanitize_name(name: &str) -> String {
+    name.chars()
+        .map(|character| {
+            if util::ascii::Charset::All.contains(character) {
+                character
+            } else {
+                '?'
+            }
+        })
+        .collect()
+}
+
 fn compute_checksum(
     metadata: &pb_backup::BackupMetaData,
     data: &pb_backup::BackupData,

--- a/src/rust/bitbox02-rust/src/hww/api/backup.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/backup.rs
@@ -29,10 +29,11 @@ pub async fn check(
         return Err(Error::Generic);
     }
     if !silent {
+        let name = backup::sanitize_name(&metadata.name);
         hal.ui()
             .confirm(&ConfirmParams {
                 title: "Name?",
-                body: &metadata.name,
+                body: &name,
                 scrollable: true,
                 accept_is_nextarrow: true,
                 ..Default::default()

--- a/src/rust/bitbox02-rust/src/hww/api/restore.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/restore.rs
@@ -32,9 +32,10 @@ pub async fn from_file(
         }
     };
 
+    let device_name = crate::backup::sanitize_name(&metadata.name);
     hal.ui()
         .confirm(&ConfirmParams {
-            body: &format!("Name: {}. ID: {}", &metadata.name, &request.id),
+            body: &format!("Name: {}. ID: {}", &device_name, &request.id),
             scrollable: true,
             accept_is_nextarrow: true,
             ..Default::default()
@@ -85,7 +86,7 @@ pub async fn from_file(
     hal.memory().set_initialized().or(Err(Error::Memory))?;
 
     // Ignore non-critical error.
-    let _ = hal.memory().set_device_name(&metadata.name);
+    let _ = hal.memory().set_device_name(&device_name);
 
     unlock::unlock_bip39(hal, seed, unlock_animation).await;
     Ok(Response::Success(pb::Success {}))
@@ -173,10 +174,46 @@ pub async fn from_mnemonic(
 mod tests {
     use super::*;
 
-    use crate::hal::testing::TestingHal;
+    use crate::hal::testing::{Screen, TestingHal};
 
     use alloc::boxed::Box;
     use alloc::vec::Vec;
+
+    #[async_test::test]
+    async fn test_from_file_legacy_backup_name() {
+        crate::keystore::lock();
+        let seed = [0x42; 32];
+        let mut mock_hal = TestingHal::new();
+        crate::backup::create(&mut mock_hal, &seed, "Bït\nBox\t", 0, 0)
+            .await
+            .unwrap();
+        let id = crate::backup::id(&seed);
+        mock_hal
+            .ui
+            .set_enter_string(Box::new(|_| Ok("password".into())));
+
+        assert_eq!(
+            from_file(
+                &mut mock_hal,
+                &pb::RestoreBackupRequest {
+                    id: id.clone(),
+                    timestamp: 0,
+                    timezone_offset: 0,
+                },
+            )
+            .await,
+            Ok(Response::Success(pb::Success {}))
+        );
+        assert_eq!(
+            mock_hal.ui.screens[1],
+            Screen::Confirm {
+                title: "".into(),
+                body: format!("Name: B?t?Box?. ID: {id}"),
+                longtouch: false,
+            }
+        );
+        assert_eq!(mock_hal.memory.get_device_name(), "B?t?Box?");
+    }
 
     #[async_test::test]
     async fn test_from_mnemonic() {

--- a/src/rust/util/src/ascii.rs
+++ b/src/rust/util/src/ascii.rs
@@ -12,12 +12,21 @@ pub enum Charset {
     AllNewline,
 }
 
+impl Charset {
+    /// Returns true if `character` is in this charset.
+    pub fn contains(&self, character: char) -> bool {
+        character.is_ascii_graphic()
+            || character == ' '
+            || (self == &Self::AllNewline && character == '\n')
+    }
+}
+
 /// Returns true if all bytes are in the given `charset`.
 pub fn is_printable_ascii<T: AsRef<[u8]>>(bytes: T, charset: Charset) -> bool {
     bytes
         .as_ref()
         .iter()
-        .all(|&b| (32..=126).contains(&b) || (charset == Charset::AllNewline && b == b'\n'))
+        .all(|&byte| charset.contains(char::from(byte)))
 }
 
 #[cfg(test)]
@@ -26,6 +35,15 @@ mod tests {
     use super::*;
 
     static ALL_ASCII: &[u8] = "! \"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~".as_bytes();
+
+    #[test]
+    fn test_contains() {
+        assert!(Charset::All.contains(' '));
+        assert!(Charset::All.contains('~'));
+        assert!(!Charset::All.contains('\n'));
+        assert!(!Charset::All.contains('ï'));
+        assert!(Charset::AllNewline.contains('\n'));
+    }
 
     #[test]
     fn test_is_printable_ascii() {


### PR DESCRIPTION
Legacy backups may contain device names with characters outside the printable-ASCII set supported by the BitBox02 UI and device-name storage. Passing such names through can omit characters or abort backup checks and restores as those boundaries are hardened.

Replace unsupported characters when consuming a backup so it remains usable and the restored device gets a valid name. Preserve the original metadata for checksum validation.

Add regression coverage for Unicode and control characters.