### PR TITLE
da14531: retain async UART buffer

### DIFF
--- a/src/da14531/da14531_protocol.c
+++ b/src/da14531/da14531_protocol.c
@@ -29,6 +29,8 @@ enum firmware_loader_state {
 
 struct firmware_loader {
     enum firmware_loader_state state;
+    bool checksum_received;
+    uint8_t received_checksum;
 };
 
 enum serial_link_in_state {
@@ -95,6 +97,8 @@ static const char* _firmware_loader_state_str(enum firmware_loader_state state)
 static void _firmware_loader_init(struct firmware_loader* self)
 {
     self->state = FIRMWARE_LOADER_STATE_DONE;
+    self->checksum_received = false;
+    self->received_checksum = 0;
 }
 
 #define SOH 0x01
@@ -149,15 +153,15 @@ static void _firmware_loader_poll(
             if (buf_in[0] == ACK) {
                 util_log("da14513: sending firmware");
                 // Wait until uart tx is ready, and issue a write for the firmware.
-                // Don't use bytequeue as the source is static
+                // Don't use bytequeue because the firmware image is already in its own buffer.
+                // Keep the allocation live until uart_0_write_done().
                 if (ble_fw != NULL) {
                     // This should never happen
                     // TODO
                 }
 
-#ifndef TESTING
+                self->checksum_received = false;
                 while (!(uart_0_write(ble_fw, ble_fw_size)));
-#endif
                 self->state = FIRMWARE_LOADER_STATE_SENT_FIRMWARE;
             } else {
                 self->state = FIRMWARE_LOADER_STATE_IDLE;
@@ -167,19 +171,27 @@ static void _firmware_loader_poll(
         break;
     case FIRMWARE_LOADER_STATE_SENT_FIRMWARE:
         if (*buf_in_len == 1) {
-            if (buf_in[0] == ble_fw_checksum) {
-                util_log("da14531: checksum success (%x)", buf_in[0]);
+            if (!self->checksum_received) {
+                self->received_checksum = buf_in[0];
+                self->checksum_received = true;
+            }
+            *buf_in_len = 0;
+        }
+        if (self->checksum_received && uart_0_write_done()) {
+            if (self->received_checksum == ble_fw_checksum) {
+                util_log("da14531: checksum success (%x)", self->received_checksum);
                 rust_bytequeue_put(out_queue, ACK);
                 self->state = FIRMWARE_LOADER_STATE_DONE;
             } else {
                 util_log(
-                    "da14531: checksum failure, their:%02X, our:%02X", buf_in[0], ble_fw_checksum);
+                    "da14531: checksum failure, their:%02X, our:%02X",
+                    self->received_checksum,
+                    ble_fw_checksum);
                 self->state = FIRMWARE_LOADER_STATE_IDLE;
             }
-            ASSERT(buf_in[0] == ble_fw_checksum);
+            ASSERT(self->received_checksum == ble_fw_checksum);
             free(ble_fw);
             ble_fw = NULL;
-            *buf_in_len = 0;
         }
         break;
     case FIRMWARE_LOADER_STATE_DONE:

--- a/src/rust/bitbox02-sys/build.rs
+++ b/src/rust/bitbox02-sys/build.rs
@@ -293,6 +293,7 @@ const FAKEHARDWARE_SOURCES: &[&str] = &[
     "test/hardware-fakes/src/fake_screen.c",
     "test/hardware-fakes/src/fake_smarteeprom.c",
     "test/hardware-fakes/src/fake_spi_mem.c",
+    "test/hardware-fakes/src/fake_uart.c",
 ];
 
 type BuildResult<T> = Result<T, String>;

--- a/src/uart.c
+++ b/src/uart.c
@@ -74,9 +74,14 @@ int32_t uart_0_read(uint8_t* buf, uint16_t buf_len)
     return 0;
 }
 
+bool uart_0_write_done(void)
+{
+    return (_usart_0_readyness & EVENT_WRITE) != 0;
+}
+
 bool uart_0_write(const uint8_t* buf, uint16_t buf_len)
 {
-    if (!(_usart_0_readyness & EVENT_WRITE)) {
+    if (!uart_0_write_done()) {
         return false;
     }
     int32_t wrote = _write(buf, buf_len);
@@ -91,7 +96,7 @@ bool uart_0_write_from_queue(struct RustByteQueue* queue)
     // the buffer).
     static uint8_t _out_buf[1024];
 
-    if (!(_usart_0_readyness & EVENT_WRITE)) {
+    if (!uart_0_write_done()) {
         return false;
     }
     uint32_t len = MIN(rust_bytequeue_num(queue), sizeof(_out_buf));

--- a/src/uart.h
+++ b/src/uart.h
@@ -10,6 +10,8 @@ struct RustByteQueue;
 void uart_init(void);
 int32_t uart_0_read(uint8_t* buf, uint16_t buf_len);
 bool uart_0_write(const uint8_t* buf, uint16_t buf_len);
+// Returns true once the previous write has completed and its buffer can be released.
+bool uart_0_write_done(void);
 bool uart_0_write_from_queue(struct RustByteQueue* queue);
 
 // Check if there are new bytes and try to send out if there are bytes to send

--- a/test/hardware-fakes/include/fake_uart.h
+++ b/test/hardware-fakes/include/fake_uart.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _FAKE_UART_H_
+#define _FAKE_UART_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void fake_uart_reset(void);
+const uint8_t* fake_uart_tx_buffer(void);
+uint16_t fake_uart_tx_buffer_len(void);
+bool fake_uart_transmit_next(uint8_t* byte_out);
+void fake_uart_tx_complete(void);
+
+#endif

--- a/test/hardware-fakes/src/fake_uart.c
+++ b/test/hardware-fakes/src/fake_uart.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fake_uart.h>
+#include <uart.h>
+
+#include <assert.h>
+#include <stddef.h>
+
+static const uint8_t* _tx_buffer = NULL;
+static uint16_t _tx_buffer_len = 0;
+static uint16_t _tx_buffer_pos = 0;
+static bool _write_done = true;
+
+void fake_uart_reset(void)
+{
+    _tx_buffer = NULL;
+    _tx_buffer_len = 0;
+    _tx_buffer_pos = 0;
+    _write_done = true;
+}
+
+bool uart_0_write(const uint8_t* buf, uint16_t buf_len)
+{
+    if (!_write_done) {
+        return false;
+    }
+    assert(buf != NULL);
+    assert(buf_len > 0);
+    _tx_buffer = buf;
+    _tx_buffer_len = buf_len;
+    _tx_buffer_pos = 0;
+    _write_done = false;
+    return true;
+}
+
+bool uart_0_write_done(void)
+{
+    return _write_done;
+}
+
+const uint8_t* fake_uart_tx_buffer(void)
+{
+    return _tx_buffer;
+}
+
+uint16_t fake_uart_tx_buffer_len(void)
+{
+    return _tx_buffer_len;
+}
+
+bool fake_uart_transmit_next(uint8_t* byte_out)
+{
+    if (_write_done || _tx_buffer_pos >= _tx_buffer_len) {
+        return false;
+    }
+    *byte_out = _tx_buffer[_tx_buffer_pos++];
+    return true;
+}
+
+void fake_uart_tx_complete(void)
+{
+    assert(!_write_done);
+    assert(_tx_buffer_pos == _tx_buffer_len);
+    _write_done = true;
+}

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -37,6 +37,8 @@ else()
      "-Wl,--wrap=util_cleanup_32"
      da14531_handler
      "-Wl,--wrap=confirm_create"
+     da14531_protocol
+     "-Wl,--wrap=free,--wrap=memory_spi_get_active_ble_firmware"
      gestures
      ""
      hww

--- a/test/unit-test/test_da14531_protocol.c
+++ b/test/unit-test/test_da14531_protocol.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+
+#include <da14531/da14531_protocol.h>
+#include <fake_uart.h>
+#include <rust/rust.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define STX 0x02
+#define ACK 0x06
+
+static const uint8_t _firmware[] = {0x42, 0x69, 0x74, 0x42, 0x6f, 0x78, 0x30, 0x32};
+static const uint8_t _firmware_checksum = 0xa5;
+static uint8_t* _firmware_allocation = NULL;
+static size_t _firmware_free_count = 0;
+
+bool __wrap_memory_spi_get_active_ble_firmware(
+    uint8_t** firmware_out,
+    size_t* size_out,
+    uint8_t* checksum_out)
+{
+    assert_null(_firmware_allocation);
+    _firmware_allocation = malloc(sizeof(_firmware));
+    assert_non_null(_firmware_allocation);
+    memcpy(_firmware_allocation, _firmware, sizeof(_firmware));
+    *firmware_out = _firmware_allocation;
+    *size_out = sizeof(_firmware);
+    *checksum_out = _firmware_checksum;
+    return true;
+}
+
+void __real_free(void* ptr);
+
+void __wrap_free(void* ptr)
+{
+    if (ptr == _firmware_allocation) {
+        _firmware_free_count++;
+    }
+    __real_free(ptr);
+}
+
+static void _poll(struct RustByteQueue* queue, uint8_t* input, uint16_t input_len)
+{
+    assert_null(da14531_protocol_poll(input, &input_len, NULL, queue));
+    assert_int_equal(input_len, 0);
+}
+
+static void _poll_byte(struct RustByteQueue* queue, uint8_t input)
+{
+    _poll(queue, &input, 1);
+}
+
+static void _poll_empty(struct RustByteQueue* queue)
+{
+    uint8_t input = 0;
+    _poll(queue, &input, 0);
+}
+
+static uint8_t _queue_get(struct RustByteQueue* queue)
+{
+    uint8_t value = 0;
+    assert_true(rust_bytequeue_get(queue, &value));
+    return value;
+}
+
+static void test_firmware_buffer_retained_until_tx_complete(void** state)
+{
+    (void)state;
+    fake_uart_reset();
+    _firmware_allocation = NULL;
+    _firmware_free_count = 0;
+
+    struct RustByteQueue* queue = rust_bytequeue_init(16);
+    assert_non_null(queue);
+    da14531_protocol_init();
+
+    // Move the serial parser into loader mode, load the image, and request it.
+    _poll_byte(queue, STX);
+    _poll_empty(queue);
+    _poll_byte(queue, STX);
+    _poll_empty(queue);
+
+    assert_int_equal(rust_bytequeue_num(queue), 3);
+    assert_int_equal(_queue_get(queue), 0x01);
+    assert_int_equal(_queue_get(queue), sizeof(_firmware) & 0xff);
+    assert_int_equal(_queue_get(queue), sizeof(_firmware) >> 8);
+
+    _poll_byte(queue, ACK);
+    assert_ptr_equal(fake_uart_tx_buffer(), _firmware_allocation);
+    assert_int_equal(fake_uart_tx_buffer_len(), sizeof(_firmware));
+
+    // A peer can provide the checksum while the async driver still retains the allocation.
+    _poll_byte(queue, _firmware_checksum);
+    assert_int_equal(_firmware_free_count, 0);
+    assert_int_equal(rust_bytequeue_num(queue), 0);
+
+    for (size_t i = 0; i < sizeof(_firmware); i++) {
+        uint8_t transmitted = 0;
+        assert_true(fake_uart_transmit_next(&transmitted));
+        assert_int_equal(transmitted, _firmware[i]);
+    }
+    uint8_t transmitted = 0;
+    assert_false(fake_uart_transmit_next(&transmitted));
+    assert_int_equal(_firmware_free_count, 0);
+
+    fake_uart_tx_complete();
+    _poll_empty(queue);
+    assert_int_equal(_firmware_free_count, 1);
+    assert_int_equal(rust_bytequeue_num(queue), 1);
+    assert_int_equal(_queue_get(queue), ACK);
+
+    _poll_empty(queue);
+    assert_int_equal(_firmware_free_count, 1);
+    _firmware_allocation = NULL;
+    assert_true(rust_bytequeue_free(queue));
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_firmware_buffer_retained_until_tx_complete),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
The loader freed the heap-backed firmware image as soon as it received
the peer checksum, even when the asynchronous UART driver still retained
the image pointer.

Record checksum receipt separately from UART completion and release the
image only after both events. Exercise the early-checksum ordering with a
UART fake that reads every remaining byte and checks the single release.
