### PR TITLE
platform: bound heap growth

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -100,7 +100,6 @@ if(CMAKE_CROSSCOMPILING)
   # Advanced Software Framework Drivers
   # Only drivers needed for bootloader (minimal set)
   add_library(asf4-drivers-min STATIC
-    asf4-drivers/hal/utils/src/utils_syscalls.c
     asf4-drivers/hal/utils/src/utils_list.c
     asf4-drivers/hal/src/hal_atomic.c
     asf4-drivers/hal/src/hal_gpio.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,7 @@ set(DBB-BOOTLOADER-SOURCES ${DBB-BOOTLOADER-SOURCES} PARENT_SCOPE)
 set(DRIVER-SOURCES
   ${CMAKE_SOURCE_DIR}/src/platform/platform_init.c
   ${CMAKE_SOURCE_DIR}/src/platform/driver_init.c
+  ${CMAKE_SOURCE_DIR}/src/platform/sbrk.c
   ${CMAKE_SOURCE_DIR}/src/ui/oled/oled.c
   ${CMAKE_SOURCE_DIR}/src/ui/oled/oled_writer.c
 )

--- a/src/platform/sbrk.c
+++ b/src/platform/sbrk.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+extern uint8_t _heap_start;
+extern uint8_t _heap_end;
+
+caddr_t _sbrk(int incr);
+
+// Unlike ASF4's implementation, this confines the program break to the
+// linker-defined heap and checks growth and shrink without overflowing.
+caddr_t _sbrk(int incr)
+{
+    static uint8_t* heap;
+    const uintptr_t heap_start = (uintptr_t)&_heap_start;
+    const uintptr_t heap_end = (uintptr_t)&_heap_end;
+
+    if (heap == NULL) {
+        heap = &_heap_start;
+    }
+
+    const uintptr_t current = (uintptr_t)heap;
+    if (incr >= 0) {
+        const uintptr_t increment = (uintptr_t)incr;
+        if (current > heap_end || increment > heap_end - current) {
+            errno = ENOMEM;
+            return (caddr_t)-1;
+        }
+        heap = (uint8_t*)(current + increment);
+    } else {
+        const uintptr_t decrement = (uintptr_t)(-(int64_t)incr);
+        if (current < heap_start || decrement > current - heap_start) {
+            errno = EINVAL;
+            return (caddr_t)-1;
+        }
+        heap = (uint8_t*)(current - decrement);
+    }
+
+    return (caddr_t)current;
+}

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -47,6 +47,8 @@ else()
      "-Wl,--wrap=rand,--wrap=rust_sha256"
      screen_process
      "-Wl,--wrap=screen_saver_get,--wrap=screen_saver_process,--wrap=waiting_create"
+     sbrk
+     ""
      ui_components
      ""
      ui_util
@@ -127,6 +129,10 @@ else()
           ${CMAKE_SOURCE_DIR}/src/bootloader_upgrade/firmware_installer_check.c
       )
       target_compile_definitions(${EXE} PRIVATE PRODUCT_BITBOX_MULTI=1)
+    endif()
+    if(TEST_NAME STREQUAL "sbrk")
+      target_sources(${EXE} PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/sbrk.c)
+      target_compile_definitions(${EXE} PRIVATE _DEFAULT_SOURCE)
     endif()
     add_test(NAME test_${TEST_NAME} COMMAND ${EXE})
   endforeach()

--- a/test/unit-test/test_sbrk.c
+++ b/test/unit-test/test_sbrk.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <errno.h>
+#include <limits.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <cmocka.h>
+
+uint8_t test_heap[16];
+
+__asm__(
+    ".global _heap_start\n"
+    "_heap_start = test_heap\n"
+    ".global _heap_end\n"
+    "_heap_end = test_heap + 16\n");
+
+extern caddr_t _sbrk(int incr);
+
+// Host malloc/free do not use the firmware's _sbrk implementation.
+static void test_sbrk_bounds(void** state)
+{
+    (void)state;
+
+    assert_ptr_equal(_sbrk(0), test_heap);
+    assert_ptr_equal(_sbrk(sizeof(test_heap)), test_heap);
+
+    errno = 0;
+    assert_ptr_equal(_sbrk(1), (caddr_t)-1);
+    assert_int_equal(errno, ENOMEM);
+    assert_ptr_equal(_sbrk(0), test_heap + sizeof(test_heap));
+
+    assert_ptr_equal(_sbrk(-(int)sizeof(test_heap)), test_heap + sizeof(test_heap));
+
+    errno = 0;
+    assert_ptr_equal(_sbrk(-1), (caddr_t)-1);
+    assert_int_equal(errno, EINVAL);
+    assert_ptr_equal(_sbrk(0), test_heap);
+
+    errno = 0;
+    assert_ptr_equal(_sbrk(INT_MIN), (caddr_t)-1);
+    assert_int_equal(errno, EINVAL);
+    assert_ptr_equal(_sbrk(0), test_heap);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_sbrk_bounds),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
ASF4's _sbrk implementation advances the program break without checking the
linker-defined heap range. A large allocation can therefore move the break
past _heap_end and let subsequent writes reach outside the reserved heap.

Replace the vendored syscall source with a first-party _sbrk implementation
that checks growth and shrink requests using overflow-safe arithmetic.
Return ENOMEM or EINVAL without changing the break when a request crosses
the linker-defined bounds. Keeping this code outside ASF4 prevents a future
vendor update from silently dropping the checks again.

nosys.specs continues to provide the unused syscall stubs. Add a unit test
for exact-fit allocation, rejected growth and shrink, unchanged state after
failure, and INT_MIN handling.

This prevents writes beyond the heap. Exhausting memory still follows the
existing allocation-failure path.
