### PR TITLE
blupgrade: accept other stage0 image versions

### DIFF
--- a/src/bootloader_upgrade/firmware_installer_check.c
+++ b/src/bootloader_upgrade/firmware_installer_check.c
@@ -57,8 +57,8 @@ static bool _read_stage0_descriptor(
         return false;
     }
     memcpy(descriptor_out, descriptor, sizeof(*descriptor_out));
+    // The stage0 image version can differ from ours without changing the descriptor layout.
     return descriptor_out->magic == BB02_STAGE0_DESCRIPTOR_MAGIC &&
-           descriptor_out->stage0_version == BB02_STAGE0_IMAGE_VERSION &&
            descriptor_out->product_id == BB02_STAGE1_PRODUCT_ID;
 }
 

--- a/test/unit-test/test_bootloader_upgrade_check.c
+++ b/test/unit-test/test_bootloader_upgrade_check.c
@@ -59,8 +59,8 @@ static void test_legacy_development_markers_absent(void** state)
 static void test_development_stage0_descriptor(void** state)
 {
     (void)state;
-    const bb02_stage0_descriptor_t descriptor = {
-        .stage0_version = BB02_STAGE0_IMAGE_VERSION,
+    bb02_stage0_descriptor_t descriptor = {
+        .stage0_version = 1u,
         .product_id = BB02_STAGE1_PRODUCT_ID,
         .flags = BB02_STAGE0_FLAG_DEVELOPMENT,
         .magic = BB02_STAGE0_DESCRIPTOR_MAGIC,
@@ -69,13 +69,17 @@ static void test_development_stage0_descriptor(void** state)
 
     assert_true(bootloader_upgrade_is_development_bootloader(
         &descriptor, NULL, legacy_bootloader, sizeof(legacy_bootloader)));
+
+    descriptor.stage0_version = BB02_STAGE0_IMAGE_VERSION + 1u;
+    assert_true(bootloader_upgrade_is_development_bootloader(
+        &descriptor, NULL, legacy_bootloader, sizeof(legacy_bootloader)));
 }
 
 static void test_development_stage1_header(void** state)
 {
     (void)state;
-    const bb02_stage0_descriptor_t stage0_descriptor = {
-        .stage0_version = BB02_STAGE0_IMAGE_VERSION,
+    bb02_stage0_descriptor_t stage0_descriptor = {
+        .stage0_version = 1u,
         .product_id = BB02_STAGE1_PRODUCT_ID,
         .flags = 0,
         .magic = BB02_STAGE0_DESCRIPTOR_MAGIC,
@@ -90,6 +94,10 @@ static void test_development_stage1_header(void** state)
     };
     uint8_t legacy_bootloader[256] = {0};
 
+    assert_true(bootloader_upgrade_is_development_bootloader(
+        &stage0_descriptor, &stage1_header, legacy_bootloader, sizeof(legacy_bootloader)));
+
+    stage0_descriptor.stage0_version = BB02_STAGE0_IMAGE_VERSION + 1u;
     assert_true(bootloader_upgrade_is_development_bootloader(
         &stage0_descriptor, &stage1_header, legacy_bootloader, sizeof(legacy_bootloader)));
 }
@@ -120,8 +128,8 @@ static void test_development_stage1_header_future_header_version(void** state)
 static void test_production_stage0_descriptor_skips_legacy_markers(void** state)
 {
     (void)state;
-    const bb02_stage0_descriptor_t stage0_descriptor = {
-        .stage0_version = BB02_STAGE0_IMAGE_VERSION,
+    bb02_stage0_descriptor_t stage0_descriptor = {
+        .stage0_version = 1u,
         .product_id = BB02_STAGE1_PRODUCT_ID,
         .flags = 0,
         .magic = BB02_STAGE0_DESCRIPTOR_MAGIC,
@@ -139,6 +147,10 @@ static void test_production_stage0_descriptor_skips_legacy_markers(void** state)
     _put_bytes(legacy_bootloader, sizeof(legacy_bootloader), 10, "DEV DEVICE");
     _put_bytes(legacy_bootloader, sizeof(legacy_bootloader), 100, "NOT FOR VALUE");
 
+    assert_false(bootloader_upgrade_is_development_bootloader(
+        &stage0_descriptor, &stage1_header, legacy_bootloader, sizeof(legacy_bootloader)));
+
+    stage0_descriptor.stage0_version = BB02_STAGE0_IMAGE_VERSION + 1u;
     assert_false(bootloader_upgrade_is_development_bootloader(
         &stage0_descriptor, &stage1_header, legacy_bootloader, sizeof(legacy_bootloader)));
 }


### PR DESCRIPTION
The production bootloader-upgrade firmware checks the installed
bootloader's development flags before writing stage0. Descriptor parsing
currently requires the installed stage0 image version to match the
installer's build, even though the descriptor layout is unchanged.

After a version bump, older descriptors fall back to legacy text-marker
scanning. This loses the stage0 development flag when stage1 has no
legacy development markers, such as a production stage1 paired with a
development stage0. Normal development stage1 images still carry those
markers and remain detectable.

Validate the descriptor using its magic and product ID regardless of the
stage0 image version. Extend the existing checks to cover v1 and a newer
image version for stage0 and stage1 development flags and production
descriptors.

refs #2098
