### PR TITLE
hww: reject oversized USB responses

### DIFF
--- a/src/hww.c
+++ b/src/hww.c
@@ -121,6 +121,10 @@ static void _maybe_write_response(hww_packet_rsp_t* response)
         break;
     default:
         response->status = HWW_RSP_NACK;
+        // No task remains after a NACK, including rejection of an oversized response.
+        if (usb_processing_locked(usb_processing_hww())) {
+            usb_processing_unlock();
+        }
         break;
     }
 }

--- a/src/rust/bitbox02-rust-c/src/async_usb.rs
+++ b/src/rust/bitbox02-rust-c/src/async_usb.rs
@@ -28,7 +28,8 @@ pub enum UsbResponse {
 /// Polls for a result of an async usb task. If a result is available, it is copied to `out`.
 ///
 /// Returns:
-/// `UsbResponseNack` if no task is running.
+/// `UsbResponseNack` if no task is running or the response does not fit in `out`.
+/// An oversized response cancels the task, including any pending continuation.
 /// `UsbResponseAck` if the result was copied.
 /// `UsbResponseNotReady` if a task is running but not yet complete.
 #[unsafe(no_mangle)]
@@ -38,6 +39,13 @@ pub unsafe extern "C" fn rust_async_usb_copy_response(out: *mut bitbox02::buffer
     match take_response() {
         Ok(response) => {
             let len = response.len();
+            if len > dst.len() {
+                // This also drops a workflow waiting for the next request after an intermediate
+                // response that cannot be delivered. The host can start a fresh request/session.
+                bitbox02_rust::async_usb::cancel();
+                unsafe { (*out).len = 0 };
+                return UsbResponse::UsbResponseNack;
+            }
             dst[..len].copy_from_slice(&response);
             unsafe { (*out).len = len as _ };
             UsbResponse::UsbResponseAck
@@ -63,4 +71,75 @@ pub extern "C" fn rust_async_usb_on_request_hww(usb_in: util::bytes::Bytes) {
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_async_usb_cancel() {
     bitbox02_rust::async_usb::cancel()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitbox02_rust::async_usb::{cancel, is_idle, next_request, spin};
+
+    #[test]
+    fn test_rust_async_usb_copy_response() {
+        cancel();
+        async fn task(response: Vec<u8>) -> Vec<u8> {
+            response
+        }
+        let mut data = [0xaa; 4];
+        let mut out = bitbox02::buffer_t {
+            data: data.as_mut_ptr(),
+            len: 0,
+            max_len: data.len(),
+        };
+        assert!(matches!(
+            unsafe { rust_async_usb_copy_response(&mut out) },
+            UsbResponse::UsbResponseNack,
+        ));
+
+        // Oversized, exact-fit, short, and empty responses, with recovery after rejection.
+        for response in [&[1, 2, 3, 4, 5][..], &[1, 2, 3, 4], &[1, 2], &[]] {
+            data.fill(0xaa);
+            spawn(task, response);
+            assert!(matches!(
+                unsafe { rust_async_usb_copy_response(&mut out) },
+                UsbResponse::UsbResponseNotReady,
+            ));
+            spin();
+            let result = unsafe { rust_async_usb_copy_response(&mut out) };
+            if response.len() > data.len() {
+                assert!(matches!(result, UsbResponse::UsbResponseNack));
+                assert_eq!(out.len, 0);
+                assert_eq!(data, [0xaa; 4]);
+            } else {
+                assert!(matches!(result, UsbResponse::UsbResponseAck));
+                assert_eq!(out.len, response.len());
+                assert_eq!(&data[..out.len], response);
+                assert!(data[out.len..].iter().all(|byte| *byte == 0xaa));
+            }
+            assert!(is_idle());
+        }
+
+        // A rejected intermediate response must not leave its workflow waiting for input.
+        async fn intermediate(response: Vec<u8>) -> Vec<u8> {
+            next_request(response).await;
+            panic!("oversized intermediate response must cancel the workflow");
+        }
+        spawn(intermediate, &[1, 2, 3, 4, 5]);
+        spin();
+        assert!(matches!(
+            unsafe { rust_async_usb_copy_response(&mut out) },
+            UsbResponse::UsbResponseNack,
+        ));
+        assert!(is_idle());
+        assert!(!waiting_for_next_request());
+
+        spawn(task, &[1]);
+        spin();
+        assert!(matches!(
+            unsafe { rust_async_usb_copy_response(&mut out) },
+            UsbResponse::UsbResponseAck,
+        ));
+        assert_eq!(out.len, 1);
+        assert_eq!(data[0], 1);
+        assert!(is_idle());
+    }
 }

--- a/test/unit-test/test_hww.c
+++ b/test/unit-test/test_hww.c
@@ -43,10 +43,43 @@ static void test_hww_new_request_is_busy_while_u2f_active(void** state)
     assert_true(rust_usb_report_queue_free(queue));
 }
 
+static void test_hww_nack_unlocks_transport(void** state)
+{
+    (void)state;
+
+    RustUsbReportQueue* queue = rust_usb_report_queue_init();
+    assert_non_null(queue);
+    usb_processing_init(queue);
+    hww_setup();
+    _u2f_workflow_active = false;
+
+    usb_processing_lock(usb_processing_hww());
+    assert_true(usb_processing_locked(usb_processing_hww()));
+    // Check the locked transport, then an already unlocked transport on another retry.
+    for (int i = 0; i < 2; i++) {
+        const uint8_t request[] = {0x01}; // HWW_REQ_RETRY without a running task yields NACK.
+        const uint32_t cid = 0x12345678;
+        assert_true(
+            usb_processing_enqueue(usb_processing_hww(), request, sizeof(request), HWW_MSG, cid));
+        usb_processing_process(usb_processing_hww());
+        assert_false(usb_processing_locked(usb_processing_hww()));
+
+        USB_FRAME response;
+        assert_true(rust_usb_report_queue_pull(queue, (uint8_t*)&response));
+        assert_int_equal(response.cid, cid);
+        assert_int_equal(response.init.cmd, HWW_MSG);
+        assert_int_equal(FRAME_MSG_LEN(response), 1);
+        assert_int_equal(response.init.data[0], 3); // HWW_RSP_NACK
+        assert_false(rust_usb_report_queue_pull(queue, (uint8_t*)&response));
+    }
+    assert_true(rust_usb_report_queue_free(queue));
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_hww_new_request_is_busy_while_u2f_active),
+        cmocka_unit_test(test_hww_nack_unlocks_transport),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Check the actual HWW output buffer capacity before copying any asynchronous
response. Oversized responses return NACK, cancel a pending continuation,
and unlock the transport so the host can start a fresh session instead of
triggering a slice-bounds panic. This also covers oversized backup-list
and Cardano responses independently of producer-specific limits.

Add boundary and recovery tests for response-size handling, intermediate
response cancellation, and the C transport lock.