### PR TITLE
bitcoin: reject missing policy xpubs

### DIFF
--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/policies.rs
@@ -767,6 +767,7 @@ pub enum Mode {
 }
 
 /// Creates a hash of this policy config, useful for registration and identification.
+/// Returns an error if any key is missing its xpub or the xpub cannot be serialized.
 pub fn get_hash(coin: BtcCoin, policy: &Policy) -> Result<[u8; 32], ()> {
     let mut hasher = Sha256::new();
     {
@@ -796,16 +797,17 @@ pub fn get_hash(coin: BtcCoin, policy: &Policy) -> Result<[u8; 32], ()> {
         let num: u32 = policy.keys.len() as _;
         hasher.update(num.to_le_bytes());
         for key in policy.keys.iter() {
-            hasher.update(&bip32::Xpub::from(key.xpub.as_ref().unwrap()).serialize(None)?);
+            let xpub = key.xpub.as_ref().ok_or(())?;
+            hasher.update(&bip32::Xpub::from(xpub).serialize(None)?);
         }
     }
     Ok(hasher.finalize().into())
 }
 
-/// Get the name of a registered policy account. The policy is not validated, it must be
-/// pre-validated!
+/// Get the name of a registered policy account. The policy itself is not validated.
 ///
-/// Returns the name of the registered policy account if it exists or None otherwise.
+/// Returns the name of the registered policy account if it exists or None otherwise, or an error
+/// if any key is missing its xpub or the xpub cannot be serialized.
 pub fn get_name(
     hal: &mut impl crate::hal::Hal,
     coin: BtcCoin,
@@ -2074,6 +2076,17 @@ mod tests {
                 .await,
             Err(Error::InvalidInput)
         ));
+    }
+
+    #[test]
+    fn test_get_hash_missing_xpub() {
+        let valid_keys = [make_key(SOME_XPUB_1), make_key(SOME_XPUB_2)];
+        for missing_index in 0..valid_keys.len() {
+            let mut keys = valid_keys.clone();
+            keys[missing_index].xpub = None;
+            let policy = make_policy("wsh(multi(2,@0/**,@1/**))", &keys);
+            assert_eq!(get_hash(BtcCoin::Btc, &policy), Err(()));
+        }
     }
 
     #[async_test::test]

--- a/src/rust/bitbox02-rust/src/hww/api/bitcoin/registration.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bitcoin/registration.rs
@@ -49,7 +49,9 @@ pub fn process_is_script_config_registered(
             let coin = BtcCoin::try_from(*coin)?;
             Ok(Response::IsScriptConfigRegistered(
                 pb::BtcIsScriptConfigRegisteredResponse {
-                    is_registered: super::policies::get_name(hal, coin, policy)?.is_some(),
+                    is_registered: super::policies::get_name(hal, coin, policy)
+                        .map_err(|_| Error::InvalidInput)?
+                        .is_some(),
                 },
             ))
         }
@@ -173,6 +175,84 @@ mod tests {
     use crate::hal::testing::TestingHal;
 
     use pb::btc_script_config::{Multisig, multisig::ScriptType};
+
+    #[test]
+    fn test_process_is_script_config_registered_policy() {
+        let mut mock_hal = TestingHal::new();
+        let policy = pb::btc_script_config::Policy {
+            policy: "wsh(pk(@0/**))".into(),
+            keys: vec![pb::KeyOriginInfo {
+                xpub: Some(parse_xpub("xpub6FMWuwbCA9KhoRzAMm63ZhLspk5S2DM5sePo8J8mQhcS1xyMbAqnc7Q7UescVEVFCS6qBMQLkEJWQ9Z3aDPgBov5nFUYxsJhwumsxM4npSo").unwrap()),
+                ..Default::default()
+            }],
+        };
+        let hash = super::super::policies::get_hash(BtcCoin::Btc, &policy).unwrap();
+        let request = pb::BtcIsScriptConfigRegisteredRequest {
+            registration: Some(pb::BtcScriptConfigRegistration {
+                coin: BtcCoin::Btc as _,
+                script_config: Some(pb::BtcScriptConfig {
+                    config: Some(Config::Policy(policy)),
+                }),
+                keypath: vec![],
+            }),
+        };
+        assert_eq!(
+            process_is_script_config_registered(&mut mock_hal, &request),
+            Ok(Response::IsScriptConfigRegistered(
+                pb::BtcIsScriptConfigRegisteredResponse {
+                    is_registered: false,
+                },
+            ))
+        );
+        mock_hal
+            .memory
+            .multisig_set_by_hash(&hash, "some name")
+            .unwrap();
+        assert_eq!(
+            process_is_script_config_registered(&mut mock_hal, &request),
+            Ok(Response::IsScriptConfigRegistered(
+                pb::BtcIsScriptConfigRegisteredResponse {
+                    is_registered: true,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn test_process_is_script_config_registered_policy_invalid_xpub() {
+        let valid_keys = vec![
+            pb::KeyOriginInfo {
+                xpub: Some(parse_xpub("xpub6FMWuwbCA9KhoRzAMm63ZhLspk5S2DM5sePo8J8mQhcS1xyMbAqnc7Q7UescVEVFCS6qBMQLkEJWQ9Z3aDPgBov5nFUYxsJhwumsxM4npSo").unwrap()),
+                ..Default::default()
+            },
+            pb::KeyOriginInfo {
+                xpub: Some(parse_xpub("xpub6EMfjyGVUvwhpc3WKN1zXhMFGKJGMaSBPqbja4tbGoYvRBSXeTBCaqrRDjcuGTcaY95JrrAnQvDG3pdQPdtnYUCugjeksHSbyZT7rq38VQF").unwrap()),
+                ..Default::default()
+            },
+        ];
+        for invalid_index in 0..valid_keys.len() {
+            for invalid_xpub in [None, Some(pb::XPub::default())] {
+                let mut keys = valid_keys.clone();
+                keys[invalid_index].xpub = invalid_xpub;
+                let request = pb::BtcIsScriptConfigRegisteredRequest {
+                    registration: Some(pb::BtcScriptConfigRegistration {
+                        coin: BtcCoin::Btc as _,
+                        script_config: Some(pb::BtcScriptConfig {
+                            config: Some(Config::Policy(pb::btc_script_config::Policy {
+                                policy: "wsh(multi(2,@0/**,@1/**))".into(),
+                                keys,
+                            })),
+                        }),
+                        keypath: vec![],
+                    }),
+                };
+                assert_eq!(
+                    process_is_script_config_registered(&mut TestingHal::new(), &request),
+                    Err(Error::InvalidInput)
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_process_is_script_config_registered() {


### PR DESCRIPTION
Policy registration-status queries hash host-provided policies without parsing them first.
A missing optional xpub currently panics in the shared hash helper.

Return an error for absent xpubs and report invalid lookup keys as InvalidInput. Keep policy
parsing, valid hash bytes and existing registration lookups unchanged.

Cover missing and malformed xpubs in either key position, successful registration lookups and
the shared hash helper with regression tests.