### PR TITLE
docs: require context prefixes in commit subjects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,14 @@ and refresh `make coverage` for cryptography or security-sensitive areas.
 - Focus on memory issues
 
 ## Commit & Pull Request Guidelines
-Write commits with a ≤50 character subject, blank line, and explanatory body per `CONTRIBUTING.md`;
-reference issues via `refs #1234` or `fixes #1234`. Keep patches atomic—avoid mixing formatting and
-logic. Pull requests should outline the change, list verification commands or screenshots, and flag
-hardware requirements; mark drafts with `[WIP]` until they are ready. Wait to squash until reviews
-conclude.
+
+Use `<context>: <summary>` for commit subjects. Inspect recent commits touching the affected
+code and reuse the established context prefix and style.
+
+Write commits with a ≤50 character subject (including the prefix), blank line, and explanatory body;
+reference issues via `refs #1234` or `fixes #1234`. Keep patches atomic—avoid
+mixing formatting and logic. Pull requests should outline the change, list verification commands or
+screenshots, and flag hardware requirements. Wait to squash until reviews conclude.
 
 
 ## Various

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,11 @@ atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention) an
 easy to read.  For this reason do not mix any formatting fixes or code moves with actual code
 changes in the same commit.
 
-Commit messages should be verbose by default consisting of a short subject line (50 chars max), a
+Use `<context>: <summary>` for commit subjects. Inspect recent commits touching the affected
+code and reuse the established context prefix and style. Keep the entire subject, including
+the prefix, within 50 characters.
+
+Commit messages should be verbose by default consisting of a short subject line, a
 blank line and detailed explanatory text as separate paragraph(s), unless the title alone is
 self-explanatory (like "Corrected typo in Makefile") in which case a single title line is
 sufficient.  Commit messages should be helpful to people reading your code in the future, so
@@ -25,7 +29,7 @@ explain the reasoning for your decisions.  Further explanation
 [here](http://chris.beams.io/posts/git-commit/).
 
 If a particular commit references another issue, please add the reference. For example: `refs
-#1234` or `fixes #4321`. 
+#1234` or `fixes #4321`.
 
 Please refer to the [Git manual](https://git-scm.com/doc) for more information about Git.
 


### PR DESCRIPTION
Require context-prefixed commit subjects and reuse the conventions in recent
commits touching the affected code. Apply the existing 50-character limit to
the complete subject, including the prefix.

State the rule directly in the agent guidelines and remove their redundant
contributor-guide reference and obsolete [WIP] draft-title instruction.
