### PR TITLE
keystore: defer cancellation during rekey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### [Unreleased]
 - Reject malformed microSD backups instead of crashing
+- Protect password changes and password-algorithm migration from host timeout cancellation
 
 ### v9.27.1
 - API: include the installed bootloader version in the device info response

--- a/src/hww.c
+++ b/src/hww.c
@@ -229,9 +229,9 @@ void hww_blocked_req_error(Packet* out_packet, const Packet* in_packet)
     out_packet->data_addr[0] = HWW_RSP_BUSY;
 }
 
-void hww_abort_outstanding_op(void)
+bool hww_abort_outstanding_op(void)
 {
-    rust_async_usb_cancel();
+    return rust_async_usb_cancel();
 }
 
 void hww_setup(void)

--- a/src/hww.h
+++ b/src/hww.h
@@ -34,7 +34,8 @@ void hww_blocked_req_error(Packet* out_packet, const Packet* in_packet);
 
 /**
  * Called to abort any operation that blocked the HWW stack.
+ * Returns false while a protected operation is finishing and the stack must remain locked.
  */
-void hww_abort_outstanding_op(void);
+bool hww_abort_outstanding_op(void);
 
 #endif

--- a/src/rust/bitbox-platform-host/src/securechip.rs
+++ b/src/rust/bitbox-platform-host/src/securechip.rs
@@ -23,6 +23,7 @@ pub struct FakeSecureChip {
     mock_attestation_signature: [u8; 64],
     mock_random_values: VecDeque<[u8; 32]>,
     last_attestation_challenge: Option<[u8; 32]>,
+    rekey_yields: bool,
 }
 
 impl FakeSecureChip {
@@ -35,6 +36,7 @@ impl FakeSecureChip {
             mock_attestation_signature: [0u8; 64],
             mock_random_values: VecDeque::new(),
             last_attestation_challenge: None,
+            rekey_yields: false,
         }
     }
 
@@ -69,10 +71,29 @@ impl FakeSecureChip {
     pub fn last_attestation_challenge(&self) -> Option<[u8; 32]> {
         self.last_attestation_challenge
     }
+
+    /// Suspend once in password initialization and random generation, so tests can cancel an
+    /// outstanding operation instead of having the fake complete every operation synchronously.
+    pub fn mock_rekey_yields(&mut self) {
+        self.rekey_yields = true;
+    }
+
+    async fn rekey_yield(&self) {
+        let mut pending = self.rekey_yields;
+        core::future::poll_fn(move |_| {
+            if core::mem::take(&mut pending) {
+                core::task::Poll::Pending
+            } else {
+                core::task::Poll::Ready(())
+            }
+        })
+        .await;
+    }
 }
 
 impl bitbox_hal::SecureChip for FakeSecureChip {
     async fn random(&mut self) -> Result<Box<zeroize::Zeroizing<[u8; 32]>>, Error> {
+        self.rekey_yield().await;
         Ok(Box::new(zeroize::Zeroizing::new(
             self.mock_random_values.pop_front().unwrap_or([0u8; 32]),
         )))
@@ -86,6 +107,7 @@ impl bitbox_hal::SecureChip for FakeSecureChip {
         password_stretch_algo: PasswordStretchAlgo,
     ) -> Result<Box<zeroize::Zeroizing<[u8; 32]>>, Error> {
         self.event_counter += 3;
+        self.rekey_yield().await;
 
         let key: &'static [u8] = match password_stretch_algo {
             PasswordStretchAlgo::V0 => b"unit-test-v0",

--- a/src/rust/bitbox02-rust-c/src/async_usb.rs
+++ b/src/rust/bitbox02-rust-c/src/async_usb.rs
@@ -61,6 +61,6 @@ pub extern "C" fn rust_async_usb_on_request_hww(usb_in: util::bytes::Bytes) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rust_async_usb_cancel() {
+pub extern "C" fn rust_async_usb_cancel() -> bool {
     bitbox02_rust::async_usb::cancel()
 }

--- a/src/rust/bitbox02-rust/src/async_usb.rs
+++ b/src/rust/bitbox02-rust/src/async_usb.rs
@@ -8,6 +8,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::task::Poll;
 use util::bb02_async::{Task, option, spin as spin_task};
+use util::cell::SyncCell;
 
 type UsbOut = Vec<u8>;
 type UsbIn = Vec<u8>;
@@ -73,6 +74,30 @@ unsafe impl Sync for SafeUsbTaskState {}
 /// Executor main state. Currently we only have at most one task at a time (usb api processing
 /// task).
 static USB_TASK_STATE: SafeUsbTaskState = SafeUsbTaskState(RefCell::new(UsbTaskState::Nothing));
+
+static CANCELLATION_GUARDS: SyncCell<usize> = SyncCell::new(0);
+static CANCELLATION_REQUESTED: SyncCell<bool> = SyncCell::new(false);
+
+/// Keep the current USB task alive across a local operation which must not be interrupted by the host.
+/// Do not hold this guard while waiting for user input or another host request. Cancellation is
+/// applied after the last guard is dropped and the current poll returns to the executor.
+/// This is a no-op outside the USB executor, e.g. in a detached U2F unlock workflow.
+pub(crate) fn defer_cancellation() -> impl Drop {
+    struct Guard(bool);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            if self.0 {
+                CANCELLATION_GUARDS.write(CANCELLATION_GUARDS.read() - 1);
+            }
+        }
+    }
+
+    let active = matches!(*USB_TASK_STATE.0.borrow(), UsbTaskState::Running(None, _));
+    if active {
+        CANCELLATION_GUARDS.write(CANCELLATION_GUARDS.read() + 1);
+    }
+    Guard(active)
+}
 
 /// Spawn a task to be spinned by the executor. This moves the state
 /// from Nothing to Running.
@@ -156,6 +181,9 @@ pub fn spin() {
     };
     if let Some(ref mut task) = popped_task {
         let spin_result = spin_task(task);
+        if CANCELLATION_REQUESTED.read() && CANCELLATION_GUARDS.read() == 0 {
+            cancel();
+        }
         if matches!(*USB_TASK_STATE.0.borrow(), UsbTaskState::Nothing) {
             // The task was cancelled while it was running, so there is nothing to do with the
             // result.
@@ -223,10 +251,19 @@ pub fn take_response() -> Result<UsbOut, CopyResponseErr> {
 /// fetch a response. Call this inside a running task only if you expect that the host may not be
 /// able to read the result (e.g. when resetting the BLE chip as part of a task), so another task
 /// can spawn afterwards immediately instead of being blocked by stale executor state.
-pub fn cancel() {
+///
+/// Returns false if cancellation is deferred until a protected local operation finishes. The
+/// transport must remain busy in that case; accepting another task could interrupt the operation.
+pub fn cancel() -> bool {
+    if CANCELLATION_GUARDS.read() != 0 {
+        CANCELLATION_REQUESTED.write(true);
+        return false;
+    }
+    CANCELLATION_REQUESTED.write(false);
     let _ = NEXT_REQUEST.0.borrow_mut().take();
     let mut state = USB_TASK_STATE.0.borrow_mut();
     *state = UsbTaskState::Nothing;
+    true
 }
 
 /// Must be called during the execution of a usb task. This sends out the response to the host and
@@ -441,5 +478,101 @@ mod tests {
         on_next_request(&[9]);
         spin();
         assert_eq!(Ok(vec![8]), take_response());
+    }
+
+    #[async_test::test]
+    async fn test_cancel_deferred_until_last_guard_is_dropped() {
+        let _guard = test_guard();
+        static STEPS: SyncCell<u8> = SyncCell::new(0);
+
+        async fn yield_once() {
+            let mut first_poll = true;
+            core::future::poll_fn(move |_| {
+                if core::mem::take(&mut first_poll) {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            })
+            .await;
+        }
+
+        async fn task(_usb_in: UsbIn) -> UsbOut {
+            let outer = defer_cancellation();
+            {
+                let _inner = defer_cancellation();
+                yield_once().await;
+                STEPS.write(1);
+            }
+            yield_once().await;
+            STEPS.write(2);
+            drop(outer);
+            yield_once().await;
+            // A pending cancellation must drop the task before polling this continuation.
+            STEPS.write(3);
+            vec![42]
+        }
+
+        for _ in 0..2 {
+            STEPS.write(0);
+            spawn(task, &[]);
+            spin();
+            for expected_step in 0..2 {
+                assert_eq!(STEPS.read(), expected_step);
+                assert!(!cancel());
+                assert!(!cancel());
+                assert!(!is_idle());
+                assert_eq!(take_response(), Err(CopyResponseErr::NotReady));
+                spin();
+            }
+            assert_eq!(STEPS.read(), 2);
+            assert!(is_idle());
+            assert_eq!(take_response(), Err(CopyResponseErr::NotRunning));
+        }
+
+        // Without cancellation, the same guarded task finishes normally.
+        spawn(task, &[]);
+        for _ in 0..4 {
+            spin();
+        }
+        assert_eq!(STEPS.read(), 3);
+        assert_eq!(take_response(), Ok(vec![42]));
+    }
+
+    #[async_test::test]
+    async fn test_cancel_deferred_during_poll_and_error_return() {
+        let _guard = test_guard();
+
+        async fn operation() -> Result<(), ()> {
+            let _guard = defer_cancellation();
+            assert!(!cancel());
+            assert!(!is_idle());
+            Err(())
+        }
+        async fn task(_usb_in: UsbIn) -> UsbOut {
+            assert!(operation().await.is_err());
+            vec![42]
+        }
+
+        spawn(task, &[]);
+        spin();
+        assert!(is_idle());
+        assert_eq!(take_response(), Err(CopyResponseErr::NotRunning));
+        assert!(cancel());
+    }
+
+    #[async_test::test]
+    async fn test_defer_cancellation_outside_usb_task() {
+        let _guard = test_guard();
+        let _cancellation_guard = defer_cancellation();
+        assert!(cancel());
+        assert!(is_idle());
+        async fn task(_usb_in: UsbIn) -> UsbOut {
+            core::future::pending().await
+        }
+        spawn(task, &[]);
+        spin();
+        assert!(cancel());
+        assert!(is_idle());
     }
 }

--- a/src/rust/bitbox02-rust/src/hww/transport.rs
+++ b/src/rust/bitbox02-rust/src/hww/transport.rs
@@ -323,6 +323,42 @@ mod tests {
         assert!(crate::async_usb::is_idle());
     }
 
+    #[async_test::test]
+    async fn test_timeout_keeps_protected_request_busy() {
+        let _guard = test_guard();
+        async fn task(request: Vec<u8>) -> Vec<u8> {
+            let _guard = crate::async_usb::defer_cancellation();
+            ready_after_second_spin_task(request).await
+        }
+        crate::async_usb::spawn(task, &[]);
+        crate::async_usb::spin();
+        let mut handler = handler();
+        assert_eq!(
+            handler
+                .handle_vendor_command(1, HWW_CMD, &[HWW_REQ_RETRY], 0)
+                .unwrap(),
+            vec![HWW_RSP_NOT_READY],
+        );
+        handler.tick(USB_OUTSTANDING_OP_TIMEOUT_MS + 1);
+        assert!(!crate::async_usb::is_idle());
+        assert_eq!(
+            handler
+                .handle_vendor_command(1, HWW_CMD, &[HWW_REQ_NEW, 0], 1000)
+                .unwrap(),
+            vec![HWW_RSP_BUSY],
+        );
+        handler.tick(2000);
+        assert!(!crate::async_usb::is_idle());
+        crate::async_usb::spin();
+        assert!(crate::async_usb::is_idle());
+        assert_eq!(
+            handler
+                .handle_vendor_command(1, HWW_CMD, &[HWW_REQ_RETRY], 2001)
+                .unwrap(),
+            vec![HWW_RSP_NACK],
+        );
+    }
+
     #[test]
     fn test_completed_outstanding_request_times_out_without_retry() {
         let _guard = test_guard();

--- a/src/rust/bitbox02-rust/src/keystore.rs
+++ b/src/rust/bitbox02-rust/src/keystore.rs
@@ -336,6 +336,10 @@ async fn encrypt_and_store_seed_internal(
 
     let password_stretch_algo = default_password_stretch_algo(hal)?;
 
+    // Rekeying replaces persistent secure-chip secrets before compatible seed ciphertext is
+    // stored. Finish storing and verifying the seed even if the host disconnects or times out.
+    // This protects against task cancellation, not power loss or secure-chip/flash errors.
+    let _cancellation_guard = crate::async_usb::defer_cancellation();
     let secret = {
         let subsystems = hal.as_mut();
         subsystems
@@ -1133,6 +1137,103 @@ mod tests {
         // Step 5: Verify new password works
         let unlocked_seed_new = unlock(&mut mock_hal, "new_password").await.unwrap();
         assert_eq!(unlocked_seed_new.as_slice(), seed.as_slice());
+    }
+
+    #[async_test::test]
+    async fn test_rekey_defers_cancellation() {
+        extern crate std;
+        use crate::async_usb;
+        use core::cell::RefCell;
+
+        const SEED: [u8; 32] =
+            hex!("cb33c20cea62a5c277527e2002da82e6e2b37450a755143a540a54cea8da9044");
+        std::thread_local! {
+            static HAL: RefCell<Option<TestingHal<'static>>> = const { RefCell::new(None) };
+        }
+        // Keep the fake persistent stores available after the executor drops the request.
+        struct ReturnHal(Option<TestingHal<'static>>);
+        impl Drop for ReturnHal {
+            fn drop(&mut self) {
+                HAL.with(|hal| *hal.borrow_mut() = self.0.take());
+            }
+        }
+        async fn task(request: Vec<u8>) -> Vec<u8> {
+            let mut saved = ReturnHal(HAL.with(|hal| hal.borrow_mut().take()));
+            let hal = saved.0.as_mut().unwrap();
+            if request[0] == 2 {
+                unlock(hal, "old_password").await.unwrap();
+            } else {
+                re_encrypt_seed(hal, &SEED, "new_password").await.unwrap();
+            }
+            vec![]
+        }
+
+        // Explicit password changes with either secure chip, and automatic Optiga V0 -> V1
+        // migration. Repeat the sequence to catch cancellation state leaking into later requests.
+        for case in [0, 1, 2, 0, 1, 2] {
+            assert!(async_usb::cancel());
+            lock();
+            let mut hal = TestingHal::new();
+            hal.memory.set_securechip_type(if case == 1 {
+                memory::SecurechipType::Optiga
+            } else {
+                memory::SecurechipType::Atecc
+            });
+            encrypt_and_store_seed(&mut hal, &SEED, "old_password")
+                .await
+                .unwrap();
+            unlock_bip39(
+                &mut KeystoreHalImpl::from_hal(&mut hal),
+                &SEED,
+                "",
+                async || {},
+            )
+            .await
+            .unwrap();
+            if case == 2 {
+                hal.memory
+                    .set_securechip_type(memory::SecurechipType::Optiga);
+                lock();
+            }
+            hal.securechip.mock_rekey_yields();
+            HAL.with(|saved| *saved.borrow_mut() = Some(hal));
+
+            async_usb::spawn(task, &[case]);
+            async_usb::spin();
+            let mut polls = 0;
+            while !async_usb::is_idle() {
+                assert!(polls < 20);
+                // Cancellation during key initialization, IV generation, or retaining the seed
+                // must not drop the request. Repeated watchdog expiry must not change that.
+                assert!(!async_usb::cancel());
+                assert!(!async_usb::cancel());
+                async_usb::spin();
+                polls += 1;
+            }
+            assert!(polls >= 2);
+            let mut hal = HAL.with(|saved| saved.borrow_mut().take().unwrap());
+            lock();
+            let password = if case == 2 {
+                "old_password"
+            } else {
+                "new_password"
+            };
+            assert_eq!(unlock(&mut hal, password).await.unwrap().as_slice(), SEED);
+            assert_eq!(
+                hal.memory.get_encrypted_seed_and_hmac().unwrap().1,
+                if case == 0 {
+                    memory::PasswordStretchAlgo::V0
+                } else {
+                    memory::PasswordStretchAlgo::V1
+                },
+            );
+            if case != 2 {
+                assert!(matches!(
+                    unlock(&mut hal, "old_password").await,
+                    Err(Error::IncorrectPassword)
+                ));
+            }
+        }
     }
 
     #[async_test::test]

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -1059,7 +1059,8 @@ void u2f_device_setup(void)
         usb_processing_u2f(), u2f_cmd_callbacks, sizeof(u2f_cmd_callbacks) / sizeof(CMD_Callback));
 }
 
-void u2f_abort_outstanding_op(void)
+bool u2f_abort_outstanding_op(void)
 {
     util_log("u2f_abort_outstanding_op");
+    return true;
 }

--- a/src/u2f.h
+++ b/src/u2f.h
@@ -33,7 +33,8 @@ void u2f_process(void);
 
 /**
  * Called to abort any operation that blocked the U2F stack.
+ * Returns true to allow the transport lock to be released.
  */
-void u2f_abort_outstanding_op(void);
+bool u2f_abort_outstanding_op(void);
 
 #endif

--- a/src/usb/usb_processing.c
+++ b/src/usb/usb_processing.c
@@ -62,10 +62,10 @@ struct usb_processing {
      */
     bool (*can_request_unblock)(const Packet* in_packet);
     /**
-     * Callback to forcefully abort any operation processing
-     * on this stack.
+     * Callback to abort any operation processing on this stack.
+     * Returns false if cancellation is deferred and the stack must remain locked.
      */
-    void (*abort_outstanding_op)(void);
+    bool (*abort_outstanding_op)(void);
 #endif
 };
 
@@ -307,7 +307,7 @@ static void _usb_consume_incoming_packets(struct usb_processing* ctx)
 /**
  * Check if the lock timer has expired for this context.
  * If it has, call the abort_outstanding_op function and unlock
- * the USB stack.
+ * the USB stack once cancellation is complete.
  *
  * @param ctx Context to check.
  */
@@ -322,8 +322,9 @@ static void _check_lock_timeout(struct usb_processing* ctx)
         if (!ctx->abort_outstanding_op) {
             Abort("abort_outstanding_op is NULL.");
         }
-        ctx->abort_outstanding_op();
-        usb_processing_unlock();
+        if (ctx->abort_outstanding_op()) {
+            usb_processing_unlock();
+        }
     }
 }
 #endif

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
      gestures
      ""
      hww
-     "-Wl,--wrap=rust_workflow_u2f_is_active"
+     "-Wl,--wrap=rust_workflow_u2f_is_active,--wrap=rust_async_usb_cancel"
      u2f_state
      ""
      random

--- a/test/unit-test/test_hww.c
+++ b/test/unit-test/test_hww.c
@@ -11,6 +11,14 @@
 #include <usb/usb_processing.h>
 
 static bool _u2f_workflow_active = false;
+static bool _cancellation_complete = true;
+static unsigned int _cancellation_requests = 0;
+
+bool __wrap_rust_async_usb_cancel(void)
+{
+    _cancellation_requests++;
+    return _cancellation_complete;
+}
 
 bool __wrap_rust_workflow_u2f_is_active(void)
 {
@@ -43,10 +51,34 @@ static void test_hww_new_request_is_busy_while_u2f_active(void** state)
     assert_true(rust_usb_report_queue_free(queue));
 }
 
+static void test_hww_timeout_keeps_lock_until_cancelled(void** state)
+{
+    (void)state;
+    RustUsbReportQueue* queue = rust_usb_report_queue_init();
+    assert_non_null(queue);
+    usb_processing_init(queue);
+    hww_setup();
+    usb_processing_lock(usb_processing_hww());
+    usb_processing_timeout_reset(6);
+
+    _cancellation_complete = false;
+    for (unsigned int i = 0; i < 3; i++) {
+        usb_processing_process(usb_processing_hww());
+        assert_true(usb_processing_locked(usb_processing_hww()));
+        assert_int_equal(_cancellation_requests, i + 1);
+    }
+    _cancellation_complete = true;
+    usb_processing_process(usb_processing_hww());
+    assert_false(usb_processing_locked(usb_processing_hww()));
+    assert_int_equal(_cancellation_requests, 4);
+    assert_true(rust_usb_report_queue_free(queue));
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_hww_new_request_is_busy_while_u2f_active),
+        cmocka_unit_test(test_hww_timeout_keeps_lock_until_cancelled),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Password rekey replaces secure-chip secrets before compatible seed ciphertext
is committed to flash. A host timeout must not drop this operation halfway
through and leave only an unusable ciphertext.

Defer USB-task cancellation across password initialization, encrypted seed
storage, read-back verification and seed retention. Apply pending cancellation
once the guarded interval completes, retaining the legacy transport lock until
then so another request cannot replace the active task. Detached U2F workflows
and ordinary cancellable work keep their existing behavior.

Cover explicit password changes with both password algorithms and automatic
Optiga V0-to-V1 migration, repeated cancellation, error cleanup and transport
busy state. Add a changelog entry.

This is deliberately limited to host-induced task cancellation. Physical power
loss, secure-chip failures and flash write failures still need recoverable
cross-store persistence; this patch does not make rekey power-loss atomic.