### PR TITLE
factorysetup: trim unused peripherals and font

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,6 +120,12 @@ set(QTOUCH-SOURCES
 )
 set(QTOUCH-SOURCES ${QTOUCH-SOURCES} PARENT_SCOPE)
 
+set(PLATFORM-BITBOX02-OLED-SOURCES
+  ${CMAKE_SOURCE_DIR}/src/ui/oled/sh1107.c
+  ${CMAKE_SOURCE_DIR}/src/ui/oled/ssd1312.c
+)
+set(PLATFORM-BITBOX02-OLED-SOURCES ${PLATFORM-BITBOX02-OLED-SOURCES} PARENT_SCOPE)
+
 # The additional files required for the plus platform
 set(PLATFORM-BITBOX02-PLUS-SOURCES
   ${CMAKE_SOURCE_DIR}/src/da14531/da14531.c
@@ -134,8 +140,7 @@ set(PLATFORM-BITBOX02-SOURCES
   ${CMAKE_SOURCE_DIR}/src/sd_mmc/sd_mmc_ext.c
   ${CMAKE_SOURCE_DIR}/src/usb/class/hid/hid.c
   ${CMAKE_SOURCE_DIR}/src/usb/class/hid/hww/hid_hww.c
-  ${CMAKE_SOURCE_DIR}/src/ui/oled/sh1107.c
-  ${CMAKE_SOURCE_DIR}/src/ui/oled/ssd1312.c
+  ${PLATFORM-BITBOX02-OLED-SOURCES}
   ${DBB-FIRMWARE-USB-SOURCES}
 )
 set(PLATFORM-BITBOX02-SOURCES ${PLATFORM-BITBOX02-SOURCES} PARENT_SCOPE)
@@ -399,7 +404,17 @@ if(CMAKE_CROSSCOMPILING)
 
   foreach(firmware ${FIRMWARES})
     set(elf ${firmware}.elf)
-    add_executable(${elf} ${FIRMWARE-SOURCES})
+    set(TARGET_FIRMWARE_SOURCES ${FIRMWARE-SOURCES})
+    if(firmware STREQUAL "factory-setup")
+      list(REMOVE_ITEM TARGET_FIRMWARE_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/hww.c
+        ${CMAKE_SOURCE_DIR}/src/sd.c
+        ${CMAKE_SOURCE_DIR}/src/touch/gestures.c
+        ${CMAKE_SOURCE_DIR}/src/usb/usb_processing.c
+        ${QTOUCH-SOURCES}
+      )
+    endif()
+    add_executable(${elf} ${TARGET_FIRMWARE_SOURCES})
     # Static libraries are LTO-capable for firmware size, but only firmware images do the LTO link.
     if(firmware STREQUAL "factory-setup")
       target_compile_options(${elf} PRIVATE -fno-lto)
@@ -427,7 +442,9 @@ if(CMAKE_CROSSCOMPILING)
     target_link_libraries(${elf} PRIVATE "-Wl,-Map=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${firmware}.map\" -T\"${CMAKE_SOURCE_DIR}/firmware.ld\"")
     target_link_libraries(${elf} PRIVATE -Wl,--defsym=STACK_SIZE=${STACK_SIZE} -Wl,-defsym=HEAP_SIZE=${HEAP_SIZE})
 
-    target_link_libraries(${elf} PRIVATE ${QTOUCHLIB_A} ${QTOUCHLIB_B} ${QTOUCHLIB_T})
+    if(NOT firmware STREQUAL "factory-setup")
+      target_link_libraries(${elf} PRIVATE ${QTOUCHLIB_A} ${QTOUCHLIB_B} ${QTOUCHLIB_T})
+    endif()
 
     # Select the smaller version of libc called nano.
     target_compile_options(${elf} PRIVATE --specs=nano.specs)
@@ -452,7 +469,7 @@ if(CMAKE_CROSSCOMPILING)
 
   target_sources(factory-setup.elf PRIVATE factorysetup.c)
   target_compile_definitions(factory-setup.elf PRIVATE PRODUCT_BITBOX02_FACTORYSETUP "APP_U2F=0")
-  target_sources(factory-setup.elf PRIVATE ${PLATFORM-BITBOX02-SOURCES})
+  target_sources(factory-setup.elf PRIVATE ${PLATFORM-BITBOX02-OLED-SOURCES})
 
   set(BB02_BLUPD_BIN_DIR ${CMAKE_SOURCE_DIR}/src/bootloader_upgrade/bin)
   set(BB02_BLUPD_STAGE0_BITBOX02_BTCONLY_PRODUCTION_BIN ${BB02_BLUPD_BIN_DIR}/bootloader-stage0-bitbox02-btconly-production.v1.bin)

--- a/src/da14531/da14531_handler.c
+++ b/src/da14531/da14531_handler.c
@@ -5,17 +5,21 @@
 #include "hardfault.h"
 #include "memory/memory.h"
 #include "memory/memory_shared.h"
-#include "screen.h"
-#include "ui/screen_stack.h"
-#include "ui/ui_util.h"
-#include "usb/class/usb_size.h"
-#include "usb/usb_frame.h"
-#include "usb/usb_packet.h"
-#include "usb/usb_processing.h"
+#if FACTORYSETUP == 0
+    #include "screen.h"
+    #include "ui/screen_stack.h"
+    #include "ui/ui_util.h"
+    #include "usb/class/usb_size.h"
+    #include "usb/usb_frame.h"
+    #include "usb/usb_packet.h"
+    #include "usb/usb_processing.h"
+#endif
 #include <rust/rust.h>
-#include <ui/components/confirm.h>
-#include <ui/components/ui_images.h>
-#include <ui/fonts/monogram_5X9.h>
+#if FACTORYSETUP == 0
+    #include <ui/components/confirm.h>
+    #include <ui/components/ui_images.h>
+    #include <ui/fonts/monogram_5X9.h>
+#endif
 #include <utils_assert.h>
 
 const uint8_t* da14531_handler_current_product = NULL;
@@ -29,11 +33,13 @@ struct da14531_ctrl_frame {
 } __attribute((packed));
 
 #if !defined(BOOTLOADER)
+    #define BLE_PAIRING_KEY_SIZE 4
 
+    #if FACTORYSETUP == 0
 static component_t* _ble_pairing_component = NULL;
 
 struct pairing_callback {
-    uint8_t key[4];
+    uint8_t key[BLE_PAIRING_KEY_SIZE];
     struct RustByteQueue* queue;
 };
 
@@ -52,12 +58,13 @@ static const component_functions_t _ble_pairing_component_functions = {
     .render = ui_util_component_render_subcomponents,
     .on_event = NULL,
 };
+    #endif
 
 static void _ble_pairing_respond(const uint8_t* key, struct RustByteQueue* queue, bool ok)
 {
     uint8_t payload[18] = {0};
     payload[0] = CTRL_CMD_TK_CONFIRM;
-    memcpy(&payload[1], key, sizeof(_ble_pairing_callback_data.key));
+    memcpy(&payload[1], key, BLE_PAIRING_KEY_SIZE);
     payload[17] = ok ? 1 : 0; /* 1 yes, 0 no */
 
     uint8_t tmp[12 + sizeof(payload) * 2];
@@ -69,6 +76,7 @@ static void _ble_pairing_respond(const uint8_t* key, struct RustByteQueue* queue
     }
 }
 
+    #if FACTORYSETUP == 0
 static void _ble_pairing_callback(bool ok, void* param)
 {
     struct pairing_callback* data = (struct pairing_callback*)param;
@@ -78,6 +86,7 @@ static void _ble_pairing_callback(bool ok, void* param)
     ui_screen_stack_pop();
     _ble_pairing_component = NULL;
 }
+    #endif
 #else
     #include <bootloader/bootloader.h>
 extern bool bootloader_pairing_request;
@@ -165,7 +174,9 @@ static void _ctrl_handler(const struct da14531_ctrl_frame* frame, struct RustByt
             ASSERT(false);
             break;
         }
-#if !defined(BOOTLOADER)
+#if FACTORYSETUP == 1
+        _ble_pairing_respond(&frame->cmd_data[0], queue, false);
+#elif !defined(BOOTLOADER)
         // A running HWW task can own a Rust-backed screen. Do not overlay it: if its watchdog
         // cancels the task, the Rust screen owner assumes that its component is still on top.
         if (usb_processing_locked(usb_processing_hww())) {
@@ -217,7 +228,7 @@ static void _ctrl_handler(const struct da14531_ctrl_frame* frame, struct RustByt
         switch (frame->cmd_data[0]) {
         case DA14531_CONNECTED_ADVERTISING:
             util_log("da14531: adveritising");
-#if !defined(BOOTLOADER)
+#if !defined(BOOTLOADER) && FACTORYSETUP == 0
             if (_ble_pairing_component != NULL && ui_screen_stack_top() == _ble_pairing_component) {
                 ui_screen_stack_pop();
                 _ble_pairing_component = NULL;
@@ -297,6 +308,7 @@ static void _ctrl_handler(const struct da14531_ctrl_frame* frame, struct RustByt
     }
 }
 
+#if FACTORYSETUP == 0
 static void _hww_handler(const struct da14531_protocol_frame* frame, struct RustByteQueue* queue)
 {
     // util_log(" in: %s", util_dbg_hex(frame->payload, 64));
@@ -309,6 +321,7 @@ static void _hww_handler(const struct da14531_protocol_frame* frame, struct Rust
     memcpy(&usb_frame, &frame->payload[0], sizeof(usb_frame));
     usb_packet_process(&usb_frame);
 }
+#endif
 
 // Handler must not use the frame pointer after it has returned
 void da14531_handler(const struct da14531_protocol_frame* frame, struct RustByteQueue* queue)
@@ -318,9 +331,11 @@ void da14531_handler(const struct da14531_protocol_frame* frame, struct RustByte
     case DA14531_PROTOCOL_PACKET_TYPE_CTRL_DATA:
         _ctrl_handler((const struct da14531_ctrl_frame*)frame, queue);
         break;
+#if FACTORYSETUP == 0
     case DA14531_PROTOCOL_PACKET_TYPE_BLE_DATA:
         _hww_handler(frame, queue);
         break;
+#endif
     default:
         break;
     }

--- a/src/factorysetup.c
+++ b/src/factorysetup.c
@@ -16,9 +16,6 @@
 #include "screen.h"
 #include "securechip/securechip.h"
 #include "uart.h"
-#include "usb/usb.h"
-#include "usb/usb_packet.h"
-#include "usb/usb_processing.h"
 #include <rust/rust.h>
 #include <ui/oled/oled.h>
 
@@ -27,8 +24,6 @@
 
 // Size of length prefix (2 bytes).
 #define LENSIZE 2
-
-#define FACTORYSETUP_CMD (HID_VENDOR_FIRST + 0x02) // factory setup commands
 
 // We commit to the BLE firmware hash here to avoid accidentally installing an unexpected firmware.
 static const uint8_t _allowed_ble_fw_hash[32] = {

--- a/src/hardfault.c
+++ b/src/hardfault.c
@@ -7,7 +7,10 @@
 #include <memory/memory.h>
 #include <platform_config.h>
 #include <screen.h>
-#include <usb/usb.h>
+
+#if FACTORYSETUP == 0
+    #include <usb/usb.h>
+#endif
 
 #if defined(TESTING)
     #include <stdio.h>
@@ -34,7 +37,9 @@ void Abort(const char* msg)
 #else
     util_log("%s", msg);
     screen_print_debug(msg, 0);
+    #if FACTORYSETUP == 0
     usb_stop();
+    #endif
     #if defined(BOOTLOADER)
     bootloader_close_interfaces();
     #else

--- a/src/platform/driver_init.c
+++ b/src/platform/driver_init.c
@@ -18,7 +18,9 @@ struct sha_sync_descriptor HASH_ALGORITHM_0;
 struct timer_descriptor TIMER_0;
 struct flash_descriptor FLASH_0;
 struct i2c_m_sync_desc I2C_0;
+#if FACTORYSETUP == 0
 struct mci_sync_desc MCI_0;
+#endif
 struct rand_sync_desc RAND_0;
 PPUKCL_PARAM pvPUKCLParam;
 PUKCL_PARAM PUKCLParam;
@@ -29,12 +31,14 @@ bool _is_initialized = false;
 /**
  * Enables PTC peripheral, clocks and initializes PTC driver
  */
+#if FACTORYSETUP == 0
 static void _ptc_clock_init(void)
 {
     hri_mclk_set_APBDMASK_ADC0_bit(MCLK);
     hri_gclk_write_PCHCTRL_reg(
         GCLK, ADC0_GCLK_ID, CONF_GCLK_ADC0_SRC | (1 << GCLK_PCHCTRL_CHEN_Pos));
 }
+#endif
 
 /**
  * Enables PUKCC peripheral, clocks and initializes PUKCC driver
@@ -192,6 +196,7 @@ static void _i2c_init(void)
 /**
  * Set pins for SD/MMC peripheral
  */
+#if FACTORYSETUP == 0
 static void _mci_set_pins(void)
 {
     // CLK
@@ -247,6 +252,7 @@ static void _mci_init(void)
     mci_sync_init(&MCI_0, SDHC0);
     _mci_set_pins();
 }
+#endif
 
 /**
  * Initialize delay driver
@@ -269,6 +275,7 @@ static void _rand_init(void)
 /**
  * Set pins for USB peripheral
  */
+#if FACTORYSETUP == 0
 static void _usb_set_pins(void)
 {
     // DM
@@ -283,14 +290,14 @@ static void _usb_set_pins(void)
     gpio_set_pin_function(PIN_USB_DP, PINMUX_PA25H_USB_DP);
 }
 
-/**
- * The USB module requires a GCLK_USB of 48 MHz ~ 0.25% clock
- * for low speed and full speed operation.
- */
-#if (CONF_GCLK_USB_FREQUENCY > (48000000 + 48000000 / 400)) || \
-    (CONF_GCLK_USB_FREQUENCY < (48000000 - 48000000 / 400))
-    #warning USB clock should be 48MHz ~ 0.25% clock, check your configuration!
-#endif
+    /**
+     * The USB module requires a GCLK_USB of 48 MHz ~ 0.25% clock
+     * for low speed and full speed operation.
+     */
+    #if (CONF_GCLK_USB_FREQUENCY > (48000000 + 48000000 / 400)) || \
+        (CONF_GCLK_USB_FREQUENCY < (48000000 - 48000000 / 400))
+        #warning USB clock should be 48MHz ~ 0.25% clock, check your configuration!
+    #endif
 
 /**
  * Initialize USB peripheral
@@ -303,6 +310,7 @@ static void _usb_init(void)
     usb_d_init();
     _usb_set_pins();
 }
+#endif
 
 static void _oled_set_pins(void)
 {
@@ -347,7 +355,9 @@ static void _uart_init(void)
 void system_init(void)
 {
     _oled_set_pins();
+#if FACTORYSETUP == 0
     _ptc_clock_init();
+#endif
 
     _timer_peripheral_init();
     _delay_driver_init();
@@ -356,8 +366,10 @@ void system_init(void)
     _spi_init();
     // ATECC608A
     _i2c_init();
+#if FACTORYSETUP == 0
     // uSD
     _mci_init();
+#endif
 
     // Hardware crypto
     _ecdsa_init();
@@ -365,8 +377,10 @@ void system_init(void)
     _rand_init();
     // Flash
     _flash_memory_init();
+#if FACTORYSETUP == 0
     // USB
     _usb_init();
+#endif
 
     if (memory_get_platform() == MEMORY_PLATFORM_BITBOX02_PLUS) {
         // External MX25 flash memory
@@ -381,7 +395,9 @@ void system_init(void)
 void bootloader_init(void)
 {
     _oled_set_pins();
+#if FACTORYSETUP == 0
     _ptc_clock_init();
+#endif
 
 #if defined(BOOTLOADER_DEVDEVICE) || PLATFORM_BITBOX02PLUS == 1
     // Only needed for qtouch, which is only needed in the devdevice bootloader.
@@ -398,8 +414,10 @@ void bootloader_init(void)
     _rand_init();
     // Flash
     _flash_memory_init();
+#if FACTORYSETUP == 0
     // USB
     _usb_init();
+#endif
 
     if (memory_get_platform() == MEMORY_PLATFORM_BITBOX02_PLUS) {
         // External MX25 flash memory
@@ -440,8 +458,10 @@ void system_close_interfaces(void)
     if (!_is_initialized) {
         return;
     }
+#if FACTORYSETUP == 0
     // uSD
     mci_sync_deinit(&MCI_0);
+#endif
     // ATECC608A
     i2c_m_sync_deinit(&I2C_0);
     // OLED interface bus
@@ -449,8 +469,10 @@ void system_close_interfaces(void)
     SPI_OLED_disable();
     // Flash
     flash_deinit(&FLASH_0);
+#if FACTORYSETUP == 0
     // USB
     usb_d_deinit();
+#endif
     // Hardware crypto
     sha_sync_deinit(&HASH_ALGORITHM_0);
     rand_sync_deinit(&RAND_0);
@@ -466,8 +488,10 @@ void bootloader_close_interfaces(void)
     SPI_OLED_disable();
     // Flash
     flash_deinit(&FLASH_0);
+#if FACTORYSETUP == 0
     // USB
     usb_d_deinit();
+#endif
     // Hardware crypto
     sha_sync_deinit(&HASH_ALGORITHM_0);
     rand_sync_deinit(&RAND_0);

--- a/src/platform/platform_init.c
+++ b/src/platform/platform_init.c
@@ -4,14 +4,14 @@
 #include "memory/memory_shared.h"
 #include "memory/spi_mem.h"
 #include <driver_init.h>
+#include <platform/platform_config.h>
 #include <ui/oled/oled.h>
 #if defined(BOOTLOADER)
     #include <bootloader_version.h>
-#else
+#elif FACTORYSETUP == 0
     #include "sd_mmc/sd_mmc_start.h"
 #endif
 #include "util.h"
-#include <platform/platform_config.h>
 #include <version.h>
 
 #if !(defined(BOOTLOADER) && PLATFORM_BITBOX02 == 1)
@@ -35,7 +35,7 @@ void platform_init(void)
     // these two functions are noops if "rtt" feature isn't enabled in rust
     util_log_init();
     util_log(PREFIX ": platform_init");
-#if !defined(BOOTLOADER)
+#if !defined(BOOTLOADER) && FACTORYSETUP == 0
     sd_mmc_start();
 #endif
     if (memory_get_platform() == MEMORY_PLATFORM_BITBOX02_PLUS) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -102,7 +102,7 @@ void screen_init(
 {
     _mirror_fn = mirror_fn;
     _clear_fn = clear_fn;
-#ifdef BOOTLOADER
+#if defined(BOOTLOADER) || defined(PRODUCT_BITBOX02_FACTORYSETUP)
     UG_Init(&guioled, pixel_fn, &font_font_a_9X9, SCREEN_WIDTH, SCREEN_HEIGHT);
 #else
     UG_Init(&guioled, pixel_fn, &font_font_a_11X10, SCREEN_WIDTH, SCREEN_HEIGHT);


### PR DESCRIPTION
Remove unused USB, SD card, and touch sources and peripheral initialization from factory setup while retaining RTT communication, OLED output, and BLE control traffic. Initialize uGUI with the 9x9 status font so the unused 11x10 font can also be discarded.

Both commits are split out from #2082. The font saving depends on peripheral removal, so they are kept together here. This PR targets `master` directly and is independent of the crypto changes remaining in #2082.

| Factory setup | Before this PR | After | Saved |
|---|---:|---:|---:|
| Image | 195,296 bytes | 180,008 bytes | 15,288 bytes (7.8%) |
| RAM | 203,304 bytes | 186,744 bytes | 16,560 bytes (8.1%) |

Peripheral removal alone saves 13,272 image bytes and 16,464 RAM bytes. The font change then reduces the image from 182,024 to 180,008 bytes (2,016 bytes) and RAM from 186,840 to 186,744 bytes (96 bytes).

Factory setup builds successfully after each commit. `make unit-test` and `make run-unit-tests` pass all 21 C test suites; `cargo test --manifest-path src/rust/Cargo.toml --all-features -- --test-threads 1` passes all 623 Rust tests. Hardware validation has not been performed.
