### PR TITLE
oled: hold display in reset during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
 The changelog records significant changes to both the firmware and the
-bootloader. Since the bootloader has a separate release cycle and existing
-customers cannot upgrade their bootloader, its changes are recorded separately.
+bootloader. Since the bootloader has a separate release cycle its changes are
+recorded separately.
 
 ## Firmware
 
-### [Unreleased]
+### Unreleased
 - Reject malformed microSD backups instead of crashing
+- Hold the screen reset pin low until firmware is ready initalize it.
 
 ### v9.27.1
 - API: include the installed bootloader version in the device info response
@@ -224,6 +225,9 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ## Bootloader
 
+### Unreleased
+- Hold the screen reset pin low until bootloader is ready to initalize it.
+
 ### v1.2.2
 - Fix stage1 firmware erase handling for partially erased flash blocks
 
@@ -253,3 +257,8 @@ customers cannot upgrade their bootloader, its changes are recorded separately.
 
 ### v1.0.4
 - Make bootloader mode more user-friendly and prompt for action on empty firmware
+
+## Stage0 bootloader
+
+### Unreleased
+- Hold the screen reset pin low until bootloader is ready to initalize it.

--- a/src/platform/driver_init.c
+++ b/src/platform/driver_init.c
@@ -314,8 +314,9 @@ static void _oled_set_pins(void)
     gpio_set_pin_level(PIN_OLED_ON, PIN_LOW);
     gpio_set_pin_function(PIN_OLED_ON, GPIO_PIN_FUNCTION_OFF);
 
+    // Hold the OLED in reset until oled_init() releases it to prevent showing stale content.
+    gpio_set_pin_level(PIN_OLED_RES, PIN_LOW);
     gpio_set_pin_direction(PIN_OLED_RES, GPIO_DIRECTION_OUT);
-    gpio_set_pin_level(PIN_OLED_RES, PIN_HIGH);
     gpio_set_pin_function(PIN_OLED_RES, GPIO_PIN_FUNCTION_OFF);
 
     gpio_set_pin_direction(PIN_OLED_CMD, GPIO_DIRECTION_OUT);

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "firmware": "v9.27.2",
-  "bootloader": "v1.2.2",
-  "stage0": 1
+  "bootloader": "v1.2.3",
+  "stage0": 2
 }


### PR DESCRIPTION
Production stage0 verifies stage1 before initializing the OLED. Leaving the reset pin high can allow previous display content to remain visible at reduced brightness while the boost converter is disabled.

Set the reset output latch low before enabling the pin as an output. Keep the OLED in reset until oled_init() releases it and uploads a cleared framebuffer.