### PR TITLE
docs: restrict external pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing
 
-The codebase is maintained using the "contributor workflow" where everyone without exception
-contributes patch proposals using "pull requests".  This facilitates social contribution, easy
-testing and peer review.
+For security reasons, we do not accept pull requests from external contributors.
 
-To contribute a patch, the workflow is as follows:
+To report a bug, suggest an improvement, or propose a change, please open an issue instead of a
+pull request.
 
-  1. Fork repository
-  1. Create topic branch
-  1. Commit patches
-  1. Push changes to your fork
-  1. Create pull request
+We reserve the right to close pull requests from external contributors without discussion.
+
+Please report security vulnerabilities through our
+[bug bounty program](https://bitbox.swiss/bug-bounty-program) instead of opening a public issue.
+
+## Maintainer guidelines
 
 In general [commits should be
 atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention) and diffs should be


### PR DESCRIPTION
For security reasons, stop accepting pull requests from external
contributors. Direct bug reports, suggestions and proposed changes to
issues, and reserve the right to close external pull requests without
discussion.

Keep vulnerability reports directed to the bug bounty program and retain
the existing commit and review guidance for maintainers.

Related: https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/4425
